### PR TITLE
subtree: sync gasboat main (PRs #168, #171, #172, #176)

### DIFF
--- a/gasboat/.rwx/ci.yml
+++ b/gasboat/.rwx/ci.yml
@@ -14,7 +14,7 @@ tasks:
   - key: code
     call: git/clone 2.0.3
     with:
-      repository: https://github.com/groblegark/gasboat.git
+      repository: https://github.com/groblegark/gasboats.git
       ref: ${{ init.commit-sha }}
 
   # ── Go toolchain ──────────────────────────────────────────────────────

--- a/gasboat/.rwx/docker.yml
+++ b/gasboat/.rwx/docker.yml
@@ -6,12 +6,12 @@
 #   push-*  tasks     -> crane-append layers to ubuntu:24.04, push to GHCR
 #
 # Images produced:
-#   push-controller     -> ghcr.io/groblegark/gasboat/controller
-#   push-agent          -> ghcr.io/groblegark/gasboat/agent
-#   push-slack-bridge   -> ghcr.io/groblegark/gasboat/slack-bridge
-#   push-jira-bridge    -> ghcr.io/groblegark/gasboat/jira-bridge
-#   push-gitlab-bridge  -> ghcr.io/groblegark/gasboat/gitlab-bridge
-#   push-advice-viewer  -> ghcr.io/groblegark/gasboat/advice-viewer
+#   push-controller     -> ghcr.io/groblegark/gasboats/controller
+#   push-agent          -> ghcr.io/groblegark/gasboats/agent
+#   push-slack-bridge   -> ghcr.io/groblegark/gasboats/slack-bridge
+#   push-jira-bridge    -> ghcr.io/groblegark/gasboats/jira-bridge
+#   push-gitlab-bridge  -> ghcr.io/groblegark/gasboats/gitlab-bridge
+#   push-advice-viewer  -> ghcr.io/groblegark/gasboats/advice-viewer
 #
 # For manual push of a single image:
 #   rwx run .rwx/docker.yml --init commit-sha=$(git rev-parse HEAD) --target push-agent
@@ -91,7 +91,7 @@ tasks:
   - key: code
     call: git/clone 2.0.3
     with:
-      repository: https://github.com/groblegark/gasboat.git
+      repository: https://github.com/groblegark/gasboats.git
       ref: ${{ init.commit-sha }}
 
   # ── Go toolchain ───────────────────────────────────────────────────
@@ -345,7 +345,7 @@ tasks:
       tar -cf /tmp/layer.tar -C /tmp/layer .
 
       # Push
-      REPO="ghcr.io/groblegark/gasboat/controller"
+      REPO="ghcr.io/groblegark/gasboats/controller"
       crane append --base ubuntu:24.04 --new_tag "${REPO}:${TAG}" --new_layer /tmp/layer.tar --platform linux/amd64
       crane mutate "${REPO}:${TAG}" --entrypoint /controller --user nobody -t "${REPO}:${TAG}"
       crane tag "${REPO}:${TAG}" latest
@@ -378,7 +378,7 @@ tasks:
       cp /etc/ssl/certs/ca-certificates.crt /tmp/layer/etc/ssl/certs/
       tar -cf /tmp/layer.tar -C /tmp/layer .
 
-      REPO="ghcr.io/groblegark/gasboat/slack-bridge"
+      REPO="ghcr.io/groblegark/gasboats/slack-bridge"
       crane append --base ubuntu:24.04 --new_tag "${REPO}:${TAG}" --new_layer /tmp/layer.tar --platform linux/amd64
       crane mutate "${REPO}:${TAG}" --entrypoint /slack-bridge --user nobody -t "${REPO}:${TAG}"
       crane tag "${REPO}:${TAG}" latest
@@ -408,7 +408,7 @@ tasks:
       cp /etc/ssl/certs/ca-certificates.crt /tmp/layer/etc/ssl/certs/
       tar -cf /tmp/layer.tar -C /tmp/layer .
 
-      REPO="ghcr.io/groblegark/gasboat/jira-bridge"
+      REPO="ghcr.io/groblegark/gasboats/jira-bridge"
       crane append --base ubuntu:24.04 --new_tag "${REPO}:${TAG}" --new_layer /tmp/layer.tar --platform linux/amd64
       crane mutate "${REPO}:${TAG}" --entrypoint /jira-bridge --user nobody -t "${REPO}:${TAG}"
       crane tag "${REPO}:${TAG}" latest
@@ -438,7 +438,7 @@ tasks:
       cp /etc/ssl/certs/ca-certificates.crt /tmp/layer/etc/ssl/certs/
       tar -cf /tmp/layer.tar -C /tmp/layer .
 
-      REPO="ghcr.io/groblegark/gasboat/gitlab-bridge"
+      REPO="ghcr.io/groblegark/gasboats/gitlab-bridge"
       crane append --base ubuntu:24.04 --new_tag "${REPO}:${TAG}" --new_layer /tmp/layer.tar --platform linux/amd64
       crane mutate "${REPO}:${TAG}" --entrypoint /gitlab-bridge --user nobody -t "${REPO}:${TAG}"
       crane tag "${REPO}:${TAG}" latest
@@ -468,7 +468,7 @@ tasks:
       cp /etc/ssl/certs/ca-certificates.crt /tmp/layer/etc/ssl/certs/
       tar -cf /tmp/layer.tar -C /tmp/layer .
 
-      REPO="ghcr.io/groblegark/gasboat/advice-viewer"
+      REPO="ghcr.io/groblegark/gasboats/advice-viewer"
       crane append --base ubuntu:24.04 --new_tag "${REPO}:${TAG}" --new_layer /tmp/layer.tar --platform linux/amd64
       crane mutate "${REPO}:${TAG}" --entrypoint /advice-viewer --user nobody -t "${REPO}:${TAG}"
       crane tag "${REPO}:${TAG}" latest
@@ -944,7 +944,7 @@ tasks:
       echo "=== Pushing image ==="
       sudo tar -cf /tmp/layer.tar -C $LAYER .
 
-      REPO="ghcr.io/groblegark/gasboat/agent"
+      REPO="ghcr.io/groblegark/gasboats/agent"
       crane append --base ubuntu:24.04 --new_tag "${REPO}:${TAG}" --new_layer /tmp/layer.tar --platform linux/amd64
       crane mutate "${REPO}:${TAG}" \
         --entrypoint /entrypoint.sh \

--- a/gasboat/.rwx/e2e.yml
+++ b/gasboat/.rwx/e2e.yml
@@ -53,7 +53,7 @@ tasks:
     use: system-deps
     call: git/clone 2.0.3
     with:
-      repository: https://github.com/groblegark/gasboat.git
+      repository: https://github.com/groblegark/gasboats.git
       ref: ${{ init.commit-sha }}
 
   - key: go

--- a/gasboat/.rwx/helm.yml
+++ b/gasboat/.rwx/helm.yml
@@ -22,7 +22,7 @@ tasks:
   - key: code
     call: git/clone 2.0.3
     with:
-      repository: https://github.com/groblegark/gasboat.git
+      repository: https://github.com/groblegark/gasboats.git
       ref: ${{ init.commit-sha }}
 
   # ── Helm installation (cached until version changes) ────────────────

--- a/gasboat/CLAUDE.md
+++ b/gasboat/CLAUDE.md
@@ -107,7 +107,7 @@ The agent image is the container that runs Claude Code agents in K8s pods. It ha
 | **Dockerfile** | `images/agent/Dockerfile` | `docker build` / local dev | Multi-stage Docker build |
 | **RWX CI** | `.rwx/docker.yml` | Push to main / tag | `crane append` with parallel cached layers |
 
-**Both produce `ghcr.io/groblegark/gasboat/agent:<tag>`**. Production uses RWX CI. The Dockerfile is the reference spec; RWX CI mirrors it with a layer-based approach for speed.
+**Both produce `ghcr.io/groblegark/gasboats/agent:<tag>`**. Production uses RWX CI. The Dockerfile is the reference spec; RWX CI mirrors it with a layer-based approach for speed.
 
 ### RWX CI Architecture
 
@@ -153,10 +153,10 @@ After a build, check that tools are present:
 
 ```bash
 # Export and inspect (without pulling the full image)
-crane export ghcr.io/groblegark/gasboat/agent:<tag> - | tar -tf - | grep <binary-name>
+crane export ghcr.io/groblegark/gasboats/agent:<tag> - | tar -tf - | grep <binary-name>
 
 # Or run a container
-docker run --rm ghcr.io/groblegark/gasboat/agent:<tag> which <tool-name>
+docker run --rm ghcr.io/groblegark/gasboats/agent:<tag> which <tool-name>
 ```
 
 Key tools to verify: `claude`, `coop`, `kd`, `gb`, `playwright`, `npx`, `ffmpeg`, `tmux`, `whisper-cli`, `go`, `rustc`, `gh`, `glab`, `helm`, `terraform`, `kubectl`

--- a/gasboat/Makefile
+++ b/gasboat/Makefile
@@ -2,7 +2,7 @@
 
 VERSION  ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
 COMMIT   ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)
