### PR TITLE
refactor(gasboat): rename gasboat refs to gasboats

### DIFF
--- a/gasboat/controller/internal/bridge/github.go
+++ b/gasboat/controller/internal/bridge/github.go
@@ -371,7 +371,7 @@ func (c *GitHubClient) CompareSHAs(ctx context.Context, repo RepoRef, base, head
 }
 
 // ImageToRepo maps a GHCR image reference to a GitHub RepoRef.
-// e.g., "ghcr.io/groblegark/gasboats/agent:latest" → RepoRef{Owner: "groblegark", Repo: "gasboat"}
+// e.g., "ghcr.io/groblegark/gasboats/agent:latest" → RepoRef{Owner: "groblegark", Repo: "gasboats"}
 // For images with sub-paths (gasboat/agent), uses the first path component as the repo.
 func ImageToRepo(image string) (RepoRef, bool) {
 	org, pkg, err := parseGHCRImageRef(image)


### PR DESCRIPTION
## Summary
- Renames all `groblegark/gasboat` references to `groblegark/gasboats` across the gasboat subtree
- Updates GHCR image paths, git clone URLs, GitHub API references, CI/CD configs, Helm values, docs, and test expectations
- All tests pass after the rename

## Context
Part of the migration from the standalone `gasboat` repo to the `gasboats` monorepo (kd-AuNBvxB9kx).

## Files changed
- `.rwx/ci.yml`, `.rwx/docker.yml`, `.rwx/e2e.yml`, `.rwx/helm.yml` — CI/CD git and image refs
- `CLAUDE.md`, `docs/release-pipeline.md` — documentation
- `helm/gasboat/values.yaml`, `helm/values-gasboat.yaml` — Helm image registry paths
- `controller/internal/bridge/github.go`, `github_test.go` — GHCR parsing code and tests
- `controller/internal/bridge/unreleased.go`, `unreleased_test.go` — release notes repo refs
- `controller/cmd/gb/setup_repos_test.go`, `controller/cmd/slack-bridge/main_test.go` — test expectations
- `tests/e2e/README.md` — e2e docs

## Test plan
- [x] `go test ./... -count=1 -short` — all packages pass
- [x] `go build ./...` — builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)