-REGISTRY ?= ghcr.io/groblegark/gasboat
+REGISTRY ?= ghcr.io/groblegark/gasboats
 
 # ── Controller ──────────────────────────────────────────────────────────
 

--- a/gasboat/controller/cmd/gb/agent_start_k8s.go
+++ b/gasboat/controller/cmd/gb/agent_start_k8s.go
@@ -134,9 +134,13 @@ func runAgentStartK8s(cmd *cobra.Command, args []string) error {
 		cleanStalePipes(coopStateDir)
 		resumeLog := findResumeSession(claudeStateDir, cfg.sessionResume)
 
+		sessionBeadID := registerSessionBead(ctx, cfg, resumeLog)
+
 		start := time.Now()
 		exitCode, _ := runCoopOnce(ctx, cfg, coopStateDir, resumeLog)
 		elapsed := time.Since(start)
+
+		closeSessionBead(context.Background(), sessionBeadID, exitCode, resumeLog)
 
 		if ctx.Err() != nil {
 			return nil // clean SIGTERM exit

--- a/gasboat/controller/cmd/gb/main.go
+++ b/gasboat/controller/cmd/gb/main.go
@@ -133,7 +133,7 @@ func init() {
 	rootCmd.AddCommand(primeCmd)
 	rootCmd.AddCommand(nudgePromptCmd)
 	rootCmd.AddCommand(stopCmd)
-	rootCmd.AddCommand(workspaceCmd)
+	rootCmd.AddCommand(sessionCmd)
 }
 
 func main() {

--- a/gasboat/controller/cmd/gb/session.go
+++ b/gasboat/controller/cmd/gb/session.go
@@ -1,0 +1,337 @@
+package main
+
+// gb session — first-class session management.
+//
+// Sessions are tracked as beads (type=session) that record each coop session's
+// lifecycle: start time, end time, exit code, session log path, and the linked
+// agent bead. This replaces the previous approach where sessions were just JSONL
+// files on disk with no metadata or tracking.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"gasboat/controller/internal/beadsapi"
+
+	"github.com/spf13/cobra"
+)
+
+var sessionCmd = &cobra.Command{
+	Use:     "session",
+	Short:   "Manage agent sessions",
+	GroupID: "session",
+}
+
+var sessionListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List sessions for the current agent or all agents",
+	RunE:  runSessionList,
+}
+
+var sessionShowCmd = &cobra.Command{
+	Use:   "show <session-id>",
+	Short: "Show details of a session",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runSessionShow,
+}
+
+var sessionRegisterCmd = &cobra.Command{
+	Use:    "register",
+	Short:  "Register a new session (called internally by the restart loop)",
+	Hidden: true,
+	RunE:   runSessionRegister,
+}
+
+var sessionCloseCmd = &cobra.Command{
+	Use:    "close <session-id>",
+	Short:  "Close a session bead (called internally)",
+	Hidden: true,
+	Args:   cobra.ExactArgs(1),
+	RunE:   runSessionClose,
+}
+
+var (
+	sessionAgent    string
+	sessionLimit    int
+	sessionAll      bool
+	sessionExitCode int
+	sessionLog      string
+)
+
+func init() {
+	sessionCmd.AddCommand(sessionListCmd)
+	sessionCmd.AddCommand(sessionShowCmd)
+	sessionCmd.AddCommand(sessionRegisterCmd)
+	sessionCmd.AddCommand(sessionCloseCmd)
+
+	sessionListCmd.Flags().StringVar(&sessionAgent, "agent", "", "filter by agent name (default: current agent)")
+	sessionListCmd.Flags().IntVar(&sessionLimit, "limit", 20, "max number of sessions to show")
+	sessionListCmd.Flags().BoolVar(&sessionAll, "all", false, "show sessions for all agents")
+
+	sessionRegisterCmd.Flags().StringVar(&sessionLog, "log", "", "path to session JSONL log")
+
+	sessionCloseCmd.Flags().IntVar(&sessionExitCode, "exit-code", 0, "exit code of the session")
+	sessionCloseCmd.Flags().StringVar(&sessionLog, "log", "", "path to session JSONL log")
+}
+
+func runSessionList(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
+
+	agentFilter := sessionAgent
+	if !sessionAll && agentFilter == "" {
+		agentFilter = os.Getenv("BOAT_AGENT")
+	}
+
+	sessions, err := daemon.ListSessionBeads(ctx, agentFilter, sessionLimit)
+	if err != nil {
+		return fmt.Errorf("listing sessions: %w", err)
+	}
+
+	if jsonOutput {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(sessions)
+	}
+
+	if len(sessions) == 0 {
+		fmt.Println("No sessions found.")
+		return nil
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 2, 2, ' ', 0)
+	fmt.Fprintf(w, "ID\tAGENT\tSTATUS\tSTARTED\tDURATION\tEXIT\n")
+	for _, s := range sessions {
+		agent := s.Fields["agent"]
+		status := s.Fields["status"]
+		startedAt := s.Fields["started_at"]
+		endedAt := s.Fields["ended_at"]
+		exitCode := s.Fields["exit_code"]
+
+		duration := "-"
+		if startedAt != "" && endedAt != "" {
+			if st, err := time.Parse(time.RFC3339, startedAt); err == nil {
+				if et, err := time.Parse(time.RFC3339, endedAt); err == nil {
+					duration = et.Sub(st).Round(time.Second).String()
+				}
+			}
+		} else if startedAt != "" && status == "active" {
+			if st, err := time.Parse(time.RFC3339, startedAt); err == nil {
+				duration = time.Since(st).Round(time.Second).String() + " (running)"
+			}
+		}
+
+		startShort := ""
+		if startedAt != "" {
+			if t, err := time.Parse(time.RFC3339, startedAt); err == nil {
+				startShort = t.Format("01-02 15:04")
+			}
+		}
+
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n",
+			s.ID, agent, status, startShort, duration, exitCode)
+	}
+	return w.Flush()
+}
+
+func runSessionShow(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
+	sessionID := args[0]
+
+	bead, err := daemon.GetBead(ctx, sessionID)
+	if err != nil {
+		return fmt.Errorf("getting session %s: %w", sessionID, err)
+	}
+
+	if jsonOutput {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(bead)
+	}
+
+	fmt.Printf("ID:           %s\n", bead.ID)
+	fmt.Printf("Title:        %s\n", bead.Title)
+	fmt.Printf("Status:       %s\n", bead.Fields["status"])
+	fmt.Printf("Agent:        %s\n", bead.Fields["agent"])
+	fmt.Printf("Agent Bead:   %s\n", bead.Fields["agent_bead_id"])
+	fmt.Printf("Project:      %s\n", bead.Fields["project"])
+	fmt.Printf("Role:         %s\n", bead.Fields["role"])
+	fmt.Printf("Hostname:     %s\n", bead.Fields["hostname"])
+	fmt.Printf("Started At:   %s\n", bead.Fields["started_at"])
+	fmt.Printf("Ended At:     %s\n", bead.Fields["ended_at"])
+	fmt.Printf("Exit Code:    %s\n", bead.Fields["exit_code"])
+	fmt.Printf("Resumed:      %s\n", bead.Fields["resumed"])
+	fmt.Printf("Session Log:  %s\n", bead.Fields["session_log"])
+
+	if bead.Fields["started_at"] != "" && bead.Fields["ended_at"] != "" {
+		if st, err := time.Parse(time.RFC3339, bead.Fields["started_at"]); err == nil {
+			if et, err := time.Parse(time.RFC3339, bead.Fields["ended_at"]); err == nil {
+				fmt.Printf("Duration:     %s\n", et.Sub(st).Round(time.Second))
+			}
+		}
+	}
+
+	return nil
+}
+
+func runSessionRegister(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
+
+	agentName := os.Getenv("BOAT_AGENT")
+	agentBeadID := envOr("KD_AGENT_ID", os.Getenv("BOAT_AGENT_BEAD_ID"))
+	project := defaultProject()
+	role := envOr("BOAT_ROLE", "unknown")
+	hostname, _ := os.Hostname()
+
+	if agentName == "" {
+		return fmt.Errorf("BOAT_AGENT not set")
+	}
+
+	fields := beadsapi.SessionFields{
+		Agent:       agentName,
+		AgentBeadID: agentBeadID,
+		Project:     project,
+		Role:        role,
+		Hostname:    hostname,
+		SessionLog:  sessionLog,
+		StartedAt:   time.Now().UTC().Format(time.RFC3339),
+		Resumed:     sessionLog != "",
+		Status:      "active",
+	}
+
+	id, err := daemon.RegisterSession(ctx, fields)
+	if err != nil {
+		return fmt.Errorf("registering session: %w", err)
+	}
+
+	fmt.Println(id)
+	return nil
+}
+
+func runSessionClose(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
+	sessionID := args[0]
+
+	if err := daemon.CloseSession(ctx, sessionID, sessionExitCode, sessionLog); err != nil {
+		return fmt.Errorf("closing session %s: %w", sessionID, err)
+	}
+
+	fmt.Printf("Session %s closed (exit code: %d).\n", sessionID, sessionExitCode)
+	return nil
+}
+
+// registerSessionBead creates a session bead for the current coop session.
+// Called from the restart loop in agent_start_k8s.go.
+func registerSessionBead(ctx context.Context, cfg k8sConfig, resumeLog string) string {
+	if daemon == nil {
+		return ""
+	}
+
+	agentBeadID := envOr("KD_AGENT_ID", os.Getenv("BOAT_AGENT_BEAD_ID"))
+	hostname, _ := os.Hostname()
+
+	fields := beadsapi.SessionFields{
+		Agent:       cfg.agent,
+		AgentBeadID: agentBeadID,
+		Project:     cfg.project,
+		Role:        cfg.role,
+		Hostname:    hostname,
+		SessionLog:  resumeLog,
+		StartedAt:   time.Now().UTC().Format(time.RFC3339),
+		Resumed:     resumeLog != "",
+		Status:      "active",
+	}
+
+	regCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	id, err := daemon.RegisterSession(regCtx, fields)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[gb agent start] warning: could not register session bead: %v\n", err)
+		return ""
+	}
+	fmt.Printf("[gb agent start] session bead registered: %s\n", id)
+	return id
+}
+
+// closeSessionBead closes the session bead after coop exits.
+func closeSessionBead(ctx context.Context, sessionBeadID string, exitCode int, resumeLog string) {
+	if daemon == nil || sessionBeadID == "" {
+		return
+	}
+
+	// Try to find the actual session log path if we started fresh.
+	logPath := resumeLog
+	if logPath == "" {
+		logPath = findLatestSessionLog()
+	}
+
+	closeCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	if err := daemon.CloseSession(closeCtx, sessionBeadID, exitCode, logPath); err != nil {
+		fmt.Fprintf(os.Stderr, "[gb agent start] warning: could not close session bead %s: %v\n", sessionBeadID, err)
+	} else {
+		fmt.Printf("[gb agent start] session bead closed: %s (exit code: %d)\n", sessionBeadID, exitCode)
+	}
+}
+
+// findLatestSessionLog returns the path of the most recently modified .jsonl
+// file under ~/.claude/projects/ (the session log coop just wrote).
+func findLatestSessionLog() string {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	projectsDir := homeDir + "/.claude/projects"
+
+	var bestPath string
+	var bestTime time.Time
+
+	_ = walkSessionLogs(projectsDir, func(path string, modTime time.Time) {
+		if modTime.After(bestTime) {
+			bestPath = path
+			bestTime = modTime
+		}
+	})
+
+	return bestPath
+}
+
+// walkSessionLogs walks the projects directory for .jsonl files,
+// excluding subagent sessions.
+func walkSessionLogs(projectsDir string, fn func(path string, modTime time.Time)) error {
+	entries, err := os.ReadDir(projectsDir)
+	if err != nil {
+		return err
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		subDir := projectsDir + "/" + entry.Name()
+		subEntries, err := os.ReadDir(subDir)
+		if err != nil {
+			continue
+		}
+		for _, se := range subEntries {
+			if se.IsDir() {
+				continue
+			}
+			name := se.Name()
+			if !strings.HasSuffix(name, ".jsonl") || strings.Contains(name, "subagent") {
+				return nil
+			}
+			info, err := se.Info()
+			if err != nil {
+				continue
+			}
+			fn(subDir+"/"+name, info.ModTime())
+		}
+	}
+	return nil
+}

--- a/gasboat/controller/cmd/gb/setup_repos_test.go
+++ b/gasboat/controller/cmd/gb/setup_repos_test.go
@@ -17,14 +17,14 @@ func TestParseBoatProjectsEnv(t *testing.T) {
 		},
 		{
 			name: "single entry with prefix",
-			raw:  "gasboat=https://github.com/groblegark/gasboat.git:kd",
-			want: []repoCloneEntry{{Name: "gasboat", URL: "https://github.com/groblegark/gasboat.git"}},
+			raw:  "gasboat=https://github.com/groblegark/gasboats.git:kd",
+			want: []repoCloneEntry{{Name: "gasboat", URL: "https://github.com/groblegark/gasboats.git"}},
 		},
 		{
 			name: "two entries",
-			raw:  "gasboat=https://github.com/groblegark/gasboat.git:kd,monorepo=https://gitlab.com/PiHealth/CoreFICS/monorepo:PE",
+			raw:  "gasboat=https://github.com/groblegark/gasboats.git:kd,monorepo=https://gitlab.com/PiHealth/CoreFICS/monorepo:PE",
 			want: []repoCloneEntry{
-				{Name: "gasboat", URL: "https://github.com/groblegark/gasboat.git"},
+				{Name: "gasboat", URL: "https://github.com/groblegark/gasboats.git"},
 				{Name: "monorepo", URL: "https://gitlab.com/PiHealth/CoreFICS/monorepo"},
 			},
 		},

--- a/gasboat/controller/cmd/slack-bridge/main_test.go
+++ b/gasboat/controller/cmd/slack-bridge/main_test.go
@@ -30,9 +30,9 @@ func TestParseRepoList(t *testing.T) {
 		},
 		{
 			name:  "default config",
-			input: "groblegark/gasboat,groblegark/kbeads~ext,groblegark/coop~ext",
+			input: "groblegark/gasboats,groblegark/kbeads~ext,groblegark/coop~ext",
 			want: []bridge.RepoRef{
-				{Owner: "groblegark", Repo: "gasboat"},
+				{Owner: "groblegark", Repo: "gasboats"},
 				{Owner: "groblegark", Repo: "kbeads", External: true},
 				{Owner: "groblegark", Repo: "coop", External: true},
 			},

--- a/gasboat/controller/internal/beadsapi/client_session.go
+++ b/gasboat/controller/internal/beadsapi/client_session.go
@@ -1,0 +1,94 @@
+package beadsapi
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// SessionFields contains metadata for a session bead.
+type SessionFields struct {
+	Agent       string `json:"agent"`
+	AgentBeadID string `json:"agent_bead_id"`
+	Project     string `json:"project"`
+	Role        string `json:"role"`
+	Hostname    string `json:"hostname"`
+	SessionLog  string `json:"session_log,omitempty"`
+	StartedAt   string `json:"started_at"`
+	EndedAt     string `json:"ended_at,omitempty"`
+	ExitCode    int    `json:"exit_code,omitempty"`
+	Resumed     bool   `json:"resumed"`
+	Status      string `json:"status"` // active, completed, crashed, retired
+}
+
+// RegisterSession creates a new session bead linked to an agent bead.
+// Returns the session bead ID.
+func (c *Client) RegisterSession(ctx context.Context, fields SessionFields) (string, error) {
+	fieldsJSON, err := json.Marshal(fields)
+	if err != nil {
+		return "", fmt.Errorf("marshalling session fields: %w", err)
+	}
+
+	title := fmt.Sprintf("session:%s:%s", fields.Agent, fields.StartedAt)
+
+	req := CreateBeadRequest{
+		Title:  title,
+		Type:   "session",
+		Kind:   "config",
+		Fields: json.RawMessage(fieldsJSON),
+	}
+	if fields.Project != "" {
+		req.Labels = []string{"project:" + fields.Project}
+	}
+
+	id, err := c.CreateBead(ctx, req)
+	if err != nil {
+		return "", fmt.Errorf("creating session bead: %w", err)
+	}
+
+	// Link session to agent bead.
+	if fields.AgentBeadID != "" {
+		_ = c.AddDependency(ctx, id, fields.AgentBeadID, "session_of", fields.Agent)
+	}
+
+	return id, nil
+}
+
+// CloseSession closes a session bead with final metadata.
+func (c *Client) CloseSession(ctx context.Context, sessionBeadID string, exitCode int, sessionLog string) error {
+	fields := map[string]any{
+		"ended_at":  time.Now().UTC().Format(time.RFC3339),
+		"exit_code": exitCode,
+		"status":    "completed",
+	}
+	if exitCode != 0 {
+		fields["status"] = "crashed"
+	}
+	if sessionLog != "" {
+		fields["session_log"] = sessionLog
+	}
+
+	if err := c.UpdateBeadFieldsTyped(ctx, sessionBeadID, fields); err != nil {
+		return fmt.Errorf("updating session bead %s: %w", sessionBeadID, err)
+	}
+	return c.CloseBead(ctx, sessionBeadID, nil)
+}
+
+// ListSessionBeads returns session beads, optionally filtered by agent name.
+func (c *Client) ListSessionBeads(ctx context.Context, agentName string, limit int) ([]*BeadDetail, error) {
+	q := ListBeadsQuery{
+		Types: []string{"session"},
+		Sort:  "-created_at",
+		Limit: limit,
+	}
+	if agentName != "" {
+		q.Search = agentName
+	}
+
+	result, err := c.ListBeadsFiltered(ctx, q)
+	if err != nil {
+		return nil, fmt.Errorf("listing session beads: %w", err)
+	}
+	return result.Beads, nil
+}

--- a/gasboat/controller/internal/beadsapi/client_session_test.go
+++ b/gasboat/controller/internal/beadsapi/client_session_test.go
@@ -1,0 +1,167 @@
+package beadsapi
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestRegisterSession(t *testing.T) {
+	var gotBody CreateBeadRequest
+	createCalled := false
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v1/beads" && r.Method == "POST" {
+			createCalled = true
+			_ = json.NewDecoder(r.Body).Decode(&gotBody)
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]string{"id": "kd-sess-1"})
+			return
+		}
+		// Dependencies endpoint (best-effort, return success).
+		if r.Method == "POST" {
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]string{"id": "dep-1"})
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	c := &Client{baseURL: srv.URL, httpClient: srv.Client()}
+
+	fields := SessionFields{
+		Agent:       "test-agent",
+		AgentBeadID: "kd-agent-1",
+		Project:     "gasboat",
+		Role:        "crew",
+		Hostname:    "pod-abc",
+		StartedAt:   time.Now().UTC().Format(time.RFC3339),
+		Resumed:     false,
+		Status:      "active",
+	}
+
+	id, err := c.RegisterSession(context.Background(), fields)
+	if err != nil {
+		t.Fatalf("RegisterSession: %v", err)
+	}
+	if id != "kd-sess-1" {
+		t.Errorf("expected id kd-sess-1, got %s", id)
+	}
+	if !createCalled {
+		t.Error("expected CreateBead to be called")
+	}
+	if gotBody.Type != "session" {
+		t.Errorf("expected type=session, got %s", gotBody.Type)
+	}
+	if gotBody.Kind != "config" {
+		t.Errorf("expected kind=config, got %s", gotBody.Kind)
+	}
+	if len(gotBody.Labels) != 1 || gotBody.Labels[0] != "project:gasboat" {
+		t.Errorf("expected label project:gasboat, got %v", gotBody.Labels)
+	}
+
+	// Verify fields were properly serialized.
+	var parsed SessionFields
+	if err := json.Unmarshal(gotBody.Fields, &parsed); err != nil {
+		t.Fatalf("unmarshalling fields: %v", err)
+	}
+	if parsed.Agent != "test-agent" {
+		t.Errorf("expected agent=test-agent, got %s", parsed.Agent)
+	}
+	if parsed.Status != "active" {
+		t.Errorf("expected status=active, got %s", parsed.Status)
+	}
+}
+
+func TestCloseSession(t *testing.T) {
+	var patchFields map[string]any
+	var closeCalled bool
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == "GET":
+			// GetBead for read-modify-write in UpdateBeadFieldsTyped.
+			bead := beadJSON{
+				ID:     "kd-sess-1",
+				Type:   "session",
+				Status: "open",
+				Fields: json.RawMessage(`{"agent":"test-agent","status":"active","started_at":"2026-03-08T12:00:00Z"}`),
+			}
+			_ = json.NewEncoder(w).Encode(bead)
+		case r.Method == "PATCH":
+			var body map[string]json.RawMessage
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			if raw, ok := body["fields"]; ok {
+				_ = json.Unmarshal(raw, &patchFields)
+			}
+			w.WriteHeader(http.StatusNoContent)
+		case r.Method == "POST":
+			closeCalled = true
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	c := &Client{baseURL: srv.URL, httpClient: srv.Client()}
+
+	err := c.CloseSession(context.Background(), "kd-sess-1", 1, "/path/to/log.jsonl")
+	if err != nil {
+		t.Fatalf("CloseSession: %v", err)
+	}
+
+	if !closeCalled {
+		t.Error("expected CloseBead to be called")
+	}
+
+	// Verify fields were updated.
+	if patchFields["status"] != "crashed" {
+		t.Errorf("expected status=crashed for non-zero exit, got %v", patchFields["status"])
+	}
+	if patchFields["session_log"] != "/path/to/log.jsonl" {
+		t.Errorf("expected session_log set, got %v", patchFields["session_log"])
+	}
+	exitCode, ok := patchFields["exit_code"].(float64)
+	if !ok || int(exitCode) != 1 {
+		t.Errorf("expected exit_code=1, got %v", patchFields["exit_code"])
+	}
+}
+
+func TestListSessionBeads(t *testing.T) {
+	var gotQuery string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.RawQuery
+		resp := listBeadsResponse{
+			Beads: []beadJSON{
+				{ID: "kd-sess-1", Type: "session", Status: "closed"},
+				{ID: "kd-sess-2", Type: "session", Status: "open"},
+			},
+			Total: 2,
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	c := &Client{baseURL: srv.URL, httpClient: srv.Client()}
+
+	beads, err := c.ListSessionBeads(context.Background(), "my-agent", 10)
+	if err != nil {
+		t.Fatalf("ListSessionBeads: %v", err)
+	}
+	if len(beads) != 2 {
+		t.Errorf("expected 2 beads, got %d", len(beads))
+	}
+	if gotQuery == "" {
+		t.Error("expected query params")
+	}
+	// Should contain type=session.
+	if got := gotQuery; got == "" {
+		t.Error("expected non-empty query")
+	}
+}

--- a/gasboat/controller/internal/bridge/bot_agent_kill.go
+++ b/gasboat/controller/internal/bridge/bot_agent_kill.go
@@ -270,3 +270,131 @@ func postCoopKeys(ctx context.Context, client *http.Client, base string, keys ..
 		resp.Body.Close()
 	}
 }
+
+// handleKillThreadAgent handles the "Kill Agent" button posted in thread spawn messages.
+// The button's value carries the agent identity. The interaction callback provides
+// the channel and thread context that slash commands cannot access.
+func (b *Bot) handleKillThreadAgent(ctx context.Context, agentName string, callback slack.InteractionCallback) {
+	agentName = extractAgentName(agentName)
+	channelID := callback.Channel.ID
+	userID := callback.User.ID
+
+	// Acknowledge immediately — kill can take 30s+.
+	_, _ = b.api.PostEphemeral(channelID, userID,
+		slack.MsgOptionText(fmt.Sprintf(":hourglass_flowing_sand: Killing thread agent *%s*…", agentName), false))
+
+	go func() {
+		if err := b.killAgent(context.Background(), agentName, false); err != nil {
+			b.logger.Error("kill-thread-agent button: failed", "agent", agentName, "error", err)
+			_, _ = b.api.PostEphemeral(channelID, userID,
+				slack.MsgOptionText(fmt.Sprintf(":x: Failed to kill thread agent %q: %s", agentName, err.Error()), false))
+			return
+		}
+		b.logger.Info("killed thread agent via button", "agent", agentName, "user", userID)
+		_, _ = b.api.PostEphemeral(channelID, userID,
+			slack.MsgOptionText(fmt.Sprintf(":skull: Thread agent *%s* terminated.", agentName), false))
+	}()
+}
+
+// handleRestartThreadAgent handles the "Restart Agent" button on thread spawn messages.
+// It kills the current agent then re-spawns a new one with the same name, project,
+// and thread metadata — preserving the session JSONL for coop --resume.
+func (b *Bot) handleRestartThreadAgent(ctx context.Context, agentName string, callback slack.InteractionCallback) {
+	agentName = extractAgentName(agentName)
+	channelID := callback.Channel.ID
+	threadTS := callback.Container.ThreadTs
+	userID := callback.User.ID
+
+	if threadTS == "" {
+		_, _ = b.api.PostEphemeral(channelID, userID,
+			slack.MsgOptionText(":x: Restart is only available in threads.", false))
+		return
+	}
+
+	_, _ = b.api.PostEphemeral(channelID, userID,
+		slack.MsgOptionText(fmt.Sprintf(":arrows_counterclockwise: Restarting thread agent *%s*…", agentName), false))
+
+	go func() {
+		bgCtx := context.Background()
+
+		// Look up the existing agent bead to capture project and metadata before killing.
+		bead, err := b.daemon.FindAgentBead(bgCtx, agentName)
+		if err != nil {
+			b.logger.Error("restart-thread-agent: agent bead not found", "agent", agentName, "error", err)
+			_, _ = b.api.PostEphemeral(channelID, userID,
+				slack.MsgOptionText(fmt.Sprintf(":x: Agent %q not found: %s", agentName, err), false))
+			return
+		}
+		project := bead.Fields["project"]
+
+		// Kill the agent (graceful shutdown + close bead + clean up state).
+		if err := b.killAgent(bgCtx, agentName, false); err != nil {
+			b.logger.Error("restart-thread-agent: kill failed", "agent", agentName, "error", err)
+			_, _ = b.api.PostEphemeral(channelID, userID,
+				slack.MsgOptionText(fmt.Sprintf(":x: Failed to kill agent %q: %s", agentName, err), false))
+			return
+		}
+
+		// Re-spawn with the SAME agent name so the entrypoint finds the existing
+		// session JSONL and PVC workspace for session continuity.
+		fields := map[string]string{
+			"agent":                agentName,
+			"mode":                 "job",
+			"role":                 "thread",
+			"project":              project,
+			"slack_thread_channel": channelID,
+			"slack_thread_ts":      threadTS,
+			"spawn_source":         "slack-thread",
+		}
+		fieldsJSON, err := json.Marshal(fields)
+		if err != nil {
+			b.logger.Error("restart-thread-agent: marshal fields", "error", err)
+			return
+		}
+
+		labels := []string{"slack-thread"}
+		if project != "" {
+			labels = append(labels, "project:"+project)
+		}
+
+		newBeadID, err := b.daemon.CreateBead(bgCtx, beadsapi.CreateBeadRequest{
+			Title:       agentName,
+			Type:        "agent",
+			Description: "Restarted thread agent (session resume).",
+			Fields:      json.RawMessage(fieldsJSON),
+			Labels:      labels,
+		})
+		if err != nil {
+			b.logger.Error("restart-thread-agent: failed to create new bead", "agent", agentName, "error", err)
+			_, _ = b.api.PostEphemeral(channelID, userID,
+				slack.MsgOptionText(fmt.Sprintf(":x: Killed agent but failed to re-spawn: %s", err), false))
+			return
+		}
+
+		// Re-establish thread→agent mapping.
+		if b.state != nil {
+			_ = b.state.SetThreadAgent(channelID, threadTS, agentName)
+		}
+
+		b.logger.Info("restarted thread agent", "agent", agentName, "new_bead", newBeadID,
+			"user", userID, "channel", channelID, "thread_ts", threadTS)
+
+		if b.api != nil {
+			msg := fmt.Sprintf(":arrows_counterclockwise: Agent *%s* restarted with session resume. (tracking: `%s`)", agentName, newBeadID)
+			_, _, _ = b.api.PostMessage(channelID,
+				slack.MsgOptionText(msg, false),
+				slack.MsgOptionBlocks(
+					slack.NewSectionBlock(slack.NewTextBlockObject("mrkdwn", msg, false, false), nil, nil),
+					slack.NewActionBlock("thread_agent_actions",
+						slack.NewButtonBlockElement("restart_thread_agent", agentName,
+							slack.NewTextBlockObject("plain_text", "Restart Agent", false, false)),
+						slack.NewButtonBlockElement("kill_thread_agent", agentName,
+							slack.NewTextBlockObject("plain_text", "Kill Agent", false, false)).
+							WithStyle(slack.StyleDanger),
+					),
+				),
+				slack.MsgOptionTS(threadTS),
+			)
+		}
+	}()
+}

--- a/gasboat/controller/internal/bridge/bot_decisions.go
+++ b/gasboat/controller/internal/bridge/bot_decisions.go
@@ -232,16 +232,18 @@ func (b *Bot) NotifyDecision(ctx context.Context, bead BeadEvent) error {
 	if threadSource == "" {
 		if reqAgentBeadID := bead.Fields["requesting_agent_bead_id"]; reqAgentBeadID != "" {
 			if agentBead, err := b.daemon.GetBead(ctx, reqAgentBeadID); err == nil {
+				// Always update agent identity from requesting bead so that
+				// agent-card threading (below) can find the correct card.
+				if agentBead.Fields["agent"] != "" {
+					agent = extractAgentName(agentBead.Fields["agent"])
+					agentDisplay = b.agentDisplayName(agent)
+				}
 				ch := agentBead.Fields["slack_thread_channel"]
 				ts := agentBead.Fields["slack_thread_ts"]
 				if isValidThreadBinding(ch, ts) {
 					targetChannel = ch
 					threadTS = ts
 					threadSource = "slack_thread"
-					if agentBead.Fields["agent"] != "" {
-						agent = agentBead.Fields["agent"]
-						agentDisplay = b.agentDisplayName(agent)
-					}
 				}
 			}
 		}

--- a/gasboat/controller/internal/bridge/bot_decisions_modal.go
+++ b/gasboat/controller/internal/bridge/bot_decisions_modal.go
@@ -29,6 +29,16 @@ func (b *Bot) handleBlockActions(ctx context.Context, callback slack.Interaction
 			b.handleClearAgent(ctx, action.Value, callback)
 			return
 
+		// Kill thread agent button: action_id = "kill_thread_agent", value = agent identity.
+		case actionID == "kill_thread_agent":
+			b.handleKillThreadAgent(ctx, action.Value, callback)
+			return
+
+		// Restart thread agent button: action_id = "restart_thread_agent", value = agent identity.
+		case actionID == "restart_thread_agent":
+			b.handleRestartThreadAgent(ctx, action.Value, callback)
+			return
+
 		// Dismiss button: action_id = "dismiss_decision", value = beadID.
 		case actionID == "dismiss_decision":
 			b.handleDismiss(ctx, action.Value, callback)

--- a/gasboat/controller/internal/bridge/bot_decisions_notify_test.go
+++ b/gasboat/controller/internal/bridge/bot_decisions_notify_test.go
@@ -285,6 +285,73 @@ func TestNotifyDecision_FallbackToRequestingAgentBeadID(t *testing.T) {
 	}
 }
 
+// Regression test: when requesting_agent_bead_id has no thread binding but
+// stores a full-path agent name (e.g., "gasboat/crew/my-agent"), agent
+// threading should still find the existing card keyed by short name.
+func TestNotifyDecision_FallbackAgentFullPath_ThreadsUnderCard(t *testing.T) {
+	daemon := newMockDaemon()
+	// The requesting agent bead has a full-path agent field and NO thread binding.
+	daemon.beads["bd-req-fullpath"] = &beadsapi.BeadDetail{
+		ID:    "bd-req-fullpath",
+		Type:  "agent",
+		Title: "my-agent",
+		Fields: map[string]string{
+			"agent": "gasboat/crew/my-agent",
+			// No slack_thread_channel / slack_thread_ts — forces agent_card fallback.
+		},
+	}
+
+	var mu sync.Mutex
+	var posts []struct{ channel, threadTS string }
+	slackSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/chat.postMessage" {
+			_ = r.ParseForm()
+			mu.Lock()
+			posts = append(posts, struct{ channel, threadTS string }{
+				r.FormValue("channel"), r.FormValue("thread_ts"),
+			})
+			mu.Unlock()
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"ok": true, "channel": "C-DEFAULT", "ts": "9999.0002"})
+	}))
+	defer slackSrv.Close()
+
+	bot := newTestBot(daemon, slackSrv)
+	bot.channel = "C-DEFAULT"
+	bot.threadingMode = "agent"
+	// Pre-populate agent card with SHORT name key (as NotifyAgentSpawn does).
+	bot.agentCards["my-agent"] = MessageRef{ChannelID: "C-DEFAULT", Timestamp: "1111.0001"}
+
+	err := bot.NotifyDecision(context.Background(), BeadEvent{
+		ID:       "dec-fullpath",
+		Type:     "decision",
+		Assignee: "some-user",
+		Fields: map[string]string{
+			"prompt":                   "Full path agent test?",
+			"options":                  `["yes","no"]`,
+			"requesting_agent_bead_id": "bd-req-fullpath",
+		},
+	})
+	if err != nil {
+		t.Fatalf("NotifyDecision: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	// The decision should be threaded under the existing agent card.
+	found := false
+	for _, p := range posts {
+		if p.threadTS == "1111.0001" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected decision to thread under agent card ts=1111.0001, got posts: %+v", posts)
+	}
+}
+
 func TestNotifyDecision_AgentThreadingModeUpdatesCard(t *testing.T) {
 	daemon := newMockDaemon()
 

--- a/gasboat/controller/internal/bridge/bot_mentions.go
+++ b/gasboat/controller/internal/bridge/bot_mentions.go
@@ -408,10 +408,19 @@ func (b *Bot) handleThreadSpawn(ctx context.Context, ev *slackevents.AppMentionE
 			}
 		}
 		if b.api != nil {
+			msg := fmt.Sprintf(":zap: Assigned a prewarmed agent — should be ready in seconds! (tracking: `%s`)", beadID)
 			_, msgTS, _ := b.api.PostMessage(channel,
-				slack.MsgOptionText(
-					fmt.Sprintf(":zap: Assigned a prewarmed agent — should be ready in seconds! (tracking: `%s`)", beadID),
-					false),
+				slack.MsgOptionText(msg, false),
+				slack.MsgOptionBlocks(
+					slack.NewSectionBlock(slack.NewTextBlockObject("mrkdwn", msg, false, false), nil, nil),
+					slack.NewActionBlock("thread_agent_actions",
+						slack.NewButtonBlockElement("restart_thread_agent", assignedAgent,
+							slack.NewTextBlockObject("plain_text", "Restart Agent", false, false)),
+						slack.NewButtonBlockElement("kill_thread_agent", assignedAgent,
+							slack.NewTextBlockObject("plain_text", "Kill Agent", false, false)).
+							WithStyle(slack.StyleDanger),
+					),
+				),
 				slack.MsgOptionTS(threadTS),
 			)
 			if msgTS != "" {
@@ -472,12 +481,21 @@ func (b *Bot) handleThreadSpawn(ctx context.Context, ev *slackevents.AppMentionE
 		}
 	}
 
-	// Post confirmation reply in thread.
+	// Post confirmation reply in thread with kill/restart buttons.
 	if b.api != nil {
+		msg := fmt.Sprintf(":zap: Spinning up an agent to help here... (tracking: `%s`)", beadID)
 		_, msgTS, _ := b.api.PostMessage(channel,
-			slack.MsgOptionText(
-				fmt.Sprintf(":zap: Spinning up an agent to help here... (tracking: `%s`)", beadID),
-				false),
+			slack.MsgOptionText(msg, false),
+			slack.MsgOptionBlocks(
+				slack.NewSectionBlock(slack.NewTextBlockObject("mrkdwn", msg, false, false), nil, nil),
+				slack.NewActionBlock("thread_agent_actions",
+					slack.NewButtonBlockElement("restart_thread_agent", agentName,
+						slack.NewTextBlockObject("plain_text", "Restart Agent", false, false)),
+					slack.NewButtonBlockElement("kill_thread_agent", agentName,
+						slack.NewTextBlockObject("plain_text", "Kill Agent", false, false)).
+						WithStyle(slack.StyleDanger),
+				),
+			),
 			slack.MsgOptionTS(threadTS),
 		)
 		if msgTS != "" {

--- a/gasboat/controller/internal/bridge/github.go
+++ b/gasboat/controller/internal/bridge/github.go
@@ -274,8 +274,8 @@ type ghPackageVersion struct {
 // matching the digest, then extracts the commit from sha-<hex> convention tags
 // (set by docker/metadata-action during CI builds).
 //
-// imageRef is the image name (e.g., "ghcr.io/groblegark/gasboat" or
-// "ghcr.io/groblegark/gasboat:latest"). The tag/digest suffix is stripped.
+// imageRef is the image name (e.g., "ghcr.io/groblegark/gasboats" or
+// "ghcr.io/groblegark/gasboats:latest"). The tag/digest suffix is stripped.
 // digest is the registry content digest (e.g., "sha256:abc123...").
 func (c *GitHubClient) GetCommitForDigest(ctx context.Context, imageRef, digest string) (string, error) {
 	org, pkg, err := parseGHCRImageRef(imageRef)
@@ -316,7 +316,7 @@ func (c *GitHubClient) GetCommitForDigest(ctx context.Context, imageRef, digest 
 }
 
 // parseGHCRImageRef extracts the org and package name from a GHCR image
-// reference like "ghcr.io/groblegark/gasboat" or "ghcr.io/groblegark/gasboat:latest".
+// reference like "ghcr.io/groblegark/gasboats" or "ghcr.io/groblegark/gasboats:latest".
 func parseGHCRImageRef(imageRef string) (org, pkg string, err error) {
 	ref := imageRef
 	// Strip tag suffix (e.g., ":latest").
@@ -371,7 +371,7 @@ func (c *GitHubClient) CompareSHAs(ctx context.Context, repo RepoRef, base, head
 }
 
 // ImageToRepo maps a GHCR image reference to a GitHub RepoRef.
-// e.g., "ghcr.io/groblegark/gasboat/agent:latest" → RepoRef{Owner: "groblegark", Repo: "gasboat"}
+// e.g., "ghcr.io/groblegark/gasboats/agent:latest" → RepoRef{Owner: "groblegark", Repo: "gasboat"}
 // For images with sub-paths (gasboat/agent), uses the first path component as the repo.
 func ImageToRepo(image string) (RepoRef, bool) {
 	org, pkg, err := parseGHCRImageRef(image)

--- a/gasboat/controller/internal/bridge/github_test.go
+++ b/gasboat/controller/internal/bridge/github_test.go
@@ -293,7 +293,7 @@ func TestCalverKey(t *testing.T) {
 
 func TestGetCommitForDigest(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/orgs/groblegark/packages/container/gasboat/versions" {
+		if r.URL.Path != "/orgs/groblegark/packages/container/gasboats/versions" {
 			http.NotFound(w, r)
 			return
 		}
@@ -307,7 +307,7 @@ func TestGetCommitForDigest(t *testing.T) {
 
 	client := newTestGitHubClient(srv.URL, "test-token")
 	sha, err := client.GetCommitForDigest(context.Background(),
-		"ghcr.io/groblegark/gasboat", "sha256:abc123def456789")
+		"ghcr.io/groblegark/gasboats", "sha256:abc123def456789")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -387,10 +387,10 @@ func TestParseGHCRImageRef(t *testing.T) {
 		wantPkg string
 		wantErr bool
 	}{
-		{"ghcr.io/groblegark/gasboat", "groblegark", "gasboat", false},
+		{"ghcr.io/groblegark/gasboats", "groblegark", "gasboats", false},
 		{"ghcr.io/groblegark/kbeads:latest", "groblegark", "kbeads", false},
 		{"ghcr.io/groblegark/coop:v1.0.0", "groblegark", "coop", false},
-		{"ghcr.io/groblegark/gasboat@sha256:abc", "groblegark", "gasboat", false},
+		{"ghcr.io/groblegark/gasboats@sha256:abc", "groblegark", "gasboats", false},
 		{"invalid", "", "", true},
 		{"ghcr.io/onlytwo", "", "", true},
 	}
@@ -600,8 +600,8 @@ func TestImageToRepo(t *testing.T) {
 		wantRef RepoRef
 		wantOK  bool
 	}{
-		{"ghcr.io/groblegark/gasboat/agent:latest", RepoRef{Owner: "groblegark", Repo: "gasboat"}, true},
-		{"ghcr.io/groblegark/gasboat:2026.63.1", RepoRef{Owner: "groblegark", Repo: "gasboat"}, true},
+		{"ghcr.io/groblegark/gasboats/agent:latest", RepoRef{Owner: "groblegark", Repo: "gasboats"}, true},
+		{"ghcr.io/groblegark/gasboats:2026.63.1", RepoRef{Owner: "groblegark", Repo: "gasboats"}, true},
 		{"ghcr.io/groblegark/kbeads:latest", RepoRef{Owner: "groblegark", Repo: "kbeads"}, true},
 		{"invalid", RepoRef{}, false},
 	}

--- a/gasboat/controller/internal/bridge/unreleased.go
+++ b/gasboat/controller/internal/bridge/unreleased.go
@@ -197,7 +197,7 @@ func MonorepoImageConfigs(repo RepoRef, tag string) []ImageTrackConfig {
 }
 
 // ExtractImageTag extracts the tag from an image reference like
-// "ghcr.io/groblegark/gasboat/agent:2026.63.1" → "2026.63.1".
+// "ghcr.io/groblegark/gasboats/agent:2026.63.1" → "2026.63.1".
 // Returns empty string if no tag is present.
 func ExtractImageTag(imageRef string) string {
 	if imageRef == "" {

--- a/gasboat/controller/internal/bridge/unreleased_test.go
+++ b/gasboat/controller/internal/bridge/unreleased_test.go
@@ -386,10 +386,10 @@ func TestExtractImageTag_Unreleased(t *testing.T) {
 		input string
 		want  string
 	}{
-		{"ghcr.io/groblegark/gasboat/agent:2026.63.1", "2026.63.1"},
-		{"ghcr.io/groblegark/gasboat/agent:latest", "latest"},
-		{"ghcr.io/groblegark/gasboat/agent", ""},
-		{"ghcr.io/groblegark/gasboat/agent@sha256:abc123", ""},
+		{"ghcr.io/groblegark/gasboats/agent:2026.63.1", "2026.63.1"},
+		{"ghcr.io/groblegark/gasboats/agent:latest", "latest"},
+		{"ghcr.io/groblegark/gasboats/agent", ""},
+		{"ghcr.io/groblegark/gasboats/agent@sha256:abc123", ""},
 		{"", ""},
 	}
 	for _, tt := range tests {

--- a/gasboat/docs/release-pipeline.md
+++ b/gasboat/docs/release-pipeline.md
@@ -35,7 +35,7 @@ This triggers the automated pipeline.
 
 | Step | System | Pipeline | What it does |
 |------|--------|----------|--------------|
-| Build + push images | RWX | `.rwx/docker.yml` | Builds all 6 images, pushes to `ghcr.io/groblegark/gasboat/*` |
+| Build + push images | RWX | `.rwx/docker.yml` | Builds all 6 images, pushes to `ghcr.io/groblegark/gasboats/*` |
 | Push helm chart | RWX | `.rwx/helm.yml` | Packages and pushes chart to `oci://ghcr.io/groblegark/charts` |
 | GitHub Release | GitHub Actions | `.github/workflows/release.yml` | Creates release with auto-generated notes |
 | Trigger deploy | GitHub Actions | `.github/workflows/release.yml` | Triggers fics-helm-chart GitLab pipeline |
@@ -80,7 +80,7 @@ Example: `2026.61.5` = 5th release on March 2, 2026.
 
 ## Images
 
-All pushed to `ghcr.io/groblegark/gasboat/`:
+All pushed to `ghcr.io/groblegark/gasboats/`:
 
 | Image | Description |
 |-------|-------------|

--- a/gasboat/helm/gasboat/values.yaml
+++ b/gasboat/helm/gasboat/values.yaml
@@ -890,7 +890,7 @@ wlBridge:
   enabled: false
 
   image:
-    repository: ghcr.io/groblegark/gasboat/wl-bridge
+    repository: ghcr.io/groblegark/gasboats/wl-bridge
     tag: ""
     pullPolicy: Always
 

--- a/gasboat/helm/values-gasboat.yaml
+++ b/gasboat/helm/values-gasboat.yaml
@@ -48,7 +48,7 @@ agents:
   # Per-project secrets (Claude OAuth, git, GitHub, GitLab, RWX, etc.) are
   # declared on project beads and auto-reconciled by the controller.
   image:
-    repository: ghcr.io/groblegark/gasboat/controller
+    repository: ghcr.io/groblegark/gasboats/controller
   nodeSelector:
     kubernetes.io/arch: amd64
 beads:
@@ -127,7 +127,7 @@ jiraBridge:
   enabled: true
   image:
     pullPolicy: IfNotPresent
-    repository: ghcr.io/groblegark/gasboat/jira-bridge
+    repository: ghcr.io/groblegark/gasboats/jira-bridge
   jira:
     baseURL: https://pihealth.atlassian.net
     boatProjects: monorepo=placeholder:PE,monorepo=placeholder:DEVOPS
@@ -217,7 +217,7 @@ registrySecrets:
 slackBridge:
   enabled: true
   image:
-    repository: ghcr.io/groblegark/gasboat/slack-bridge
+    repository: ghcr.io/groblegark/gasboats/slack-bridge
   logLevel: debug
   nodeSelector:
     kubernetes.io/arch: amd64
@@ -246,7 +246,7 @@ gitlabBridge:
   enabled: true
   image:
     pullPolicy: Always
-    repository: ghcr.io/groblegark/gasboat/gitlab-bridge
+    repository: ghcr.io/groblegark/gasboats/gitlab-bridge
     tag: main
   gitlab:
     baseURL: https://gitlab.com

--- a/gasboat/images/agent/entrypoint.sh
+++ b/gasboat/images/agent/entrypoint.sh
@@ -146,14 +146,16 @@ _clone_repo() {
     fi
 }
 
-REPOS_DIR="${WORKSPACE}/repos"
-mkdir -p "${REPOS_DIR}"
-
 # Clone reference repos declared on the project bead.
-# Init container clones them first; this is a fallback for job mode (EmptyDir).
+# The init container clones them into /home/agent/bot/{project}/repos/ for
+# PVC-backed (crew) pods.  This block is the fallback for job mode (EmptyDir)
+# where no init container runs.  Skip if the init container already cloned.
 # Format: "name=https://host/path.git:branch,name2=https://host2/path2.git:branch2"
 # The branch suffix is always present (controller defaults empty to "main").
-if [ -n "${BOAT_REFERENCE_REPOS:-}" ]; then
+INIT_REPOS_DIR="/home/agent/bot/${PROJECT}/repos"
+if [ -n "${BOAT_REFERENCE_REPOS:-}" ] && [ ! -d "${INIT_REPOS_DIR}" ]; then
+    REPOS_DIR="${WORKSPACE}/repos"
+    mkdir -p "${REPOS_DIR}"
     IFS=',' read -ra REPO_ENTRIES <<< "${BOAT_REFERENCE_REPOS}"
     for entry in "${REPO_ENTRIES[@]}"; do
         repo_name="${entry%%=*}"
@@ -367,6 +369,19 @@ if [ -n "${PROJECT}" ] && [ -d "/home/agent/bot/${PROJECT}/work/.git" ]; then
     COOP_WORKDIR="/home/agent/bot/${PROJECT}/work"
     export KD_WORKSPACE="${COOP_WORKDIR}"
     echo "[entrypoint] Using project repo as cwd: ${COOP_WORKDIR}"
+
+    # Symlink repos/ into the working directory so that nudge-prompt hints
+    # ("ls repos/") work from the agent's cwd.  The init container clones
+    # reference repos to /home/agent/bot/{project}/repos/ which is a sibling
+    # of work/, not a child — without this symlink agents cannot find them.
+    REPOS_PARENT="/home/agent/bot/${PROJECT}/repos"
+    if [ -d "${REPOS_PARENT}" ] && [ ! -e "${COOP_WORKDIR}/repos" ]; then
+        ln -s "${REPOS_PARENT}" "${COOP_WORKDIR}/repos"
+        # Keep the symlink out of git status noise.
+        grep -qxF 'repos/' "${COOP_WORKDIR}/.gitignore" 2>/dev/null \
+            || echo 'repos/' >> "${COOP_WORKDIR}/.gitignore"
+        echo "[entrypoint] Symlinked repos/ → ${REPOS_PARENT}"
+    fi
 else
     echo "[entrypoint] No project repo found, using scaffold workspace: ${COOP_WORKDIR}"
 fi

--- a/gasboat/tests/e2e/README.md
+++ b/gasboat/tests/e2e/README.md
@@ -52,7 +52,7 @@ claudeless run tests/e2e/claudeless/gate-decision-flow.toml \
   --settings .claude/settings.json
 ```
 
-Claudeless is installed in the `ghcr.io/groblegark/gasboat/agent:latest` image.
+Claudeless is installed in the `ghcr.io/groblegark/gasboats/agent:latest` image.
 
 ## Decisions/Yield Tests (`test-decisions-yield.sh`)
 


### PR DESCRIPTION
## Summary
- Subtree pull of gasboat main into gasboats monorepo
- Includes 4 merged PRs:
  - **#168**: feat(bridge): add kill and restart buttons for thread agents
  - **#171**: fix(entrypoint): symlink repos/ into workdir and skip double clone
  - **#172**: feat(gb): first-class session beads
  - **#176**: refactor: switch all references from groblegark/gasboat to groblegark/gasboats
- Resolved conflict in `gasboat/helm/gasboat/values.yaml` (kept monorepo's explicit `/controller` image subpath)

## Test plan
- [ ] CI passes on gasboats monorepo
- [ ] Helm lint `gasboat/helm/gasboat/`
- [ ] Go build + test in `gasboat/controller/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)