### PR TITLE
subtree: sync gasboat main (PRs #174, #181, #182)

### DIFF
--- a/gasboat/controller/internal/bridge/bot_agent_kill_test.go
+++ b/gasboat/controller/internal/bridge/bot_agent_kill_test.go
@@ -1,0 +1,422 @@
+package bridge
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/slack-go/slack"
+)
+
+// --- handleClearAgent tests ---
+
+func TestHandleClearAgent_DeletesCardAndCleansState(t *testing.T) {
+	daemon := newMockDaemon()
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+
+	bot := newTestBot(daemon, slackSrv)
+
+	// Set up state manager.
+	tmpDir := t.TempDir()
+	sm, err := NewStateManager(filepath.Join(tmpDir, "state.json"))
+	if err != nil {
+		t.Fatalf("failed to create state manager: %v", err)
+	}
+	bot.state = sm
+
+	// Pre-populate agent maps.
+	bot.mu.Lock()
+	bot.agentCards["my-agent"] = MessageRef{ChannelID: "C123", Timestamp: "1111.2222"}
+	bot.agentPending["my-agent"] = 3
+	bot.agentState["my-agent"] = "working"
+	bot.agentPodName["my-agent"] = "pod-abc"
+	bot.agentImageTag["my-agent"] = "v1.0.0"
+	bot.agentRole["my-agent"] = "crew"
+	bot.mu.Unlock()
+	_ = sm.SetAgentCard("my-agent", MessageRef{ChannelID: "C123", Timestamp: "1111.2222"})
+	_ = sm.SetThreadAgent("C123", "3333.4444", "my-agent")
+
+	callback := slack.InteractionCallback{
+		Channel: slack.Channel{},
+		User:    slack.User{ID: "U456"},
+	}
+	callback.Channel.GroupConversation.Conversation.ID = "C123"
+
+	bot.handleClearAgent(context.Background(), "my-agent", callback)
+
+	// Verify all in-memory maps were cleaned.
+	bot.mu.Lock()
+	_, hasCard := bot.agentCards["my-agent"]
+	_, hasPending := bot.agentPending["my-agent"]
+	_, hasState := bot.agentState["my-agent"]
+	_, hasPod := bot.agentPodName["my-agent"]
+	_, hasTag := bot.agentImageTag["my-agent"]
+	_, hasRole := bot.agentRole["my-agent"]
+	bot.mu.Unlock()
+
+	if hasCard {
+		t.Error("expected agentCards to be cleared")
+	}
+	if hasPending {
+		t.Error("expected agentPending to be cleared")
+	}
+	if hasState {
+		t.Error("expected agentState to be cleared")
+	}
+	if hasPod {
+		t.Error("expected agentPodName to be cleared")
+	}
+	if hasTag {
+		t.Error("expected agentImageTag to be cleared")
+	}
+	if hasRole {
+		t.Error("expected agentRole to be cleared")
+	}
+}
+
+func TestHandleClearAgent_NoCard_NoOp(t *testing.T) {
+	daemon := newMockDaemon()
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+
+	bot := newTestBot(daemon, slackSrv)
+
+	callback := slack.InteractionCallback{
+		User: slack.User{ID: "U456"},
+	}
+
+	// Should not panic when no card exists.
+	bot.handleClearAgent(context.Background(), "nonexistent-agent", callback)
+}
+
+func TestHandleClearAgent_ExtractsShortName(t *testing.T) {
+	daemon := newMockDaemon()
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+
+	bot := newTestBot(daemon, slackSrv)
+
+	// Store card under short name.
+	bot.mu.Lock()
+	bot.agentCards["my-agent"] = MessageRef{ChannelID: "C123", Timestamp: "1111.2222"}
+	bot.mu.Unlock()
+
+	callback := slack.InteractionCallback{
+		User: slack.User{ID: "U456"},
+	}
+
+	// Pass full identity; should extract short name and find the card.
+	bot.handleClearAgent(context.Background(), "gasboat/crew/my-agent", callback)
+
+	bot.mu.Lock()
+	_, hasCard := bot.agentCards["my-agent"]
+	bot.mu.Unlock()
+
+	if hasCard {
+		t.Error("expected card to be cleared using short name extracted from full identity")
+	}
+}
+
+func TestHandleClearAgent_RemovesThreadAgentMapping(t *testing.T) {
+	daemon := newMockDaemon()
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+
+	bot := newTestBot(daemon, slackSrv)
+
+	tmpDir := t.TempDir()
+	sm, err := NewStateManager(filepath.Join(tmpDir, "state.json"))
+	if err != nil {
+		t.Fatalf("failed to create state manager: %v", err)
+	}
+	bot.state = sm
+
+	// No card, but a thread mapping exists.
+	_ = sm.SetThreadAgent("C123", "3333.4444", "my-agent")
+
+	callback := slack.InteractionCallback{
+		User: slack.User{ID: "U456"},
+	}
+
+	bot.handleClearAgent(context.Background(), "my-agent", callback)
+
+	// Thread mapping should be cleaned up even when no card exists.
+	_, ok := sm.GetThreadAgent("C123", "3333.4444")
+	if ok {
+		t.Error("expected thread agent mapping to be removed")
+	}
+}
+
+// --- getCoopAgentState tests ---
+
+func TestGetCoopAgentState_ReturnsState(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/agent" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		if r.Method != http.MethodGet {
+			t.Errorf("unexpected method: %s", r.Method)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"state": "working"})
+	}))
+	defer srv.Close()
+
+	client := &http.Client{Timeout: 3 * time.Second}
+	state, err := getCoopAgentState(context.Background(), client, srv.URL+"/api/v1")
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if state != "working" {
+		t.Errorf("expected state=working, got %q", state)
+	}
+}
+
+func TestGetCoopAgentState_ExitedState(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"state": "exited"})
+	}))
+	defer srv.Close()
+
+	client := &http.Client{Timeout: 3 * time.Second}
+	state, err := getCoopAgentState(context.Background(), client, srv.URL+"/api/v1")
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if state != "exited" {
+		t.Errorf("expected state=exited, got %q", state)
+	}
+}
+
+func TestGetCoopAgentState_ServerUnreachable(t *testing.T) {
+	client := &http.Client{Timeout: 100 * time.Millisecond}
+	_, err := getCoopAgentState(context.Background(), client, "http://127.0.0.1:1/api/v1")
+
+	if err == nil {
+		t.Error("expected error for unreachable server")
+	}
+}
+
+func TestGetCoopAgentState_CancelledContext(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"state": "working"})
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+
+	client := &http.Client{Timeout: 3 * time.Second}
+	_, err := getCoopAgentState(ctx, client, srv.URL+"/api/v1")
+
+	if err == nil {
+		t.Error("expected error for cancelled context")
+	}
+}
+
+func TestGetCoopAgentState_InvalidJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte("not json"))
+	}))
+	defer srv.Close()
+
+	client := &http.Client{Timeout: 3 * time.Second}
+	_, err := getCoopAgentState(context.Background(), client, srv.URL+"/api/v1")
+
+	if err == nil {
+		t.Error("expected error for invalid JSON response")
+	}
+}
+
+// --- postCoopKeys tests ---
+
+func TestPostCoopKeys_SendsKeysPayload(t *testing.T) {
+	var receivedBody []byte
+	var receivedPath string
+	var receivedMethod string
+	var receivedContentType string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedPath = r.URL.Path
+		receivedMethod = r.Method
+		receivedContentType = r.Header.Get("Content-Type")
+		receivedBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	client := &http.Client{Timeout: 3 * time.Second}
+	postCoopKeys(context.Background(), client, srv.URL+"/api/v1", "Escape")
+
+	if receivedPath != "/api/v1/input/keys" {
+		t.Errorf("expected path /api/v1/input/keys, got %s", receivedPath)
+	}
+	if receivedMethod != http.MethodPost {
+		t.Errorf("expected POST, got %s", receivedMethod)
+	}
+	if receivedContentType != "application/json" {
+		t.Errorf("expected Content-Type application/json, got %s", receivedContentType)
+	}
+
+	var payload map[string][]string
+	if err := json.Unmarshal(receivedBody, &payload); err != nil {
+		t.Fatalf("failed to unmarshal payload: %v", err)
+	}
+	if len(payload["keys"]) != 1 || payload["keys"][0] != "Escape" {
+		t.Errorf("expected keys=[Escape], got %v", payload["keys"])
+	}
+}
+
+func TestPostCoopKeys_MultipleKeys(t *testing.T) {
+	var receivedBody []byte
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	client := &http.Client{Timeout: 3 * time.Second}
+	postCoopKeys(context.Background(), client, srv.URL+"/api/v1", "Escape", "Enter")
+
+	var payload map[string][]string
+	if err := json.Unmarshal(receivedBody, &payload); err != nil {
+		t.Fatalf("failed to unmarshal payload: %v", err)
+	}
+	if len(payload["keys"]) != 2 {
+		t.Errorf("expected 2 keys, got %d", len(payload["keys"]))
+	}
+}
+
+func TestPostCoopKeys_UnreachableServer_NoPanic(t *testing.T) {
+	client := &http.Client{Timeout: 100 * time.Millisecond}
+	// Should not panic when server is unreachable.
+	postCoopKeys(context.Background(), client, "http://127.0.0.1:1/api/v1", "Escape")
+}
+
+func TestPostCoopKeys_CancelledContext_NoPanic(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	client := &http.Client{Timeout: 3 * time.Second}
+	postCoopKeys(ctx, client, srv.URL+"/api/v1", "Escape")
+}
+
+// --- gracefulShutdownCoop tests ---
+
+func TestGracefulShutdownCoop_ImmediateExit(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/api/v1/agent" && r.Method == http.MethodGet {
+			_ = json.NewEncoder(w).Encode(map[string]string{"state": "exited"})
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	ok := gracefulShutdownCoop(ctx, srv.URL)
+	if !ok {
+		t.Error("expected graceful shutdown to succeed when agent is already exited")
+	}
+}
+
+func TestGracefulShutdownCoop_TransitionsToExited(t *testing.T) {
+	var callCount atomic.Int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/api/v1/agent" && r.Method == http.MethodGet {
+			count := callCount.Add(1)
+			if count >= 2 {
+				_ = json.NewEncoder(w).Encode(map[string]string{"state": "exited"})
+			} else {
+				_ = json.NewEncoder(w).Encode(map[string]string{"state": "working"})
+			}
+			return
+		}
+		// /input/keys endpoint
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	ok := gracefulShutdownCoop(ctx, srv.URL)
+	if !ok {
+		t.Error("expected graceful shutdown to succeed after transition to exited")
+	}
+	if callCount.Load() < 2 {
+		t.Errorf("expected at least 2 state checks, got %d", callCount.Load())
+	}
+}
+
+func TestGracefulShutdownCoop_ServerUnreachable(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	// Use an address that will fail immediately.
+	ok := gracefulShutdownCoop(ctx, "http://127.0.0.1:1")
+	if ok {
+		t.Error("expected false when server is unreachable")
+	}
+}
+
+func TestGracefulShutdownCoop_ContextCancelled(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// Always return "working" so it never exits on its own.
+		_ = json.NewEncoder(w).Encode(map[string]string{"state": "working"})
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+
+	ok := gracefulShutdownCoop(ctx, srv.URL)
+	if ok {
+		t.Error("expected false when context is cancelled before agent exits")
+	}
+}
+
+func TestGracefulShutdownCoop_TrailingSlashInURL(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/api/v1/agent" {
+			_ = json.NewEncoder(w).Encode(map[string]string{"state": "exited"})
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// URL with trailing slash should still work.
+	ok := gracefulShutdownCoop(ctx, srv.URL+"/")
+	if !ok {
+		t.Error("expected success with trailing slash in URL")
+	}
+}

--- a/gasboat/controller/internal/bridge/bot_autodestruct_test.go
+++ b/gasboat/controller/internal/bridge/bot_autodestruct_test.go
@@ -5,7 +5,10 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
+
+	"github.com/slack-go/slack"
 )
 
 func TestIsAutoDestructAllowed(t *testing.T) {
@@ -122,4 +125,349 @@ func TestCallAutoDestruct(t *testing.T) {
 			t.Fatal("expected error on 500 response")
 		}
 	})
+}
+
+// --- handleAutoDestructCommand routing tests ---
+
+func TestHandleAutoDestructCommand_Unauthorized(t *testing.T) {
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+
+	bot := newTestBot(newMockDaemon(), slackSrv)
+	t.Setenv("AUTODESTRUCT_ALLOWED_USERS", "")
+
+	// Should post ephemeral error without panic.
+	bot.handleAutoDestructCommand(context.Background(), slack.SlashCommand{
+		ChannelID: "C123",
+		UserID:    "U999",
+	})
+}
+
+func TestHandleAutoDestructCommand_RoutesToConfirm(t *testing.T) {
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+
+	bot := newTestBot(newMockDaemon(), slackSrv)
+	t.Setenv("AUTODESTRUCT_ALLOWED_USERS", "U123")
+
+	// Empty text -> default case -> autoDestructConfirm.
+	bot.handleAutoDestructCommand(context.Background(), slack.SlashCommand{
+		ChannelID: "C123",
+		UserID:    "U123",
+		Text:      "",
+	})
+}
+
+func TestHandleAutoDestructCommand_RoutesToClear(t *testing.T) {
+	ctrlSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/autodestruct/clear" && r.Method == "POST" {
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte(`{"status":"cleared"}`))
+			return
+		}
+		w.WriteHeader(404)
+	}))
+	defer ctrlSrv.Close()
+
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+
+	bot := newTestBot(newMockDaemon(), slackSrv)
+	bot.controllerURL = ctrlSrv.URL
+	t.Setenv("AUTODESTRUCT_ALLOWED_USERS", "U123")
+	t.Setenv("AUTODESTRUCT_TOKEN", "test-token")
+
+	bot.handleAutoDestructCommand(context.Background(), slack.SlashCommand{
+		ChannelID: "C123",
+		UserID:    "U123",
+		Text:      "clear",
+	})
+}
+
+func TestHandleAutoDestructCommand_RoutesToStatus(t *testing.T) {
+	ctrlSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/autodestruct/status" && r.Method == "GET" {
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte(`{"active":false}`))
+			return
+		}
+		w.WriteHeader(404)
+	}))
+	defer ctrlSrv.Close()
+
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+
+	bot := newTestBot(newMockDaemon(), slackSrv)
+	bot.controllerURL = ctrlSrv.URL
+	t.Setenv("AUTODESTRUCT_ALLOWED_USERS", "U123")
+	t.Setenv("AUTODESTRUCT_TOKEN", "test-token")
+
+	bot.handleAutoDestructCommand(context.Background(), slack.SlashCommand{
+		ChannelID: "C123",
+		UserID:    "U123",
+		Text:      "status",
+	})
+}
+
+// --- autoDestructConfirm tests ---
+
+func TestAutoDestructConfirm_PostsBlocks(t *testing.T) {
+	var called bool
+	slackSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"ok": true, "message_ts": "1234.5678"})
+	}))
+	defer slackSrv.Close()
+
+	bot := newTestBot(newMockDaemon(), slackSrv)
+
+	bot.autoDestructConfirm(context.Background(), slack.SlashCommand{
+		ChannelID: "C123",
+		UserID:    "U456",
+	})
+
+	if !called {
+		t.Error("expected Slack API to be called for ephemeral message")
+	}
+}
+
+// --- autoDestructClear tests ---
+
+func TestAutoDestructClear_Success(t *testing.T) {
+	ctrlSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/autodestruct/clear" {
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte(`{"status":"cleared"}`))
+			return
+		}
+		w.WriteHeader(404)
+	}))
+	defer ctrlSrv.Close()
+
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+
+	bot := newTestBot(newMockDaemon(), slackSrv)
+	bot.controllerURL = ctrlSrv.URL
+	t.Setenv("AUTODESTRUCT_TOKEN", "test-token")
+
+	bot.autoDestructClear(context.Background(), slack.SlashCommand{
+		ChannelID: "C123",
+		UserID:    "U456",
+	})
+}
+
+func TestAutoDestructClear_Error(t *testing.T) {
+	ctrlSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(500)
+		_, _ = w.Write([]byte("internal error"))
+	}))
+	defer ctrlSrv.Close()
+
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+
+	bot := newTestBot(newMockDaemon(), slackSrv)
+	bot.controllerURL = ctrlSrv.URL
+	t.Setenv("AUTODESTRUCT_TOKEN", "test-token")
+
+	bot.autoDestructClear(context.Background(), slack.SlashCommand{
+		ChannelID: "C123",
+		UserID:    "U456",
+	})
+}
+
+// --- autoDestructStatus tests ---
+
+func TestAutoDestructStatus_Success(t *testing.T) {
+	ctrlSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/autodestruct/status" {
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte(`{"active":false,"killed":0}`))
+			return
+		}
+		w.WriteHeader(404)
+	}))
+	defer ctrlSrv.Close()
+
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+
+	bot := newTestBot(newMockDaemon(), slackSrv)
+	bot.controllerURL = ctrlSrv.URL
+	t.Setenv("AUTODESTRUCT_TOKEN", "test-token")
+
+	bot.autoDestructStatus(context.Background(), slack.SlashCommand{
+		ChannelID: "C123",
+		UserID:    "U456",
+	})
+}
+
+func TestAutoDestructStatus_Error(t *testing.T) {
+	ctrlSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(500)
+		_, _ = w.Write([]byte("server error"))
+	}))
+	defer ctrlSrv.Close()
+
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+
+	bot := newTestBot(newMockDaemon(), slackSrv)
+	bot.controllerURL = ctrlSrv.URL
+	t.Setenv("AUTODESTRUCT_TOKEN", "test-token")
+
+	bot.autoDestructStatus(context.Background(), slack.SlashCommand{
+		ChannelID: "C123",
+		UserID:    "U456",
+	})
+}
+
+// --- handleAutoDestructButtonAction tests ---
+
+func TestHandleAutoDestructButtonAction_Unauthorized(t *testing.T) {
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+
+	bot := newTestBot(newMockDaemon(), slackSrv)
+	t.Setenv("AUTODESTRUCT_ALLOWED_USERS", "")
+
+	callback := slack.InteractionCallback{
+		User:    slack.User{ID: "U999"},
+		Channel: slack.Channel{GroupConversation: slack.GroupConversation{Conversation: slack.Conversation{ID: "C123"}}},
+	}
+
+	bot.handleAutoDestructButtonAction(context.Background(), "autodestruct_confirm", callback)
+}
+
+func TestHandleAutoDestructButtonAction_Confirm(t *testing.T) {
+	ctrlSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/autodestruct" && r.Method == "POST" {
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte(`{"killed":3}`))
+			return
+		}
+		w.WriteHeader(404)
+	}))
+	defer ctrlSrv.Close()
+
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+
+	bot := newTestBot(newMockDaemon(), slackSrv)
+	bot.controllerURL = ctrlSrv.URL
+	t.Setenv("AUTODESTRUCT_ALLOWED_USERS", "U123")
+	t.Setenv("AUTODESTRUCT_TOKEN", "test-token")
+
+	callback := slack.InteractionCallback{
+		User:    slack.User{ID: "U123"},
+		Channel: slack.Channel{GroupConversation: slack.GroupConversation{Conversation: slack.Conversation{ID: "C123"}}},
+	}
+
+	bot.handleAutoDestructButtonAction(context.Background(), "autodestruct_confirm", callback)
+}
+
+func TestHandleAutoDestructButtonAction_ConfirmError(t *testing.T) {
+	ctrlSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(500)
+		_, _ = w.Write([]byte("boom"))
+	}))
+	defer ctrlSrv.Close()
+
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+
+	bot := newTestBot(newMockDaemon(), slackSrv)
+	bot.controllerURL = ctrlSrv.URL
+	t.Setenv("AUTODESTRUCT_ALLOWED_USERS", "U123")
+	t.Setenv("AUTODESTRUCT_TOKEN", "test-token")
+
+	callback := slack.InteractionCallback{
+		User:    slack.User{ID: "U123"},
+		Channel: slack.Channel{GroupConversation: slack.GroupConversation{Conversation: slack.Conversation{ID: "C123"}}},
+	}
+
+	bot.handleAutoDestructButtonAction(context.Background(), "autodestruct_confirm", callback)
+}
+
+func TestHandleAutoDestructButtonAction_Cancel(t *testing.T) {
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+
+	bot := newTestBot(newMockDaemon(), slackSrv)
+	t.Setenv("AUTODESTRUCT_ALLOWED_USERS", "U123")
+
+	callback := slack.InteractionCallback{
+		User:    slack.User{ID: "U123"},
+		Channel: slack.Channel{GroupConversation: slack.GroupConversation{Conversation: slack.Conversation{ID: "C123"}}},
+	}
+
+	bot.handleAutoDestructButtonAction(context.Background(), "autodestruct_cancel", callback)
+}
+
+// --- resolveSlackUser tests ---
+
+func TestResolveSlackUser_RealName(t *testing.T) {
+	slackSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if strings.Contains(r.URL.Path, "users.info") || r.FormValue("user") != "" {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"ok":   true,
+				"user": map[string]any{"id": "U123", "real_name": "Alice Smith", "name": "alice"},
+			})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"ok": true, "message_ts": "1234.5678"})
+	}))
+	defer slackSrv.Close()
+
+	bot := newTestBot(newMockDaemon(), slackSrv)
+
+	result := bot.resolveSlackUser("U123")
+	if result != "Alice Smith" {
+		t.Errorf("expected 'Alice Smith', got %q", result)
+	}
+}
+
+func TestResolveSlackUser_FallbackToName(t *testing.T) {
+	slackSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if strings.Contains(r.URL.Path, "users.info") || r.FormValue("user") != "" {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"ok":   true,
+				"user": map[string]any{"id": "U123", "real_name": "", "name": "alice"},
+			})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"ok": true, "message_ts": "1234.5678"})
+	}))
+	defer slackSrv.Close()
+
+	bot := newTestBot(newMockDaemon(), slackSrv)
+
+	result := bot.resolveSlackUser("U123")
+	if result != "alice" {
+		t.Errorf("expected 'alice', got %q", result)
+	}
+}
+
+func TestResolveSlackUser_FallbackToMention(t *testing.T) {
+	slackSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if strings.Contains(r.URL.Path, "users.info") || r.FormValue("user") != "" {
+			_ = json.NewEncoder(w).Encode(map[string]any{"ok": false, "error": "user_not_found"})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"ok": true, "message_ts": "1234.5678"})
+	}))
+	defer slackSrv.Close()
+
+	bot := newTestBot(newMockDaemon(), slackSrv)
+
+	result := bot.resolveSlackUser("U999")
+	if result != "<@U999>" {
+		t.Errorf("expected '<@U999>', got %q", result)
+	}
 }

--- a/gasboat/controller/internal/bridge/bot_beadactivity_test.go
+++ b/gasboat/controller/internal/bridge/bot_beadactivity_test.go
@@ -1,0 +1,456 @@
+package bridge
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"gasboat/controller/internal/beadsapi"
+)
+
+// --- getAgentThreadTS tests ---
+
+func TestGetAgentThreadTS_Found(t *testing.T) {
+	daemon := newMockDaemon()
+	srv := newFakeSlackServer(t)
+	defer srv.Close()
+
+	bot := newTestBot(daemon, srv)
+	bot.agentCards["test-agent"] = MessageRef{ChannelID: "C-123", Timestamp: "1234.5678"}
+
+	ts := bot.getAgentThreadTS("test-agent")
+	if ts != "1234.5678" {
+		t.Errorf("expected 1234.5678, got %s", ts)
+	}
+}
+
+func TestGetAgentThreadTS_NotFound(t *testing.T) {
+	daemon := newMockDaemon()
+	srv := newFakeSlackServer(t)
+	defer srv.Close()
+
+	bot := newTestBot(daemon, srv)
+
+	ts := bot.getAgentThreadTS("nonexistent")
+	if ts != "" {
+		t.Errorf("expected empty string, got %s", ts)
+	}
+}
+
+// --- NotifyBeadCreated tests ---
+
+func TestNotifyBeadCreated_PostsToAgentThread(t *testing.T) {
+	daemon := newMockDaemon()
+	srv, calls, mu := capturingSlackServer(t)
+	defer srv.Close()
+
+	bot := newTestBot(daemon, srv)
+	bot.channel = "C-test"
+	bot.threadingMode = "agent"
+	bot.beadMsgs = make(map[string]MessageRef)
+	bot.agentCards["test-agent"] = MessageRef{ChannelID: "C-test", Timestamp: "1000.0001"}
+
+	bead := BeadEvent{
+		ID:        "bd-task-1",
+		Type:      "task",
+		Title:     "Fix the bug",
+		CreatedBy: "gasboat/crew/test-agent",
+	}
+
+	bot.NotifyBeadCreated(context.Background(), bead)
+
+	got := getCalls(calls, mu)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 Slack call, got %d", len(got))
+	}
+	if got[0].Method != "chat.postMessage" {
+		t.Errorf("expected chat.postMessage, got %s", got[0].Method)
+	}
+	if got[0].ThreadTS != "1000.0001" {
+		t.Errorf("expected thread_ts 1000.0001, got %s", got[0].ThreadTS)
+	}
+	if !strings.Contains(got[0].Text, "Created task") {
+		t.Errorf("expected text to contain 'Created task', got %s", got[0].Text)
+	}
+	if !strings.Contains(got[0].Text, "Fix the bug") {
+		t.Errorf("expected text to contain bead title, got %s", got[0].Text)
+	}
+}
+
+func TestNotifyBeadCreated_NoAgent_Noop(t *testing.T) {
+	daemon := newMockDaemon()
+	srv, calls, mu := capturingSlackServer(t)
+	defer srv.Close()
+
+	bot := newTestBot(daemon, srv)
+	bot.channel = "C-test"
+	bot.threadingMode = "agent"
+	bot.beadMsgs = make(map[string]MessageRef)
+
+	bead := BeadEvent{
+		ID:        "bd-task-2",
+		Type:      "task",
+		Title:     "Orphan task",
+		CreatedBy: "",
+	}
+
+	bot.NotifyBeadCreated(context.Background(), bead)
+
+	got := getCalls(calls, mu)
+	if len(got) != 0 {
+		t.Errorf("expected no Slack calls for empty agent, got %d", len(got))
+	}
+}
+
+func TestNotifyBeadCreated_RecordsActivity(t *testing.T) {
+	daemon := newMockDaemon()
+	srv := newFakeSlackServer(t)
+	defer srv.Close()
+
+	bot := newTestBot(daemon, srv)
+	bot.channel = "C-test"
+	bot.threadingMode = "agent"
+	bot.beadMsgs = make(map[string]MessageRef)
+	bot.agentCards["test-agent"] = MessageRef{ChannelID: "C-test", Timestamp: "1000.0001"}
+
+	before := time.Now()
+	bot.NotifyBeadCreated(context.Background(), BeadEvent{
+		ID:        "bd-task-3",
+		Type:      "task",
+		Title:     "Test",
+		CreatedBy: "test-agent",
+	})
+
+	bot.mu.Lock()
+	seen, ok := bot.agentSeen["test-agent"]
+	bot.mu.Unlock()
+
+	if !ok {
+		t.Fatal("expected agentSeen entry for test-agent")
+	}
+	if seen.Before(before) {
+		t.Error("expected agentSeen to be updated")
+	}
+}
+
+func TestNotifyBeadCreated_ThreadBoundAgent(t *testing.T) {
+	daemon := newMockDaemon()
+	// Seed agent bead with thread binding.
+	daemon.mu.Lock()
+	daemon.beads["thread-creator"] = &beadsapi.BeadDetail{
+		ID:    "bd-agent-tc",
+		Title: "thread-creator",
+		Type:  "agent",
+		Fields: map[string]string{
+			"agent":                "thread-creator",
+			"slack_thread_channel": "C-bound",
+			"slack_thread_ts":      "8888.0001",
+		},
+	}
+	daemon.mu.Unlock()
+
+	srv, calls, mu := capturingSlackServer(t)
+	defer srv.Close()
+
+	bot := newTestBot(daemon, srv)
+	bot.channel = "C-default"
+	bot.threadingMode = "agent"
+	bot.beadMsgs = make(map[string]MessageRef)
+
+	bead := BeadEvent{
+		ID:        "bd-task-tc",
+		Type:      "task",
+		Title:     "Thread task",
+		CreatedBy: "thread-creator",
+	}
+
+	bot.NotifyBeadCreated(context.Background(), bead)
+
+	got := getCalls(calls, mu)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 call, got %d", len(got))
+	}
+	if got[0].Channel != "C-bound" {
+		t.Errorf("expected channel C-bound, got %s", got[0].Channel)
+	}
+	if got[0].ThreadTS != "8888.0001" {
+		t.Errorf("expected thread_ts 8888.0001, got %s", got[0].ThreadTS)
+	}
+}
+
+func TestNotifyBeadCreated_NoThreading_Dropped(t *testing.T) {
+	daemon := newMockDaemon()
+	srv, calls, mu := capturingSlackServer(t)
+	defer srv.Close()
+
+	bot := newTestBot(daemon, srv)
+	bot.channel = "C-test"
+	bot.threadingMode = "" // flat mode
+	bot.beadMsgs = make(map[string]MessageRef)
+
+	bead := BeadEvent{
+		ID:        "bd-task-flat",
+		Type:      "task",
+		Title:     "Flat mode task",
+		CreatedBy: "some-agent",
+	}
+
+	bot.NotifyBeadCreated(context.Background(), bead)
+
+	got := getCalls(calls, mu)
+	if len(got) != 0 {
+		t.Errorf("expected no calls in flat mode without agent card, got %d", len(got))
+	}
+}
+
+// --- NotifyBeadClaimed tests ---
+
+func TestNotifyBeadClaimed_PostsToAgentThread(t *testing.T) {
+	daemon := newMockDaemon()
+	srv, calls, mu := capturingSlackServer(t)
+	defer srv.Close()
+
+	bot := newTestBot(daemon, srv)
+	bot.channel = "C-test"
+	bot.threadingMode = "agent"
+	bot.beadMsgs = make(map[string]MessageRef)
+	bot.agentCards["claim-agent"] = MessageRef{ChannelID: "C-test", Timestamp: "2000.0001"}
+
+	bead := BeadEvent{
+		ID:       "bd-claim-1",
+		Type:     "task",
+		Title:    "Important task",
+		Assignee: "gasboat/crew/claim-agent",
+	}
+
+	bot.NotifyBeadClaimed(context.Background(), bead)
+
+	got := getCalls(calls, mu)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 Slack call, got %d", len(got))
+	}
+	if !strings.Contains(got[0].Text, "Claimed task") {
+		t.Errorf("expected text to contain 'Claimed task', got %s", got[0].Text)
+	}
+	if !strings.Contains(got[0].Text, "Important task") {
+		t.Errorf("expected text to contain title, got %s", got[0].Text)
+	}
+	if got[0].ThreadTS != "2000.0001" {
+		t.Errorf("expected thread_ts 2000.0001, got %s", got[0].ThreadTS)
+	}
+}
+
+func TestNotifyBeadClaimed_NoAssignee_Noop(t *testing.T) {
+	daemon := newMockDaemon()
+	srv, calls, mu := capturingSlackServer(t)
+	defer srv.Close()
+
+	bot := newTestBot(daemon, srv)
+	bot.channel = "C-test"
+	bot.threadingMode = "agent"
+	bot.beadMsgs = make(map[string]MessageRef)
+
+	bead := BeadEvent{
+		ID:   "bd-claim-2",
+		Type: "task",
+	}
+
+	bot.NotifyBeadClaimed(context.Background(), bead)
+
+	got := getCalls(calls, mu)
+	if len(got) != 0 {
+		t.Errorf("expected no calls for empty assignee, got %d", len(got))
+	}
+}
+
+func TestNotifyBeadClaimed_RecordsActivity(t *testing.T) {
+	daemon := newMockDaemon()
+	srv := newFakeSlackServer(t)
+	defer srv.Close()
+
+	bot := newTestBot(daemon, srv)
+	bot.channel = "C-test"
+	bot.threadingMode = "agent"
+	bot.beadMsgs = make(map[string]MessageRef)
+	bot.agentCards["activity-agent"] = MessageRef{ChannelID: "C-test", Timestamp: "3000.0001"}
+
+	before := time.Now()
+	bot.NotifyBeadClaimed(context.Background(), BeadEvent{
+		ID:       "bd-claim-act",
+		Type:     "task",
+		Title:    "Activity test",
+		Assignee: "activity-agent",
+	})
+
+	bot.mu.Lock()
+	seen, ok := bot.agentSeen["activity-agent"]
+	bot.mu.Unlock()
+
+	if !ok {
+		t.Fatal("expected agentSeen entry for activity-agent")
+	}
+	if seen.Before(before) {
+		t.Error("expected agentSeen to be updated")
+	}
+}
+
+// --- NotifyBeadCreatedAndClaimed tests ---
+
+func TestNotifyBeadCreatedAndClaimed_PostsToAgentThread(t *testing.T) {
+	daemon := newMockDaemon()
+	srv, calls, mu := capturingSlackServer(t)
+	defer srv.Close()
+
+	bot := newTestBot(daemon, srv)
+	bot.channel = "C-test"
+	bot.threadingMode = "agent"
+	bot.beadMsgs = make(map[string]MessageRef)
+	bot.agentCards["combo-agent"] = MessageRef{ChannelID: "C-test", Timestamp: "4000.0001"}
+
+	bead := BeadEvent{
+		ID:        "bd-combo-1",
+		Type:      "task",
+		Title:     "Self-assigned task",
+		Assignee:  "combo-agent",
+		CreatedBy: "combo-agent",
+	}
+
+	bot.NotifyBeadCreatedAndClaimed(context.Background(), bead)
+
+	got := getCalls(calls, mu)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 Slack call, got %d", len(got))
+	}
+	if !strings.Contains(got[0].Text, "Created & claimed task") {
+		t.Errorf("expected text to contain 'Created & claimed task', got %s", got[0].Text)
+	}
+	if got[0].ThreadTS != "4000.0001" {
+		t.Errorf("expected thread_ts 4000.0001, got %s", got[0].ThreadTS)
+	}
+}
+
+func TestNotifyBeadCreatedAndClaimed_FallsBackToCreatedBy(t *testing.T) {
+	daemon := newMockDaemon()
+	srv, calls, mu := capturingSlackServer(t)
+	defer srv.Close()
+
+	bot := newTestBot(daemon, srv)
+	bot.channel = "C-test"
+	bot.threadingMode = "agent"
+	bot.beadMsgs = make(map[string]MessageRef)
+	bot.agentCards["fallback-agent"] = MessageRef{ChannelID: "C-test", Timestamp: "5000.0001"}
+
+	bead := BeadEvent{
+		ID:        "bd-combo-2",
+		Type:      "task",
+		Title:     "Fallback task",
+		Assignee:  "",
+		CreatedBy: "fallback-agent",
+	}
+
+	bot.NotifyBeadCreatedAndClaimed(context.Background(), bead)
+
+	got := getCalls(calls, mu)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 Slack call, got %d", len(got))
+	}
+}
+
+func TestNotifyBeadCreatedAndClaimed_NoAgent_Noop(t *testing.T) {
+	daemon := newMockDaemon()
+	srv, calls, mu := capturingSlackServer(t)
+	defer srv.Close()
+
+	bot := newTestBot(daemon, srv)
+	bot.channel = "C-test"
+	bot.threadingMode = "agent"
+	bot.beadMsgs = make(map[string]MessageRef)
+
+	bead := BeadEvent{
+		ID:   "bd-combo-3",
+		Type: "task",
+	}
+
+	bot.NotifyBeadCreatedAndClaimed(context.Background(), bead)
+
+	got := getCalls(calls, mu)
+	if len(got) != 0 {
+		t.Errorf("expected no calls for empty agent, got %d", len(got))
+	}
+}
+
+func TestNotifyBeadCreatedAndClaimed_TruncatesTitle(t *testing.T) {
+	daemon := newMockDaemon()
+	srv, calls, mu := capturingSlackServer(t)
+	defer srv.Close()
+
+	bot := newTestBot(daemon, srv)
+	bot.channel = "C-test"
+	bot.threadingMode = "agent"
+	bot.beadMsgs = make(map[string]MessageRef)
+	bot.agentCards["trunc-agent"] = MessageRef{ChannelID: "C-test", Timestamp: "6000.0001"}
+
+	// Title longer than 60 chars should be truncated.
+	longTitle := strings.Repeat("A", 100)
+
+	bead := BeadEvent{
+		ID:       "bd-combo-trunc",
+		Type:     "task",
+		Title:    longTitle,
+		Assignee: "trunc-agent",
+	}
+
+	bot.NotifyBeadCreatedAndClaimed(context.Background(), bead)
+
+	got := getCalls(calls, mu)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 Slack call, got %d", len(got))
+	}
+	// The title should have been truncated to 60 chars with "..."
+	if strings.Contains(got[0].Text, longTitle) {
+		t.Error("expected title to be truncated, but full title was found")
+	}
+	if !strings.Contains(got[0].Text, "...") {
+		t.Error("expected truncation marker '...' in text")
+	}
+}
+
+// --- postOrUpdateBeadMessage (update path) tests ---
+
+func TestPostOrUpdateBeadMessage_UpdatesExisting(t *testing.T) {
+	daemon := newMockDaemon()
+	srv, calls, mu := capturingSlackServer(t)
+	defer srv.Close()
+
+	bot := newTestBot(daemon, srv)
+	bot.channel = "C-test"
+	bot.threadingMode = "agent"
+	bot.beadMsgs = make(map[string]MessageRef)
+
+	// Pre-populate a tracked bead message.
+	bot.beadMsgs["update-agent:bd-update-1"] = MessageRef{
+		ChannelID: "C-test",
+		Timestamp: "7000.0001",
+	}
+
+	bot.agentCards["update-agent"] = MessageRef{ChannelID: "C-test", Timestamp: "7000.0000"}
+
+	// Claiming a bead that was already created should update in-place.
+	bead := BeadEvent{
+		ID:       "bd-update-1",
+		Type:     "task",
+		Title:    "Updated task",
+		Assignee: "update-agent",
+	}
+
+	bot.NotifyBeadClaimed(context.Background(), bead)
+
+	got := getCalls(calls, mu)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 call (update), got %d", len(got))
+	}
+	if got[0].Method != "chat.update" {
+		t.Errorf("expected chat.update for in-place update, got %s", got[0].Method)
+	}
+}

--- a/gasboat/controller/internal/bridge/bot_commands_extra_test.go
+++ b/gasboat/controller/internal/bridge/bot_commands_extra_test.go
@@ -1,0 +1,517 @@
+package bridge
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"gasboat/controller/internal/beadsapi"
+
+	"github.com/slack-go/slack"
+)
+
+// --- projectFromTicketPrefix tests ---
+
+func TestProjectFromTicketPrefix_MatchesPrefix(t *testing.T) {
+	daemon := newMockDaemon()
+	daemon.mu.Lock()
+	daemon.beads["proj-monorepo"] = &beadsapi.BeadDetail{
+		ID:    "proj-monorepo",
+		Title: "monorepo",
+		Type:  "project",
+		Fields: map[string]string{
+			"prefix": "pe",
+		},
+	}
+	daemon.mu.Unlock()
+
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+
+	bot := newTestBot(daemon, slackSrv)
+
+	got := bot.projectFromTicketPrefix(context.Background(), "PE-1234")
+	if got != "monorepo" {
+		t.Errorf("expected project=monorepo, got %q", got)
+	}
+}
+
+func TestProjectFromTicketPrefix_NoMatch(t *testing.T) {
+	daemon := newMockDaemon()
+	daemon.mu.Lock()
+	daemon.beads["proj-monorepo"] = &beadsapi.BeadDetail{
+		ID:    "proj-monorepo",
+		Title: "monorepo",
+		Type:  "project",
+		Fields: map[string]string{
+			"prefix": "pe",
+		},
+	}
+	daemon.mu.Unlock()
+
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+
+	bot := newTestBot(daemon, slackSrv)
+
+	got := bot.projectFromTicketPrefix(context.Background(), "DEVOPS-42")
+	if got != "" {
+		t.Errorf("expected empty string for unmatched prefix, got %q", got)
+	}
+}
+
+func TestProjectFromTicketPrefix_NoDash(t *testing.T) {
+	daemon := newMockDaemon()
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+
+	bot := newTestBot(daemon, slackSrv)
+
+	got := bot.projectFromTicketPrefix(context.Background(), "nodash")
+	if got != "" {
+		t.Errorf("expected empty string for ticket without dash, got %q", got)
+	}
+}
+
+func TestProjectFromTicketPrefix_CaseInsensitive(t *testing.T) {
+	daemon := newMockDaemon()
+	daemon.mu.Lock()
+	daemon.beads["proj-gasboat"] = &beadsapi.BeadDetail{
+		ID:    "proj-gasboat",
+		Title: "gasboat",
+		Type:  "project",
+		Fields: map[string]string{
+			"prefix": "GB",
+		},
+	}
+	daemon.mu.Unlock()
+
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+
+	bot := newTestBot(daemon, slackSrv)
+
+	got := bot.projectFromTicketPrefix(context.Background(), "gb-999")
+	if got != "gasboat" {
+		t.Errorf("expected project=gasboat with case-insensitive match, got %q", got)
+	}
+}
+
+// --- handleDecisionsCommand tests ---
+
+func TestHandleDecisionsCommand_NoDecisions(t *testing.T) {
+	daemon := newMockDaemon()
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+
+	bot := newTestBot(daemon, slackSrv)
+
+	// Should not panic and should post ephemeral with "No pending decisions".
+	bot.handleDecisionsCommand(context.Background(), slack.SlashCommand{
+		Command:   "/decisions",
+		Text:      "",
+		ChannelID: "C123",
+		UserID:    "U456",
+	})
+	// If we reach here without panic, the test passes. The fake server accepts all API calls.
+}
+
+func TestHandleDecisionsCommand_WithDecisions(t *testing.T) {
+	daemon := newMockDaemon()
+	daemon.mu.Lock()
+	daemon.beads["d1"] = &beadsapi.BeadDetail{
+		ID:       "d1",
+		Title:    "Should we deploy?",
+		Type:     "decision",
+		Assignee: "my-bot",
+		Fields:   map[string]string{"question": "Should we deploy to prod?"},
+		Labels:   []string{},
+	}
+	daemon.beads["d2"] = &beadsapi.BeadDetail{
+		ID:       "d2",
+		Title:    "Auth approach?",
+		Type:     "decision",
+		Assignee: "other-bot",
+		Fields:   map[string]string{"question": "Which auth approach?"},
+		Labels:   []string{"escalated"},
+	}
+	daemon.mu.Unlock()
+
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+
+	bot := newTestBot(daemon, slackSrv)
+
+	bot.handleDecisionsCommand(context.Background(), slack.SlashCommand{
+		Command:   "/decisions",
+		Text:      "",
+		ChannelID: "C123",
+		UserID:    "U456",
+	})
+	// Success = no panic, ephemeral posted via fake server.
+}
+
+func TestHandleDecisionsCommand_TruncatesLongQuestion(t *testing.T) {
+	daemon := newMockDaemon()
+	daemon.mu.Lock()
+	longQ := ""
+	for i := 0; i < 120; i++ {
+		longQ += "x"
+	}
+	daemon.beads["d1"] = &beadsapi.BeadDetail{
+		ID:     "d1",
+		Title:  "Long decision",
+		Type:   "decision",
+		Fields: map[string]string{"question": longQ},
+		Labels: []string{},
+	}
+	daemon.mu.Unlock()
+
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+
+	bot := newTestBot(daemon, slackSrv)
+
+	bot.handleDecisionsCommand(context.Background(), slack.SlashCommand{
+		Command:   "/decisions",
+		Text:      "",
+		ChannelID: "C123",
+		UserID:    "U456",
+	})
+}
+
+func TestHandleDecisionsCommand_FallsBackToTitle(t *testing.T) {
+	daemon := newMockDaemon()
+	daemon.mu.Lock()
+	daemon.beads["d1"] = &beadsapi.BeadDetail{
+		ID:     "d1",
+		Title:  "Fallback title",
+		Type:   "decision",
+		Fields: map[string]string{}, // no "question" field
+		Labels: []string{},
+	}
+	daemon.mu.Unlock()
+
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+
+	bot := newTestBot(daemon, slackSrv)
+
+	bot.handleDecisionsCommand(context.Background(), slack.SlashCommand{
+		Command:   "/decisions",
+		Text:      "",
+		ChannelID: "C123",
+		UserID:    "U456",
+	})
+}
+
+func TestHandleDecisionsCommand_MoreThan15(t *testing.T) {
+	daemon := newMockDaemon()
+	daemon.mu.Lock()
+	for i := 0; i < 20; i++ {
+		id := "d" + string(rune('A'+i))
+		daemon.beads[id] = &beadsapi.BeadDetail{
+			ID:     id,
+			Title:  "Decision " + id,
+			Type:   "decision",
+			Fields: map[string]string{"question": "Q?"},
+			Labels: []string{},
+		}
+	}
+	daemon.mu.Unlock()
+
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+
+	bot := newTestBot(daemon, slackSrv)
+
+	bot.handleDecisionsCommand(context.Background(), slack.SlashCommand{
+		Command:   "/decisions",
+		Text:      "",
+		ChannelID: "C123",
+		UserID:    "U456",
+	})
+}
+
+// --- handleKillCommand tests ---
+
+func TestHandleKillCommand_NoArgs(t *testing.T) {
+	daemon := newMockDaemon()
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+
+	bot := newTestBot(daemon, slackSrv)
+
+	bot.handleKillCommand(context.Background(), slack.SlashCommand{
+		Command:   "/kill",
+		Text:      "",
+		ChannelID: "C123",
+		UserID:    "U456",
+	})
+	// Should post usage ephemeral, no panic.
+}
+
+func TestHandleKillCommand_OnlyForceFlag(t *testing.T) {
+	daemon := newMockDaemon()
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+
+	bot := newTestBot(daemon, slackSrv)
+
+	bot.handleKillCommand(context.Background(), slack.SlashCommand{
+		Command:   "/kill",
+		Text:      "--force",
+		ChannelID: "C123",
+		UserID:    "U456",
+	})
+	// Should post usage ephemeral since no agent name provided.
+}
+
+func TestHandleKillCommand_KillsAgent(t *testing.T) {
+	daemon := newMockDaemon()
+	daemon.mu.Lock()
+	daemon.beads["my-bot"] = &beadsapi.BeadDetail{
+		ID:     "bd-agent-mybot",
+		Title:  "my-bot",
+		Type:   "agent",
+		Fields: map[string]string{"agent": "my-bot"},
+	}
+	daemon.mu.Unlock()
+
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+
+	bot := newTestBot(daemon, slackSrv)
+
+	bot.handleKillCommand(context.Background(), slack.SlashCommand{
+		Command:   "/kill",
+		Text:      "my-bot --force",
+		ChannelID: "C123",
+		UserID:    "U456",
+	})
+
+	// The kill runs in a goroutine. Wait briefly for it to complete.
+	time.Sleep(100 * time.Millisecond)
+
+	closed := daemon.getClosed()
+	if len(closed) != 1 {
+		t.Fatalf("expected 1 close call, got %d", len(closed))
+	}
+	if closed[0].BeadID != "bd-agent-mybot" {
+		t.Errorf("expected closed bead ID=bd-agent-mybot, got %s", closed[0].BeadID)
+	}
+}
+
+func TestHandleKillCommand_AgentNotFound(t *testing.T) {
+	daemon := newMockDaemon()
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+
+	bot := newTestBot(daemon, slackSrv)
+
+	bot.handleKillCommand(context.Background(), slack.SlashCommand{
+		Command:   "/kill",
+		Text:      "nonexistent",
+		ChannelID: "C123",
+		UserID:    "U456",
+	})
+
+	// The kill runs async. Wait briefly.
+	time.Sleep(100 * time.Millisecond)
+
+	closed := daemon.getClosed()
+	if len(closed) != 0 {
+		t.Errorf("expected no close calls for nonexistent agent, got %d", len(closed))
+	}
+}
+
+// --- handleClearThreadsCommand tests ---
+
+func TestHandleClearThreadsCommand_NilState(t *testing.T) {
+	daemon := newMockDaemon()
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+
+	bot := newTestBot(daemon, slackSrv)
+	bot.state = nil // explicitly nil
+
+	bot.handleClearThreadsCommand(context.Background(), slack.SlashCommand{
+		Command:   "/clear-threads",
+		Text:      "",
+		ChannelID: "C123",
+		UserID:    "U456",
+	})
+	// Should post ephemeral about state not available, no panic.
+}
+
+func TestHandleClearThreadsCommand_WithState(t *testing.T) {
+	daemon := newMockDaemon()
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+
+	// Create a real StateManager backed by a temp file.
+	tmpDir := t.TempDir()
+	sm, err := NewStateManager(filepath.Join(tmpDir, "state.json"))
+	if err != nil {
+		t.Fatalf("failed to create state manager: %v", err)
+	}
+
+	// Pre-populate some thread→agent mappings.
+	_ = sm.SetThreadAgent("C123", "1234.5678", "bot-a")
+	_ = sm.SetThreadAgent("C123", "2345.6789", "bot-b")
+	_ = sm.SetThreadAgent("C456", "3456.7890", "bot-c")
+
+	bot := newTestBot(daemon, slackSrv)
+	bot.state = sm
+	bot.lastThreadNudge = map[string]time.Time{
+		"key1": time.Now(),
+		"key2": time.Now(),
+	}
+
+	bot.handleClearThreadsCommand(context.Background(), slack.SlashCommand{
+		Command:   "/clear-threads",
+		Text:      "",
+		ChannelID: "C123",
+		UserID:    "U456",
+	})
+
+	// Verify thread agents were cleared.
+	sm.mu.Lock()
+	remaining := len(sm.data.ThreadAgents)
+	sm.mu.Unlock()
+
+	if remaining != 0 {
+		t.Errorf("expected all thread mappings cleared, got %d remaining", remaining)
+	}
+
+	// Verify lastThreadNudge was cleared.
+	bot.mu.Lock()
+	nudgeCount := len(bot.lastThreadNudge)
+	bot.mu.Unlock()
+
+	if nudgeCount != 0 {
+		t.Errorf("expected lastThreadNudge cleared, got %d entries", nudgeCount)
+	}
+}
+
+// --- handleRosterCommand tests ---
+
+func TestHandleRosterCommand_NoAgents(t *testing.T) {
+	daemon := newMockDaemon()
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+
+	bot := newTestBot(daemon, slackSrv)
+
+	bot.handleRosterCommand(context.Background(), slack.SlashCommand{
+		Command:   "/roster",
+		Text:      "",
+		ChannelID: "C123",
+		UserID:    "U456",
+	})
+	// Should post "No active agents" ephemeral.
+}
+
+func TestHandleRosterCommand_WithAgents(t *testing.T) {
+	daemon := newMockDaemon()
+	daemon.mu.Lock()
+	daemon.beads["a1"] = &beadsapi.BeadDetail{
+		ID:    "a1",
+		Title: "bot-alpha",
+		Type:  "agent",
+		Fields: map[string]string{
+			"agent":   "bot-alpha",
+			"project": "gasboat",
+			"role":    "crew",
+			"mode":    "crew",
+		},
+	}
+	daemon.beads["a2"] = &beadsapi.BeadDetail{
+		ID:    "a2",
+		Title: "bot-beta",
+		Type:  "agent",
+		Fields: map[string]string{
+			"agent":   "bot-beta",
+			"project": "monorepo",
+			"role":    "captain",
+			"mode":    "crew",
+		},
+	}
+	daemon.mu.Unlock()
+
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+
+	bot := newTestBot(daemon, slackSrv)
+
+	bot.handleRosterCommand(context.Background(), slack.SlashCommand{
+		Command:   "/roster",
+		Text:      "",
+		ChannelID: "C123",
+		UserID:    "U456",
+	})
+	// Should post roster with 2 agents. No panic = success.
+}
+
+func TestHandleRosterCommand_MoreThan20Agents(t *testing.T) {
+	daemon := newMockDaemon()
+	daemon.mu.Lock()
+	for i := 0; i < 25; i++ {
+		id := fmt.Sprintf("a%d", i)
+		daemon.beads[id] = &beadsapi.BeadDetail{
+			ID:    id,
+			Title: fmt.Sprintf("bot-%d", i),
+			Type:  "agent",
+			Fields: map[string]string{
+				"agent": fmt.Sprintf("bot-%d", i),
+				"role":  "crew",
+				"mode":  "crew",
+			},
+		}
+	}
+	daemon.mu.Unlock()
+
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+
+	bot := newTestBot(daemon, slackSrv)
+
+	bot.handleRosterCommand(context.Background(), slack.SlashCommand{
+		Command:   "/roster",
+		Text:      "",
+		ChannelID: "C123",
+		UserID:    "U456",
+	})
+	// Should show 20 + "...and 5 more".
+}
+
+func TestHandleRosterCommand_AgentWithNoName(t *testing.T) {
+	daemon := newMockDaemon()
+	daemon.mu.Lock()
+	daemon.beads["a1"] = &beadsapi.BeadDetail{
+		ID:    "a1",
+		Title: "", // empty title
+		Type:  "agent",
+		Fields: map[string]string{
+			"agent": "", // empty agent name
+			"role":  "crew",
+			"mode":  "crew",
+		},
+	}
+	daemon.mu.Unlock()
+
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+
+	bot := newTestBot(daemon, slackSrv)
+
+	bot.handleRosterCommand(context.Background(), slack.SlashCommand{
+		Command:   "/roster",
+		Text:      "",
+		ChannelID: "C123",
+		UserID:    "U456",
+	})
+	// Should fall back to ID for display.
+}

--- a/gasboat/controller/internal/bridge/bot_decisions.go
+++ b/gasboat/controller/internal/bridge/bot_decisions.go
@@ -236,7 +236,6 @@ func (b *Bot) NotifyDecision(ctx context.Context, bead BeadEvent) error {
 				// agent-card threading (below) can find the correct card.
 				if agentBead.Fields["agent"] != "" {
 					agent = extractAgentName(agentBead.Fields["agent"])
-					agentDisplay = b.agentDisplayName(agent)
 				}
 				ch := agentBead.Fields["slack_thread_channel"]
 				ts := agentBead.Fields["slack_thread_ts"]

--- a/gasboat/controller/internal/bridge/bot_decisions_modal_test.go
+++ b/gasboat/controller/internal/bridge/bot_decisions_modal_test.go
@@ -1,0 +1,674 @@
+package bridge
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"gasboat/controller/internal/beadsapi"
+
+	"github.com/slack-go/slack"
+)
+
+func TestResolveOptionLabel_WithOptions(t *testing.T) {
+	daemon := newMockDaemon()
+	opts := []map[string]string{
+		{"id": "a", "short": "Alpha", "label": "Option Alpha"},
+		{"id": "b", "short": "Beta", "label": ""},
+		{"id": "c", "short": "", "label": ""},
+	}
+	optsJSON, _ := json.Marshal(opts)
+	daemon.mu.Lock()
+	daemon.beads["dec-1"] = &beadsapi.BeadDetail{
+		ID:     "dec-1",
+		Type:   "decision",
+		Fields: map[string]string{"options": string(optsJSON)},
+	}
+	daemon.mu.Unlock()
+
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+	bot := newTestBot(daemon, slackSrv)
+
+	tests := []struct {
+		name     string
+		beadID   string
+		optIndex string
+		want     string
+	}{
+		{"label present", "dec-1", "1", "Option Alpha"},
+		{"falls back to short", "dec-1", "2", "Beta"},
+		{"falls back to id", "dec-1", "3", "c"},
+		{"out of range index", "dec-1", "99", "Option 99"},
+		{"zero index", "dec-1", "0", "Option 0"},
+		{"non-numeric index", "dec-1", "abc", "Option abc"},
+		{"unknown bead (returns default from GetBead)", "unknown-bead", "1", "Option 1"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := bot.resolveOptionLabel(context.Background(), tt.beadID, tt.optIndex)
+			if got != tt.want {
+				t.Errorf("resolveOptionLabel(%q, %q) = %q, want %q", tt.beadID, tt.optIndex, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLookupArtifactType(t *testing.T) {
+	daemon := newMockDaemon()
+	opts := []map[string]string{
+		{"id": "a", "label": "Option Alpha", "artifact_type": "report"},
+		{"id": "b", "short": "Beta", "artifact_type": "plan"},
+		{"id": "c", "label": "No Artifact"},
+	}
+	optsJSON, _ := json.Marshal(opts)
+	daemon.mu.Lock()
+	daemon.beads["dec-2"] = &beadsapi.BeadDetail{
+		ID:     "dec-2",
+		Type:   "decision",
+		Fields: map[string]string{"options": string(optsJSON)},
+	}
+	daemon.mu.Unlock()
+
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+	bot := newTestBot(daemon, slackSrv)
+
+	tests := []struct {
+		name        string
+		beadID      string
+		chosenLabel string
+		want        string
+	}{
+		{"match by label", "dec-2", "Option Alpha", "report"},
+		{"match by short fallback", "dec-2", "Beta", "plan"},
+		{"no artifact_type", "dec-2", "No Artifact", ""},
+		{"no match", "dec-2", "Unknown", ""},
+		{"unknown bead", "nonexistent", "anything", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := bot.lookupArtifactType(context.Background(), tt.beadID, tt.chosenLabel)
+			if got != tt.want {
+				t.Errorf("lookupArtifactType(%q, %q) = %q, want %q", tt.beadID, tt.chosenLabel, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHandleDismiss(t *testing.T) {
+	daemon := newMockDaemon()
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+	bot := newTestBot(daemon, slackSrv)
+
+	callback := slack.InteractionCallback{
+		Channel: slack.Channel{
+			GroupConversation: slack.GroupConversation{
+				Conversation: slack.Conversation{ID: "C123"},
+			},
+		},
+		User: slack.User{Name: "testuser"},
+	}
+	callback.MessageTs = "1234.5678"
+
+	bot.handleDismiss(context.Background(), "dec-dismiss-1", callback)
+
+	closed := daemon.getClosed()
+	if len(closed) != 1 {
+		t.Fatalf("expected 1 close call, got %d", len(closed))
+	}
+	if closed[0].BeadID != "dec-dismiss-1" {
+		t.Errorf("expected beadID=dec-dismiss-1, got %s", closed[0].BeadID)
+	}
+	if closed[0].Fields["chosen"] != "dismissed" {
+		t.Errorf("expected chosen=dismissed, got %s", closed[0].Fields["chosen"])
+	}
+	if closed[0].Fields["rationale"] != "Dismissed by @testuser via Slack" {
+		t.Errorf("unexpected rationale: %s", closed[0].Fields["rationale"])
+	}
+}
+
+func TestHandleBlockActions_DismissAction(t *testing.T) {
+	daemon := newMockDaemon()
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+	bot := newTestBot(daemon, slackSrv)
+
+	callback := slack.InteractionCallback{
+		Channel: slack.Channel{
+			GroupConversation: slack.GroupConversation{
+				Conversation: slack.Conversation{ID: "C123"},
+			},
+		},
+		User: slack.User{Name: "alice"},
+	}
+	callback.MessageTs = "1111.2222"
+	callback.ActionCallback.BlockActions = []*slack.BlockAction{
+		{ActionID: "dismiss_decision", Value: "dec-block-1"},
+	}
+
+	bot.handleBlockActions(context.Background(), callback)
+
+	closed := daemon.getClosed()
+	if len(closed) != 1 {
+		t.Fatalf("expected 1 close call, got %d", len(closed))
+	}
+	if closed[0].BeadID != "dec-block-1" {
+		t.Errorf("expected beadID=dec-block-1, got %s", closed[0].BeadID)
+	}
+}
+
+func TestHandleBlockActions_ResolveOptionOpensModal(t *testing.T) {
+	daemon := newMockDaemon()
+	opts := []map[string]string{
+		{"id": "opt1", "label": "First Option"},
+	}
+	optsJSON, _ := json.Marshal(opts)
+	daemon.mu.Lock()
+	daemon.beads["dec-modal-1"] = &beadsapi.BeadDetail{
+		ID:     "dec-modal-1",
+		Type:   "decision",
+		Fields: map[string]string{
+			"options":  string(optsJSON),
+			"question": "Which path?",
+		},
+	}
+	daemon.mu.Unlock()
+
+	// Track calls to views.open
+	var openViewCalled bool
+	slackSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/views.open" {
+			openViewCalled = true
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"ok":   true,
+			"view": map[string]any{"id": "V123"},
+		})
+	}))
+	defer slackSrv.Close()
+	bot := newTestBot(daemon, slackSrv)
+
+	callback := slack.InteractionCallback{
+		Channel: slack.Channel{
+			GroupConversation: slack.GroupConversation{
+				Conversation: slack.Conversation{ID: "C123"},
+			},
+		},
+		User:    slack.User{Name: "bob"},
+		Message: slack.Message{Msg: slack.Msg{Timestamp: "9999.0000"}},
+	}
+	callback.TriggerID = "trigger-123"
+	callback.ActionCallback.BlockActions = []*slack.BlockAction{
+		{ActionID: "resolve_dec-modal-1_1", Value: "dec-modal-1:1"},
+	}
+
+	bot.handleBlockActions(context.Background(), callback)
+
+	if !openViewCalled {
+		t.Error("expected views.open to be called for resolve option")
+	}
+}
+
+func TestHandleBlockActions_NoActions(t *testing.T) {
+	daemon := newMockDaemon()
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+	bot := newTestBot(daemon, slackSrv)
+
+	callback := slack.InteractionCallback{}
+	callback.ActionCallback.BlockActions = []*slack.BlockAction{}
+
+	// Should not panic or error with empty actions.
+	bot.handleBlockActions(context.Background(), callback)
+
+	if len(daemon.getClosed()) != 0 {
+		t.Error("expected no close calls for empty actions")
+	}
+}
+
+func TestHandleBlockActions_ResolveOtherOpensModal(t *testing.T) {
+	daemon := newMockDaemon()
+	daemon.mu.Lock()
+	daemon.beads["dec-other-1"] = &beadsapi.BeadDetail{
+		ID:     "dec-other-1",
+		Type:   "decision",
+		Fields: map[string]string{"question": "What do you think?"},
+	}
+	daemon.mu.Unlock()
+
+	var openViewCalled bool
+	slackSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/views.open" {
+			openViewCalled = true
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"ok":   true,
+			"view": map[string]any{"id": "V456"},
+		})
+	}))
+	defer slackSrv.Close()
+	bot := newTestBot(daemon, slackSrv)
+
+	callback := slack.InteractionCallback{
+		Channel: slack.Channel{
+			GroupConversation: slack.GroupConversation{
+				Conversation: slack.Conversation{ID: "C123"},
+			},
+		},
+		User: slack.User{Name: "carol"},
+	}
+	callback.TriggerID = "trigger-456"
+	callback.ActionCallback.BlockActions = []*slack.BlockAction{
+		{ActionID: "resolve_other_dec-other-1"},
+	}
+
+	bot.handleBlockActions(context.Background(), callback)
+
+	if !openViewCalled {
+		t.Error("expected views.open to be called for other option")
+	}
+}
+
+func TestHandleBlockActions_InvalidResolveValue(t *testing.T) {
+	daemon := newMockDaemon()
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+	bot := newTestBot(daemon, slackSrv)
+
+	callback := slack.InteractionCallback{}
+	callback.ActionCallback.BlockActions = []*slack.BlockAction{
+		// Value missing the ":" separator — should be skipped.
+		{ActionID: "resolve_dec-bad_1", Value: "no-colon-here"},
+	}
+
+	bot.handleBlockActions(context.Background(), callback)
+
+	if len(daemon.getClosed()) != 0 {
+		t.Error("expected no close calls for invalid resolve value")
+	}
+}
+
+func TestHandleViewSubmission_ResolveDecision(t *testing.T) {
+	daemon := newMockDaemon()
+	daemon.mu.Lock()
+	daemon.beads["dec-resolve-1"] = &beadsapi.BeadDetail{
+		ID:     "dec-resolve-1",
+		Type:   "decision",
+		Fields: map[string]string{},
+	}
+	daemon.mu.Unlock()
+
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+	bot := newTestBot(daemon, slackSrv)
+
+	// Pre-populate message cache so updateMessageResolved can find it.
+	bot.messages["dec-resolve-1"] = MessageRef{ChannelID: "C123", Timestamp: "1111.2222"}
+
+	callback := slack.InteractionCallback{
+		User: slack.User{Name: "dave"},
+		View: slack.View{
+			CallbackID:      "resolve_decision",
+			PrivateMetadata: "dec-resolve-1|Option Alpha|C123|1111.2222",
+			State: &slack.ViewState{
+				Values: map[string]map[string]slack.BlockAction{
+					"rationale": {
+						"rationale_input": {Value: "Looks correct"},
+					},
+				},
+			},
+		},
+	}
+
+	bot.handleViewSubmission(context.Background(), callback)
+
+	closed := daemon.getClosed()
+	if len(closed) != 1 {
+		t.Fatalf("expected 1 close call, got %d", len(closed))
+	}
+	if closed[0].BeadID != "dec-resolve-1" {
+		t.Errorf("expected beadID=dec-resolve-1, got %s", closed[0].BeadID)
+	}
+	if closed[0].Fields["chosen"] != "Option Alpha" {
+		t.Errorf("expected chosen=Option Alpha, got %s", closed[0].Fields["chosen"])
+	}
+	if closed[0].Fields["rationale"] != "Looks correct — @dave via Slack" {
+		t.Errorf("unexpected rationale: %s", closed[0].Fields["rationale"])
+	}
+}
+
+func TestHandleViewSubmission_ResolveDecisionNoRationale(t *testing.T) {
+	daemon := newMockDaemon()
+	daemon.mu.Lock()
+	daemon.beads["dec-nr-1"] = &beadsapi.BeadDetail{
+		ID:     "dec-nr-1",
+		Type:   "decision",
+		Fields: map[string]string{},
+	}
+	daemon.mu.Unlock()
+
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+	bot := newTestBot(daemon, slackSrv)
+	bot.messages["dec-nr-1"] = MessageRef{ChannelID: "C123", Timestamp: "1111.2222"}
+
+	callback := slack.InteractionCallback{
+		User: slack.User{Name: "eve"},
+		View: slack.View{
+			CallbackID:      "resolve_decision",
+			PrivateMetadata: "dec-nr-1|Beta|C123|1111.2222",
+			State: &slack.ViewState{
+				Values: map[string]map[string]slack.BlockAction{
+					"rationale": {
+						"rationale_input": {Value: ""},
+					},
+				},
+			},
+		},
+	}
+
+	bot.handleViewSubmission(context.Background(), callback)
+
+	closed := daemon.getClosed()
+	if len(closed) != 1 {
+		t.Fatalf("expected 1 close call, got %d", len(closed))
+	}
+	if closed[0].Fields["rationale"] != "Chosen by @eve via Slack" {
+		t.Errorf("unexpected rationale: %s", closed[0].Fields["rationale"])
+	}
+}
+
+func TestHandleViewSubmission_ResolveDecisionWithArtifactType(t *testing.T) {
+	daemon := newMockDaemon()
+	opts := []map[string]string{
+		{"id": "a", "label": "Plan It", "artifact_type": "plan"},
+	}
+	optsJSON, _ := json.Marshal(opts)
+	daemon.mu.Lock()
+	daemon.beads["dec-art-1"] = &beadsapi.BeadDetail{
+		ID:     "dec-art-1",
+		Type:   "decision",
+		Fields: map[string]string{"options": string(optsJSON)},
+	}
+	daemon.mu.Unlock()
+
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+	bot := newTestBot(daemon, slackSrv)
+	bot.messages["dec-art-1"] = MessageRef{ChannelID: "C123", Timestamp: "1111.2222"}
+
+	callback := slack.InteractionCallback{
+		User: slack.User{Name: "frank"},
+		View: slack.View{
+			CallbackID:      "resolve_decision",
+			PrivateMetadata: "dec-art-1|Plan It|C123|1111.2222",
+			State: &slack.ViewState{
+				Values: map[string]map[string]slack.BlockAction{
+					"rationale": {
+						"rationale_input": {Value: ""},
+					},
+				},
+			},
+		},
+	}
+
+	bot.handleViewSubmission(context.Background(), callback)
+
+	closed := daemon.getClosed()
+	if len(closed) != 1 {
+		t.Fatalf("expected 1 close call, got %d", len(closed))
+	}
+	if closed[0].Fields["required_artifact"] != "plan" {
+		t.Errorf("expected required_artifact=plan, got %s", closed[0].Fields["required_artifact"])
+	}
+	if closed[0].Fields["artifact_status"] != "pending" {
+		t.Errorf("expected artifact_status=pending, got %s", closed[0].Fields["artifact_status"])
+	}
+}
+
+func TestHandleViewSubmission_ResolveOther(t *testing.T) {
+	daemon := newMockDaemon()
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+	bot := newTestBot(daemon, slackSrv)
+	bot.messages["dec-other-sub-1"] = MessageRef{ChannelID: "C123", Timestamp: "1111.2222"}
+
+	callback := slack.InteractionCallback{
+		User: slack.User{Name: "grace"},
+		View: slack.View{
+			CallbackID:      "resolve_other",
+			PrivateMetadata: "dec-other-sub-1|C123|1111.2222",
+			State: &slack.ViewState{
+				Values: map[string]map[string]slack.BlockAction{
+					"response": {
+						"response_input": {Value: "Custom answer here"},
+					},
+					"artifact_type": {
+						"artifact_type_input": {
+							SelectedOption: slack.OptionBlockObject{
+								Value: "report",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	bot.handleViewSubmission(context.Background(), callback)
+
+	closed := daemon.getClosed()
+	if len(closed) != 1 {
+		t.Fatalf("expected 1 close call, got %d", len(closed))
+	}
+	if closed[0].BeadID != "dec-other-sub-1" {
+		t.Errorf("expected beadID=dec-other-sub-1, got %s", closed[0].BeadID)
+	}
+	if closed[0].Fields["chosen"] != "Custom answer here" {
+		t.Errorf("expected chosen='Custom answer here', got %s", closed[0].Fields["chosen"])
+	}
+	if closed[0].Fields["required_artifact"] != "report" {
+		t.Errorf("expected required_artifact=report, got %s", closed[0].Fields["required_artifact"])
+	}
+}
+
+func TestHandleViewSubmission_ResolveOtherNoArtifact(t *testing.T) {
+	daemon := newMockDaemon()
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+	bot := newTestBot(daemon, slackSrv)
+	bot.messages["dec-other-noart"] = MessageRef{ChannelID: "C123", Timestamp: "1111.2222"}
+
+	callback := slack.InteractionCallback{
+		User: slack.User{Name: "heidi"},
+		View: slack.View{
+			CallbackID:      "resolve_other",
+			PrivateMetadata: "dec-other-noart|C123|1111.2222",
+			State: &slack.ViewState{
+				Values: map[string]map[string]slack.BlockAction{
+					"response": {
+						"response_input": {Value: "My response"},
+					},
+					"artifact_type": {
+						"artifact_type_input": {
+							SelectedOption: slack.OptionBlockObject{
+								Value: "none",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	bot.handleViewSubmission(context.Background(), callback)
+
+	closed := daemon.getClosed()
+	if len(closed) != 1 {
+		t.Fatalf("expected 1 close call, got %d", len(closed))
+	}
+	if _, ok := closed[0].Fields["required_artifact"]; ok {
+		t.Errorf("expected no required_artifact for 'none', got %s", closed[0].Fields["required_artifact"])
+	}
+}
+
+func TestHandleViewSubmission_ResolveOtherEmptyResponse(t *testing.T) {
+	daemon := newMockDaemon()
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+	bot := newTestBot(daemon, slackSrv)
+
+	callback := slack.InteractionCallback{
+		User: slack.User{Name: "ivan"},
+		View: slack.View{
+			CallbackID:      "resolve_other",
+			PrivateMetadata: "dec-empty|C123|1111.2222",
+			State: &slack.ViewState{
+				Values: map[string]map[string]slack.BlockAction{
+					"response": {
+						"response_input": {Value: ""},
+					},
+				},
+			},
+		},
+	}
+
+	bot.handleViewSubmission(context.Background(), callback)
+
+	// Empty response should be a no-op.
+	if len(daemon.getClosed()) != 0 {
+		t.Error("expected no close calls for empty response")
+	}
+}
+
+func TestHandleViewSubmission_InvalidMetadata(t *testing.T) {
+	daemon := newMockDaemon()
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+	bot := newTestBot(daemon, slackSrv)
+
+	callback := slack.InteractionCallback{
+		User: slack.User{Name: "judy"},
+		View: slack.View{
+			CallbackID:      "resolve_decision",
+			PrivateMetadata: "", // empty metadata
+			State: &slack.ViewState{
+				Values: map[string]map[string]slack.BlockAction{},
+			},
+		},
+	}
+
+	// Should not panic with invalid metadata.
+	bot.handleViewSubmission(context.Background(), callback)
+
+	if len(daemon.getClosed()) != 0 {
+		t.Error("expected no close calls for invalid metadata")
+	}
+}
+
+func TestHandleViewSubmission_UnknownCallbackID(t *testing.T) {
+	daemon := newMockDaemon()
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+	bot := newTestBot(daemon, slackSrv)
+
+	callback := slack.InteractionCallback{
+		View: slack.View{
+			CallbackID: "unknown_callback",
+			State:      &slack.ViewState{Values: map[string]map[string]slack.BlockAction{}},
+		},
+	}
+
+	// Should not panic.
+	bot.handleViewSubmission(context.Background(), callback)
+	if len(daemon.getClosed()) != 0 {
+		t.Error("expected no close calls for unknown callback")
+	}
+}
+
+func TestNudgeDecisionRequestingAgent(t *testing.T) {
+	// Set up a coop server to receive the nudge.
+	var nudgeReceived bool
+	coopSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/agent/nudge" {
+			nudgeReceived = true
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer coopSrv.Close()
+
+	daemon := newMockDaemon()
+	daemon.mu.Lock()
+	daemon.beads["dec-nudge-1"] = &beadsapi.BeadDetail{
+		ID:     "dec-nudge-1",
+		Type:   "decision",
+		Fields: map[string]string{"requesting_agent_bead_id": "agent-bead-1"},
+	}
+	daemon.beads["agent-bead-1"] = &beadsapi.BeadDetail{
+		ID:    "agent-bead-1",
+		Type:  "agent",
+		Notes: "coop_url: " + coopSrv.URL,
+	}
+	daemon.mu.Unlock()
+
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+	bot := newTestBot(daemon, slackSrv)
+
+	bot.nudgeDecisionRequestingAgent(context.Background(), "dec-nudge-1")
+
+	if !nudgeReceived {
+		t.Error("expected nudge to be sent to coop server")
+	}
+}
+
+func TestNudgeDecisionRequestingAgent_NoAgentBeadID(t *testing.T) {
+	daemon := newMockDaemon()
+	daemon.mu.Lock()
+	daemon.beads["dec-no-agent"] = &beadsapi.BeadDetail{
+		ID:     "dec-no-agent",
+		Type:   "decision",
+		Fields: map[string]string{},
+	}
+	daemon.mu.Unlock()
+
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+	bot := newTestBot(daemon, slackSrv)
+
+	// Should not panic with no requesting_agent_bead_id.
+	bot.nudgeDecisionRequestingAgent(context.Background(), "dec-no-agent")
+}
+
+func TestNudgeDecisionRequestingAgent_NoCoopURL(t *testing.T) {
+	daemon := newMockDaemon()
+	daemon.mu.Lock()
+	daemon.beads["dec-no-coop"] = &beadsapi.BeadDetail{
+		ID:     "dec-no-coop",
+		Type:   "decision",
+		Fields: map[string]string{"requesting_agent_bead_id": "agent-no-coop"},
+	}
+	daemon.beads["agent-no-coop"] = &beadsapi.BeadDetail{
+		ID:    "agent-no-coop",
+		Type:  "agent",
+		Notes: "",
+	}
+	daemon.mu.Unlock()
+
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+	bot := newTestBot(daemon, slackSrv)
+
+	// Should not panic with no coop_url.
+	bot.nudgeDecisionRequestingAgent(context.Background(), "dec-no-coop")
+}

--- a/gasboat/controller/internal/bridge/bot_formula_extra_test.go
+++ b/gasboat/controller/internal/bridge/bot_formula_extra_test.go
@@ -1,0 +1,326 @@
+package bridge
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"gasboat/controller/internal/beadsapi"
+
+	"github.com/slack-go/slack"
+)
+
+// --- handleFormulaShow tests ---
+
+func TestHandleFormulaShow_ByID(t *testing.T) {
+	daemon := newMockDaemon()
+
+	vars := []formulaVarDef{
+		{Name: "env", Required: true, Description: "Target environment", Enum: []string{"staging", "prod"}},
+		{Name: "version", Default: "latest"},
+	}
+	steps := []formulaStep{
+		{ID: "build", Title: "Build service", Type: "task"},
+		{ID: "deploy", Title: "Deploy to {{env}}", DependsOn: []string{"build"}, Role: "devops", Project: "infra", SuggestNewAgent: true},
+	}
+	varsJSON, _ := json.Marshal(vars)
+	stepsJSON, _ := json.Marshal(steps)
+
+	daemon.mu.Lock()
+	daemon.beads["kd-formula-show1"] = &beadsapi.BeadDetail{
+		ID:          "kd-formula-show1",
+		Title:       "Deploy Pipeline",
+		Type:        "formula",
+		Description: "A formula for deploying services",
+		Fields: map[string]string{
+			"vars":  string(varsJSON),
+			"steps": string(stepsJSON),
+		},
+	}
+	daemon.mu.Unlock()
+
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+
+	bot := newTestBot(daemon, slackSrv)
+
+	// Should not panic; posts ephemeral with formula details.
+	bot.handleFormulaShow(context.Background(), slack.SlashCommand{
+		ChannelID: "C123",
+		UserID:    "U456",
+	}, "kd-formula-show1")
+}
+
+func TestHandleFormulaShow_ByID_NotFound(t *testing.T) {
+	daemon := newMockDaemon()
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+
+	bot := newTestBot(daemon, slackSrv)
+
+	// GetBead on mock returns an empty bead (type != "formula"), so resolveFormula
+	// will return an error about wrong type.
+	bot.handleFormulaShow(context.Background(), slack.SlashCommand{
+		ChannelID: "C123",
+		UserID:    "U456",
+	}, "kd-nonexistent")
+}
+
+func TestHandleFormulaShow_ByName_SingleMatch(t *testing.T) {
+	daemon := newMockDaemon()
+
+	daemon.mu.Lock()
+	daemon.beads["kd-formula-named"] = &beadsapi.BeadDetail{
+		ID:     "kd-formula-named",
+		Title:  "My Deploy Formula",
+		Type:   "formula",
+		Status: "open",
+		Fields: map[string]string{},
+	}
+	daemon.mu.Unlock()
+
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+
+	bot := newTestBot(daemon, slackSrv)
+
+	// Search by name (not starting with kd-).
+	bot.handleFormulaShow(context.Background(), slack.SlashCommand{
+		ChannelID: "C123",
+		UserID:    "U456",
+	}, "deploy")
+}
+
+func TestHandleFormulaShow_NoVarsNoSteps(t *testing.T) {
+	daemon := newMockDaemon()
+
+	daemon.mu.Lock()
+	daemon.beads["kd-formula-empty"] = &beadsapi.BeadDetail{
+		ID:     "kd-formula-empty",
+		Title:  "Empty Formula",
+		Type:   "formula",
+		Fields: map[string]string{},
+	}
+	daemon.mu.Unlock()
+
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+
+	bot := newTestBot(daemon, slackSrv)
+
+	bot.handleFormulaShow(context.Background(), slack.SlashCommand{
+		ChannelID: "C123",
+		UserID:    "U456",
+	}, "kd-formula-empty")
+}
+
+func TestHandleFormulaShow_LongDescription(t *testing.T) {
+	daemon := newMockDaemon()
+
+	longDesc := ""
+	for i := 0; i < 250; i++ {
+		longDesc += "x"
+	}
+
+	daemon.mu.Lock()
+	daemon.beads["kd-formula-long"] = &beadsapi.BeadDetail{
+		ID:          "kd-formula-long",
+		Title:       "Long Desc Formula",
+		Type:        "formula",
+		Description: longDesc,
+		Fields:      map[string]string{},
+	}
+	daemon.mu.Unlock()
+
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+
+	bot := newTestBot(daemon, slackSrv)
+
+	// Should truncate description to 200 chars without panic.
+	bot.handleFormulaShow(context.Background(), slack.SlashCommand{
+		ChannelID: "C123",
+		UserID:    "U456",
+	}, "kd-formula-long")
+}
+
+func TestHandleFormulaShow_StepWithConditions(t *testing.T) {
+	daemon := newMockDaemon()
+
+	steps := []formulaStep{
+		{ID: "s1", Title: "Step One", Type: "bug", DependsOn: []string{"s0"}},
+		{ID: "s2", Title: "Step Two", Project: "infra"},
+		{ID: "s3", Title: "Step Three", Role: "devops"},
+		{ID: "s4", Title: "Step Four", Project: "infra", Role: "devops", SuggestNewAgent: true},
+	}
+	stepsJSON, _ := json.Marshal(steps)
+
+	daemon.mu.Lock()
+	daemon.beads["kd-formula-steps"] = &beadsapi.BeadDetail{
+		ID:    "kd-formula-steps",
+		Title: "Steps Formula",
+		Type:  "formula",
+		Fields: map[string]string{
+			"steps": string(stepsJSON),
+		},
+	}
+	daemon.mu.Unlock()
+
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+
+	bot := newTestBot(daemon, slackSrv)
+
+	bot.handleFormulaShow(context.Background(), slack.SlashCommand{
+		ChannelID: "C123",
+		UserID:    "U456",
+	}, "kd-formula-steps")
+}
+
+// --- handleFormulaCommand routing tests ---
+
+func TestHandleFormulaCommand_ShowSubcommand(t *testing.T) {
+	daemon := newMockDaemon()
+
+	daemon.mu.Lock()
+	daemon.beads["kd-formula-cmd"] = &beadsapi.BeadDetail{
+		ID:     "kd-formula-cmd",
+		Title:  "Test Formula",
+		Type:   "formula",
+		Fields: map[string]string{},
+	}
+	daemon.mu.Unlock()
+
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+
+	bot := newTestBot(daemon, slackSrv)
+
+	bot.handleFormulaCommand(context.Background(), slack.SlashCommand{
+		ChannelID: "C123",
+		UserID:    "U456",
+		Text:      "show kd-formula-cmd",
+	})
+}
+
+func TestHandleFormulaCommand_ShowMissingArg(t *testing.T) {
+	daemon := newMockDaemon()
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+
+	bot := newTestBot(daemon, slackSrv)
+
+	// "show" without ID should post usage error.
+	bot.handleFormulaCommand(context.Background(), slack.SlashCommand{
+		ChannelID: "C123",
+		UserID:    "U456",
+		Text:      "show",
+	})
+}
+
+func TestHandleFormulaCommand_Help(t *testing.T) {
+	daemon := newMockDaemon()
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+
+	bot := newTestBot(daemon, slackSrv)
+
+	bot.handleFormulaCommand(context.Background(), slack.SlashCommand{
+		ChannelID: "C123",
+		UserID:    "U456",
+		Text:      "help",
+	})
+}
+
+func TestHandleFormulaCommand_Unknown(t *testing.T) {
+	daemon := newMockDaemon()
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+
+	bot := newTestBot(daemon, slackSrv)
+
+	bot.handleFormulaCommand(context.Background(), slack.SlashCommand{
+		ChannelID: "C123",
+		UserID:    "U456",
+		Text:      "bogus",
+	})
+}
+
+// --- resolveFormula tests ---
+
+func TestResolveFormula_ByID_WrongType(t *testing.T) {
+	daemon := newMockDaemon()
+
+	daemon.mu.Lock()
+	daemon.beads["kd-not-formula"] = &beadsapi.BeadDetail{
+		ID:   "kd-not-formula",
+		Type: "task",
+	}
+	daemon.mu.Unlock()
+
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+
+	bot := newTestBot(daemon, slackSrv)
+
+	_, err := bot.resolveFormula(context.Background(), "kd-not-formula")
+	if err == nil {
+		t.Fatal("expected error for non-formula bead type")
+	}
+}
+
+func TestResolveFormula_ByID_TemplateType(t *testing.T) {
+	daemon := newMockDaemon()
+
+	daemon.mu.Lock()
+	daemon.beads["kd-template-1"] = &beadsapi.BeadDetail{
+		ID:   "kd-template-1",
+		Type: "template",
+	}
+	daemon.mu.Unlock()
+
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+
+	bot := newTestBot(daemon, slackSrv)
+
+	f, err := bot.resolveFormula(context.Background(), "kd-template-1")
+	if err != nil {
+		t.Fatalf("expected template type to be accepted, got error: %v", err)
+	}
+	if f.ID != "kd-template-1" {
+		t.Errorf("expected ID kd-template-1, got %s", f.ID)
+	}
+}
+
+func TestResolveFormula_ByName_NoMatches(t *testing.T) {
+	daemon := newMockDaemon()
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+
+	bot := newTestBot(daemon, slackSrv)
+
+	_, err := bot.resolveFormula(context.Background(), "nonexistent")
+	if err == nil {
+		t.Fatal("expected error when no formula matches")
+	}
+}
+
+func TestResolveFormula_ByName_MultipleMatches(t *testing.T) {
+	daemon := newMockDaemon()
+
+	daemon.mu.Lock()
+	daemon.beads["kd-f1"] = &beadsapi.BeadDetail{ID: "kd-f1", Title: "Deploy A", Type: "formula", Status: "open"}
+	daemon.beads["kd-f2"] = &beadsapi.BeadDetail{ID: "kd-f2", Title: "Deploy B", Type: "formula", Status: "open"}
+	daemon.mu.Unlock()
+
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+
+	bot := newTestBot(daemon, slackSrv)
+
+	_, err := bot.resolveFormula(context.Background(), "deploy")
+	if err == nil {
+		t.Fatal("expected error for multiple matching formulas")
+	}
+}

--- a/gasboat/controller/internal/bridge/bot_gate_test.go
+++ b/gasboat/controller/internal/bridge/bot_gate_test.go
@@ -1,0 +1,392 @@
+package bridge
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/slack-go/slack"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+)
+
+// newTestBouncer creates a Bouncer backed by a fake K8s dynamic client with
+// a pre-populated Traefik middleware resource containing the given sourceRange.
+func newTestBouncer(sourceRange []string) *Bouncer {
+	mw := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "traefik.io/v1alpha1",
+			"kind":       "Middleware",
+			"metadata": map[string]interface{}{
+				"name":      "test-mw",
+				"namespace": "default",
+			},
+			"spec": map[string]interface{}{
+				"ipWhiteList": map[string]interface{}{
+					"sourceRange": toInterfaceSlice(sourceRange),
+				},
+			},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	gvr := schema.GroupVersionResource{
+		Group:    "traefik.io",
+		Version:  "v1alpha1",
+		Resource: "middlewares",
+	}
+	scheme.AddKnownTypeWithName(
+		schema.GroupVersionKind{Group: gvr.Group, Version: gvr.Version, Kind: "Middleware"},
+		&unstructured.Unstructured{},
+	)
+	scheme.AddKnownTypeWithName(
+		schema.GroupVersionKind{Group: gvr.Group, Version: gvr.Version, Kind: "MiddlewareList"},
+		&unstructured.UnstructuredList{},
+	)
+
+	client := dynamicfake.NewSimpleDynamicClient(scheme, mw)
+	return NewBouncer(BouncerConfig{
+		Client:          client,
+		Namespace:       "default",
+		MiddlewareNames: []string{"test-mw"},
+		Logger:          slog.Default(),
+	})
+}
+
+func toInterfaceSlice(ss []string) []interface{} {
+	out := make([]interface{}, len(ss))
+	for i, s := range ss {
+		out[i] = s
+	}
+	return out
+}
+
+// captureEphemeral creates a fake Slack server that captures the text of
+// ephemeral messages posted.
+func captureEphemeral(t *testing.T) (*httptest.Server, *[]string) {
+	t.Helper()
+	var texts []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/chat.postEphemeral" {
+			_ = r.ParseForm()
+			texts = append(texts, r.FormValue("text"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"ok": true, "message_ts": "1234.5678"})
+	}))
+	return srv, &texts
+}
+
+func TestHandleBouncerCommand_NoBouncer(t *testing.T) {
+	daemon := newMockDaemon()
+	slackSrv, texts := captureEphemeral(t)
+	defer slackSrv.Close()
+
+	bot := newTestBot(daemon, slackSrv)
+	// bouncer is nil by default.
+
+	bot.handleBouncerCommand(context.Background(), slack.SlashCommand{
+		ChannelID: "C123",
+		UserID:    "U456",
+		Text:      "list",
+	})
+
+	if len(*texts) != 1 {
+		t.Fatalf("expected 1 ephemeral message, got %d", len(*texts))
+	}
+	if !strings.Contains((*texts)[0], "not configured") {
+		t.Errorf("unexpected message: %s", (*texts)[0])
+	}
+}
+
+func TestHandleBouncerCommand_NoArgs(t *testing.T) {
+	daemon := newMockDaemon()
+	slackSrv, texts := captureEphemeral(t)
+	defer slackSrv.Close()
+
+	bot := newTestBot(daemon, slackSrv)
+	bot.bouncer = newTestBouncer([]string{"10.0.0.1/32"})
+
+	bot.handleBouncerCommand(context.Background(), slack.SlashCommand{
+		ChannelID: "C123",
+		UserID:    "U456",
+		Text:      "",
+	})
+
+	if len(*texts) != 1 {
+		t.Fatalf("expected 1 ephemeral message, got %d", len(*texts))
+	}
+	if !strings.Contains((*texts)[0], "Usage") {
+		t.Errorf("expected usage message, got: %s", (*texts)[0])
+	}
+}
+
+func TestHandleBouncerCommand_UnknownSubcommand(t *testing.T) {
+	daemon := newMockDaemon()
+	slackSrv, texts := captureEphemeral(t)
+	defer slackSrv.Close()
+
+	bot := newTestBot(daemon, slackSrv)
+	bot.bouncer = newTestBouncer([]string{"10.0.0.1/32"})
+
+	bot.handleBouncerCommand(context.Background(), slack.SlashCommand{
+		ChannelID: "C123",
+		UserID:    "U456",
+		Text:      "unknown",
+	})
+
+	if len(*texts) != 1 {
+		t.Fatalf("expected 1 ephemeral message, got %d", len(*texts))
+	}
+	if !strings.Contains((*texts)[0], "Usage") {
+		t.Errorf("expected usage message, got: %s", (*texts)[0])
+	}
+}
+
+func TestHandleBouncerList(t *testing.T) {
+	daemon := newMockDaemon()
+	slackSrv, texts := captureEphemeral(t)
+	defer slackSrv.Close()
+
+	bot := newTestBot(daemon, slackSrv)
+	bot.bouncer = newTestBouncer([]string{"10.0.0.1/32", "192.168.1.0/24"})
+
+	bot.handleBouncerCommand(context.Background(), slack.SlashCommand{
+		ChannelID: "C123",
+		UserID:    "U456",
+		Text:      "list",
+	})
+
+	if len(*texts) != 1 {
+		t.Fatalf("expected 1 ephemeral message, got %d", len(*texts))
+	}
+	msg := (*texts)[0]
+	if !strings.Contains(msg, "IP Whitelist") {
+		t.Errorf("expected whitelist header, got: %s", msg)
+	}
+	if !strings.Contains(msg, "10.0.0.1/32") {
+		t.Errorf("expected 10.0.0.1/32 in list, got: %s", msg)
+	}
+	if !strings.Contains(msg, "192.168.1.0/24") {
+		t.Errorf("expected 192.168.1.0/24 in list, got: %s", msg)
+	}
+	if !strings.Contains(msg, "2 entries") {
+		t.Errorf("expected '2 entries' in list, got: %s", msg)
+	}
+}
+
+func TestHandleBouncerList_Ls(t *testing.T) {
+	daemon := newMockDaemon()
+	slackSrv, texts := captureEphemeral(t)
+	defer slackSrv.Close()
+
+	bot := newTestBot(daemon, slackSrv)
+	bot.bouncer = newTestBouncer([]string{"1.2.3.4/32"})
+
+	bot.handleBouncerCommand(context.Background(), slack.SlashCommand{
+		ChannelID: "C123",
+		UserID:    "U456",
+		Text:      "ls",
+	})
+
+	if len(*texts) != 1 {
+		t.Fatalf("expected 1 ephemeral message, got %d", len(*texts))
+	}
+	if !strings.Contains((*texts)[0], "1.2.3.4/32") {
+		t.Errorf("expected IP in list, got: %s", (*texts)[0])
+	}
+}
+
+func TestHandleBouncerAdd(t *testing.T) {
+	daemon := newMockDaemon()
+	slackSrv, texts := captureEphemeral(t)
+	defer slackSrv.Close()
+
+	bot := newTestBot(daemon, slackSrv)
+	bot.bouncer = newTestBouncer([]string{"10.0.0.1/32"})
+
+	bot.handleBouncerCommand(context.Background(), slack.SlashCommand{
+		ChannelID: "C123",
+		UserID:    "U456",
+		Text:      "add 192.168.1.1",
+	})
+
+	if len(*texts) != 1 {
+		t.Fatalf("expected 1 ephemeral message, got %d", len(*texts))
+	}
+	msg := (*texts)[0]
+	if !strings.Contains(msg, "Added") {
+		t.Errorf("expected 'Added' confirmation, got: %s", msg)
+	}
+	if !strings.Contains(msg, "192.168.1.1/32") {
+		t.Errorf("expected normalized CIDR in response, got: %s", msg)
+	}
+}
+
+func TestHandleBouncerAdd_NoIP(t *testing.T) {
+	daemon := newMockDaemon()
+	slackSrv, texts := captureEphemeral(t)
+	defer slackSrv.Close()
+
+	bot := newTestBot(daemon, slackSrv)
+	bot.bouncer = newTestBouncer([]string{"10.0.0.1/32"})
+
+	bot.handleBouncerCommand(context.Background(), slack.SlashCommand{
+		ChannelID: "C123",
+		UserID:    "U456",
+		Text:      "add",
+	})
+
+	if len(*texts) != 1 {
+		t.Fatalf("expected 1 ephemeral message, got %d", len(*texts))
+	}
+	if !strings.Contains((*texts)[0], "Usage") {
+		t.Errorf("expected usage message, got: %s", (*texts)[0])
+	}
+}
+
+func TestHandleBouncerAdd_InvalidIP(t *testing.T) {
+	daemon := newMockDaemon()
+	slackSrv, texts := captureEphemeral(t)
+	defer slackSrv.Close()
+
+	bot := newTestBot(daemon, slackSrv)
+	bot.bouncer = newTestBouncer([]string{"10.0.0.1/32"})
+
+	bot.handleBouncerCommand(context.Background(), slack.SlashCommand{
+		ChannelID: "C123",
+		UserID:    "U456",
+		Text:      "add not-an-ip",
+	})
+
+	if len(*texts) != 1 {
+		t.Fatalf("expected 1 ephemeral message, got %d", len(*texts))
+	}
+	if !strings.Contains((*texts)[0], "invalid") {
+		t.Errorf("expected error about invalid IP, got: %s", (*texts)[0])
+	}
+}
+
+func TestHandleBouncerRemove(t *testing.T) {
+	daemon := newMockDaemon()
+	slackSrv, texts := captureEphemeral(t)
+	defer slackSrv.Close()
+
+	bot := newTestBot(daemon, slackSrv)
+	bot.bouncer = newTestBouncer([]string{"10.0.0.1/32", "192.168.1.1/32"})
+
+	bot.handleBouncerCommand(context.Background(), slack.SlashCommand{
+		ChannelID: "C123",
+		UserID:    "U456",
+		Text:      "remove 192.168.1.1",
+	})
+
+	if len(*texts) != 1 {
+		t.Fatalf("expected 1 ephemeral message, got %d", len(*texts))
+	}
+	msg := (*texts)[0]
+	if !strings.Contains(msg, "Removed") {
+		t.Errorf("expected 'Removed' confirmation, got: %s", msg)
+	}
+	if !strings.Contains(msg, "192.168.1.1/32") {
+		t.Errorf("expected CIDR in response, got: %s", msg)
+	}
+}
+
+func TestHandleBouncerRemove_Rm(t *testing.T) {
+	daemon := newMockDaemon()
+	slackSrv, texts := captureEphemeral(t)
+	defer slackSrv.Close()
+
+	bot := newTestBot(daemon, slackSrv)
+	bot.bouncer = newTestBouncer([]string{"10.0.0.1/32", "192.168.1.1/32"})
+
+	bot.handleBouncerCommand(context.Background(), slack.SlashCommand{
+		ChannelID: "C123",
+		UserID:    "U456",
+		Text:      "rm 192.168.1.1",
+	})
+
+	if len(*texts) != 1 {
+		t.Fatalf("expected 1 ephemeral message, got %d", len(*texts))
+	}
+	if !strings.Contains((*texts)[0], "Removed") {
+		t.Errorf("expected 'Removed' confirmation, got: %s", (*texts)[0])
+	}
+}
+
+func TestHandleBouncerRemove_NoIP(t *testing.T) {
+	daemon := newMockDaemon()
+	slackSrv, texts := captureEphemeral(t)
+	defer slackSrv.Close()
+
+	bot := newTestBot(daemon, slackSrv)
+	bot.bouncer = newTestBouncer([]string{"10.0.0.1/32"})
+
+	bot.handleBouncerCommand(context.Background(), slack.SlashCommand{
+		ChannelID: "C123",
+		UserID:    "U456",
+		Text:      "remove",
+	})
+
+	if len(*texts) != 1 {
+		t.Fatalf("expected 1 ephemeral message, got %d", len(*texts))
+	}
+	if !strings.Contains((*texts)[0], "Usage") {
+		t.Errorf("expected usage message, got: %s", (*texts)[0])
+	}
+}
+
+func TestHandleBouncerRemove_NotInList(t *testing.T) {
+	daemon := newMockDaemon()
+	slackSrv, texts := captureEphemeral(t)
+	defer slackSrv.Close()
+
+	bot := newTestBot(daemon, slackSrv)
+	bot.bouncer = newTestBouncer([]string{"10.0.0.1/32"})
+
+	bot.handleBouncerCommand(context.Background(), slack.SlashCommand{
+		ChannelID: "C123",
+		UserID:    "U456",
+		Text:      "remove 99.99.99.99",
+	})
+
+	if len(*texts) != 1 {
+		t.Fatalf("expected 1 ephemeral message, got %d", len(*texts))
+	}
+	if !strings.Contains((*texts)[0], "Failed") {
+		t.Errorf("expected failure message, got: %s", (*texts)[0])
+	}
+}
+
+func TestHandleBouncerAdd_WithCIDR(t *testing.T) {
+	daemon := newMockDaemon()
+	slackSrv, texts := captureEphemeral(t)
+	defer slackSrv.Close()
+
+	bot := newTestBot(daemon, slackSrv)
+	bot.bouncer = newTestBouncer([]string{"10.0.0.1/32"})
+
+	bot.handleBouncerCommand(context.Background(), slack.SlashCommand{
+		ChannelID: "C123",
+		UserID:    "U456",
+		Text:      "add 172.16.0.0/16",
+	})
+
+	if len(*texts) != 1 {
+		t.Fatalf("expected 1 ephemeral message, got %d", len(*texts))
+	}
+	msg := (*texts)[0]
+	if !strings.Contains(msg, "Added") {
+		t.Errorf("expected 'Added' confirmation, got: %s", msg)
+	}
+	if !strings.Contains(msg, "172.16.0.0/16") {
+		t.Errorf("expected CIDR notation in response, got: %s", msg)
+	}
+}

--- a/gasboat/controller/internal/bridge/bot_helpers_test.go
+++ b/gasboat/controller/internal/bridge/bot_helpers_test.go
@@ -1,0 +1,720 @@
+package bridge
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"gasboat/controller/internal/beadsapi"
+
+	"github.com/slack-go/slack/slackevents"
+)
+
+// --- handleMessageEvent tests ---
+
+func TestHandleMessageEvent_IgnoresBotOwnMessages(t *testing.T) {
+	daemon := newMockDaemon()
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+
+	bot := newTestBot(daemon, slackSrv)
+	bot.botUserID = "UBOTID"
+
+	// Message from the bot itself should be ignored.
+	bot.handleMessageEvent(context.Background(), &slackevents.MessageEvent{
+		User:    "UBOTID",
+		Text:    "hello",
+		Channel: "C123",
+	})
+}
+
+func TestHandleMessageEvent_IgnoresEmptyUser(t *testing.T) {
+	daemon := newMockDaemon()
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+
+	bot := newTestBot(daemon, slackSrv)
+	bot.botUserID = "UBOTID"
+
+	bot.handleMessageEvent(context.Background(), &slackevents.MessageEvent{
+		User:    "",
+		Text:    "hello",
+		Channel: "C123",
+	})
+}
+
+func TestHandleMessageEvent_IgnoresSubtypes(t *testing.T) {
+	daemon := newMockDaemon()
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+
+	bot := newTestBot(daemon, slackSrv)
+	bot.botUserID = "UBOTID"
+
+	bot.handleMessageEvent(context.Background(), &slackevents.MessageEvent{
+		User:    "U123",
+		Text:    "hello",
+		Channel: "C123",
+		SubType: "message_changed",
+	})
+}
+
+func TestHandleMessageEvent_NonThreadNonMention_Ignored(t *testing.T) {
+	daemon := newMockDaemon()
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+
+	bot := newTestBot(daemon, slackSrv)
+	bot.botUserID = "UBOTID"
+
+	// Non-thread, non-mention, non-group message is ignored.
+	bot.handleMessageEvent(context.Background(), &slackevents.MessageEvent{
+		User:        "U123",
+		Text:        "random message",
+		Channel:     "C123",
+		ChannelType: "channel",
+	})
+}
+
+func TestHandleMessageEvent_GroupChannelMention_SynthesizesAppMention(t *testing.T) {
+	daemon := newMockDaemon()
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+
+	bot := newTestBot(daemon, slackSrv)
+	bot.botUserID = "UBOTID"
+
+	// Group channel + mention should synthesize AppMentionEvent.
+	// This won't crash because handleAppMention will just not match any agent.
+	bot.handleMessageEvent(context.Background(), &slackevents.MessageEvent{
+		User:        "U123",
+		Text:        "hey <@UBOTID> do something",
+		Channel:     "G123",
+		ChannelType: "group",
+		TimeStamp:   "1234.5678",
+	})
+}
+
+// --- hintMentionRequired tests ---
+
+func TestHintMentionRequired_PostsHint(t *testing.T) {
+	var posted bool
+	slackSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		posted = true
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"ok": true, "ts": "1234.5678"})
+	}))
+	defer slackSrv.Close()
+
+	daemon := newMockDaemon()
+	bot := newTestBot(daemon, slackSrv)
+	bot.lastThreadNudge = make(map[string]time.Time)
+
+	bot.hintMentionRequired(context.Background(), "C123", "1111.2222", "my-agent")
+
+	if !posted {
+		t.Error("expected hint message to be posted")
+	}
+}
+
+func TestHintMentionRequired_Throttled(t *testing.T) {
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+
+	daemon := newMockDaemon()
+	bot := newTestBot(daemon, slackSrv)
+	bot.lastThreadNudge = make(map[string]time.Time)
+
+	// First call should go through.
+	bot.hintMentionRequired(context.Background(), "C123", "1111.2222", "my-agent")
+
+	// Second call within 10 minutes should be throttled.
+	callCount := 0
+	slackSrv2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"ok": true, "ts": "1234.5678"})
+	}))
+	defer slackSrv2.Close()
+
+	// Re-wire the API to the counting server — but the throttle should prevent the call.
+	bot.hintMentionRequired(context.Background(), "C123", "1111.2222", "my-agent")
+
+	// The second call used the same bot.api, so the lastThreadNudge check
+	// should prevent posting. We verify by checking the nudge map has the key.
+	key := "hint:C123:1111.2222"
+	bot.mu.Lock()
+	_, ok := bot.lastThreadNudge[key]
+	bot.mu.Unlock()
+	if !ok {
+		t.Error("expected nudge key to be stored")
+	}
+}
+
+func TestHintMentionRequired_NilAPI(t *testing.T) {
+	daemon := newMockDaemon()
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+
+	bot := newTestBot(daemon, slackSrv)
+	bot.lastThreadNudge = make(map[string]time.Time)
+	bot.api = nil
+
+	// Should not panic when api is nil.
+	bot.hintMentionRequired(context.Background(), "C123", "1111.2222", "my-agent")
+}
+
+// --- handleThreadReply tests ---
+
+func TestHandleThreadReply_NoDecisionThread(t *testing.T) {
+	daemon := newMockDaemon()
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+
+	bot := newTestBot(daemon, slackSrv)
+
+	// No state manager, so getDecisionByThread returns "".
+	bot.handleThreadReply(context.Background(), &slackevents.MessageEvent{
+		User:            "U123",
+		Text:            "my reply",
+		Channel:         "C123",
+		ThreadTimeStamp: "1111.2222",
+	})
+
+	// Should silently return without error.
+	if len(daemon.getClosed()) != 0 {
+		t.Error("expected no beads to be closed")
+	}
+}
+
+func TestHandleThreadReply_ResolvesOpenDecision(t *testing.T) {
+	daemon := newMockDaemon()
+
+	// Seed an open decision bead.
+	daemon.mu.Lock()
+	daemon.beads["kd-dec-1"] = &beadsapi.BeadDetail{
+		ID:     "kd-dec-1",
+		Title:  "Choose a color",
+		Type:   "decision",
+		Status: "open",
+	}
+	daemon.mu.Unlock()
+
+	// Create a real slack server that handles users.info.
+	slackSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if strings.Contains(r.URL.Path, "users.info") || r.FormValue("user") != "" {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"ok":   true,
+				"user": map[string]any{"id": "U123", "real_name": "Bob", "name": "bob"},
+			})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"ok": true, "ts": "1234.5678"})
+	}))
+	defer slackSrv.Close()
+
+	bot := newTestBot(daemon, slackSrv)
+
+	// Set up a state manager with the decision message mapping.
+	tmpDir := t.TempDir()
+	statePath := filepath.Join(tmpDir, "state.json")
+	sm, err := NewStateManager(statePath)
+	if err != nil {
+		t.Fatalf("failed to create state manager: %v", err)
+	}
+	_ = sm.SetDecisionMessage("kd-dec-1", MessageRef{ChannelID: "C123", Timestamp: "1111.2222"})
+	bot.state = sm
+
+	bot.handleThreadReply(context.Background(), &slackevents.MessageEvent{
+		User:            "U123",
+		Text:            "blue",
+		Channel:         "C123",
+		ThreadTimeStamp: "1111.2222",
+		TimeStamp:       "1111.3333",
+	})
+
+	closed := daemon.getClosed()
+	if len(closed) != 1 {
+		t.Fatalf("expected 1 close call, got %d", len(closed))
+	}
+	if closed[0].BeadID != "kd-dec-1" {
+		t.Errorf("expected bead kd-dec-1 to be closed, got %s", closed[0].BeadID)
+	}
+	if closed[0].Fields["chosen"] != "blue" {
+		t.Errorf("expected chosen=blue, got %s", closed[0].Fields["chosen"])
+	}
+}
+
+func TestHandleThreadReply_SkipsAlreadyClosedDecision(t *testing.T) {
+	daemon := newMockDaemon()
+
+	// Seed a closed decision bead.
+	daemon.mu.Lock()
+	daemon.beads["kd-dec-closed"] = &beadsapi.BeadDetail{
+		ID:     "kd-dec-closed",
+		Title:  "Already decided",
+		Type:   "decision",
+		Status: "closed",
+	}
+	daemon.mu.Unlock()
+
+	slackSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if strings.Contains(r.URL.Path, "users.info") || r.FormValue("user") != "" {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"ok":   true,
+				"user": map[string]any{"id": "U123", "real_name": "Bob"},
+			})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"ok": true, "ts": "1234.5678"})
+	}))
+	defer slackSrv.Close()
+
+	bot := newTestBot(daemon, slackSrv)
+
+	tmpDir := t.TempDir()
+	statePath := filepath.Join(tmpDir, "state.json")
+	sm, err := NewStateManager(statePath)
+	if err != nil {
+		t.Fatalf("failed to create state manager: %v", err)
+	}
+	_ = sm.SetDecisionMessage("kd-dec-closed", MessageRef{ChannelID: "C123", Timestamp: "1111.2222"})
+	bot.state = sm
+
+	bot.handleThreadReply(context.Background(), &slackevents.MessageEvent{
+		User:            "U123",
+		Text:            "too late",
+		Channel:         "C123",
+		ThreadTimeStamp: "1111.2222",
+		TimeStamp:       "1111.3333",
+	})
+
+	// Decision already closed, so no close call.
+	if len(daemon.getClosed()) != 0 {
+		t.Error("expected no close calls for already-closed decision")
+	}
+}
+
+// --- getDecisionByThread tests ---
+
+func TestGetDecisionByThread_NilState(t *testing.T) {
+	daemon := newMockDaemon()
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+
+	bot := newTestBot(daemon, slackSrv)
+	bot.state = nil
+
+	result := bot.getDecisionByThread("C123", "1111.2222")
+	if result != "" {
+		t.Errorf("expected empty string for nil state, got %q", result)
+	}
+}
+
+func TestGetDecisionByThread_Found(t *testing.T) {
+	daemon := newMockDaemon()
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+
+	bot := newTestBot(daemon, slackSrv)
+
+	tmpDir := t.TempDir()
+	statePath := filepath.Join(tmpDir, "state.json")
+	sm, err := NewStateManager(statePath)
+	if err != nil {
+		t.Fatalf("failed to create state manager: %v", err)
+	}
+	_ = sm.SetDecisionMessage("kd-dec-42", MessageRef{ChannelID: "C123", Timestamp: "1111.2222"})
+	bot.state = sm
+
+	result := bot.getDecisionByThread("C123", "1111.2222")
+	if result != "kd-dec-42" {
+		t.Errorf("expected kd-dec-42, got %q", result)
+	}
+}
+
+func TestGetDecisionByThread_NotFound(t *testing.T) {
+	daemon := newMockDaemon()
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+
+	bot := newTestBot(daemon, slackSrv)
+
+	tmpDir := t.TempDir()
+	statePath := filepath.Join(tmpDir, "state.json")
+	sm, err := NewStateManager(statePath)
+	if err != nil {
+		t.Fatalf("failed to create state manager: %v", err)
+	}
+	bot.state = sm
+
+	result := bot.getDecisionByThread("C123", "9999.9999")
+	if result != "" {
+		t.Errorf("expected empty for no match, got %q", result)
+	}
+}
+
+// --- postThreadStateReply tests ---
+
+func TestPostThreadStateReply_Done(t *testing.T) {
+	var postedText string
+	slackSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err == nil {
+			if text := r.FormValue("text"); text != "" {
+				postedText = text
+			}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"ok": true, "ts": "1234.5678"})
+	}))
+	defer slackSrv.Close()
+
+	daemon := newMockDaemon()
+	bot := newTestBot(daemon, slackSrv)
+
+	bead := BeadEvent{
+		ID:     "kd-agent-1",
+		Fields: map[string]string{},
+	}
+
+	bot.postThreadStateReply(context.Background(), "my-agent", "done", bead, "C123", "1111.2222")
+
+	if postedText == "" {
+		t.Error("expected a message to be posted")
+	}
+	if !strings.Contains(postedText, "finished") {
+		t.Errorf("expected 'finished' in posted text, got %q", postedText)
+	}
+}
+
+func TestPostThreadStateReply_Failed(t *testing.T) {
+	var postedText string
+	slackSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err == nil {
+			if text := r.FormValue("text"); text != "" {
+				postedText = text
+			}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"ok": true, "ts": "1234.5678"})
+	}))
+	defer slackSrv.Close()
+
+	daemon := newMockDaemon()
+	bot := newTestBot(daemon, slackSrv)
+
+	bead := BeadEvent{
+		ID:     "kd-agent-1",
+		Fields: map[string]string{"close_reason": "OOM killed"},
+	}
+
+	bot.postThreadStateReply(context.Background(), "my-agent", "failed", bead, "C123", "1111.2222")
+
+	if postedText == "" {
+		t.Error("expected a message to be posted")
+	}
+	if !strings.Contains(postedText, "failed") {
+		t.Errorf("expected 'failed' in posted text, got %q", postedText)
+	}
+}
+
+func TestPostThreadStateReply_NonTerminalState_NoPost(t *testing.T) {
+	var called bool
+	slackSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"ok": true, "ts": "1234.5678"})
+	}))
+	defer slackSrv.Close()
+
+	daemon := newMockDaemon()
+	bot := newTestBot(daemon, slackSrv)
+
+	bead := BeadEvent{ID: "kd-agent-1", Fields: map[string]string{}}
+
+	bot.postThreadStateReply(context.Background(), "my-agent", "running", bead, "C123", "1111.2222")
+
+	if called {
+		t.Error("expected no Slack API call for non-terminal state")
+	}
+}
+
+func TestPostThreadStateReply_UpdatesSpawnMessage(t *testing.T) {
+	var updatedText string
+	slackSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err == nil {
+			if text := r.FormValue("text"); text != "" {
+				updatedText = text
+			}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"ok": true, "ts": "9999.1111"})
+	}))
+	defer slackSrv.Close()
+
+	daemon := newMockDaemon()
+	bot := newTestBot(daemon, slackSrv)
+
+	// Pre-populate spawn message ref so it tries to update in-place.
+	bot.mu.Lock()
+	bot.threadSpawnMsgs["my-agent"] = MessageRef{ChannelID: "C123", Timestamp: "9999.1111"}
+	bot.mu.Unlock()
+
+	bead := BeadEvent{ID: "kd-agent-1", Fields: map[string]string{}}
+	bot.postThreadStateReply(context.Background(), "my-agent", "done", bead, "C123", "1111.2222")
+
+	if updatedText == "" {
+		t.Error("expected spawn message to be updated")
+	}
+
+	// Verify spawn message was removed from the map.
+	bot.mu.Lock()
+	_, still := bot.threadSpawnMsgs["my-agent"]
+	bot.mu.Unlock()
+	if still {
+		t.Error("expected spawn message ref to be removed after update")
+	}
+}
+
+func TestPostThreadStateReply_WithWrapup(t *testing.T) {
+	var postedText string
+	slackSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err == nil {
+			if text := r.FormValue("text"); text != "" {
+				postedText = text
+			}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"ok": true, "ts": "1234.5678"})
+	}))
+	defer slackSrv.Close()
+
+	daemon := newMockDaemon()
+	bot := newTestBot(daemon, slackSrv)
+
+	wrapup := `{"accomplishments":"Fixed the bug","blockers":"","handoff_notes":"Ready for review"}`
+	bead := BeadEvent{
+		ID:     "kd-agent-1",
+		Fields: map[string]string{"wrapup": wrapup},
+	}
+
+	bot.postThreadStateReply(context.Background(), "my-agent", "done", bead, "C123", "1111.2222")
+
+	if postedText == "" {
+		t.Error("expected a message to be posted with wrapup content")
+	}
+}
+
+// --- resolveChannel project-specific override tests ---
+
+func TestResolveChannel_RouterPatternMatch(t *testing.T) {
+	daemon := newMockDaemon()
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+
+	bot := newTestBot(daemon, slackSrv)
+	bot.channel = "C-default"
+	bot.router = NewRouter(RouterConfig{
+		DefaultChannel: "C-router-default",
+		Channels: map[string]string{
+			"gasboat/crew/*": "C-crew",
+		},
+	})
+
+	result := bot.resolveChannel("gasboat/crew/my-agent")
+	if result != "C-crew" {
+		t.Errorf("expected C-crew from pattern match, got %q", result)
+	}
+}
+
+func TestResolveChannel_RouterOverrideTakesPrecedence(t *testing.T) {
+	daemon := newMockDaemon()
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+
+	bot := newTestBot(daemon, slackSrv)
+	bot.channel = "C-default"
+	bot.router = NewRouter(RouterConfig{
+		DefaultChannel: "C-router-default",
+		Channels: map[string]string{
+			"gasboat/crew/*": "C-crew",
+		},
+		Overrides: map[string]string{
+			"gasboat/crew/special-bot": "C-special",
+		},
+	})
+
+	result := bot.resolveChannel("gasboat/crew/special-bot")
+	if result != "C-special" {
+		t.Errorf("expected C-special (override takes precedence), got %q", result)
+	}
+}
+
+func TestResolveChannel_RouterNoMatch_FallsBackToRouterDefault(t *testing.T) {
+	daemon := newMockDaemon()
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+
+	bot := newTestBot(daemon, slackSrv)
+	bot.channel = "C-default"
+	bot.router = NewRouter(RouterConfig{
+		DefaultChannel: "C-router-default",
+		Channels: map[string]string{
+			"other-project/crew/*": "C-other",
+		},
+	})
+
+	result := bot.resolveChannel("gasboat/crew/my-agent")
+	if result != "C-router-default" {
+		t.Errorf("expected C-router-default when no pattern matches, got %q", result)
+	}
+}
+
+func TestResolveChannel_NilRouter_UsesDefaultChannel(t *testing.T) {
+	daemon := newMockDaemon()
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+
+	bot := newTestBot(daemon, slackSrv)
+	bot.channel = "C-default"
+	bot.router = nil
+
+	result := bot.resolveChannel("gasboat/crew/my-agent")
+	if result != "C-default" {
+		t.Errorf("expected C-default with nil router, got %q", result)
+	}
+}
+
+func TestResolveChannel_RouterMultipleProjects(t *testing.T) {
+	daemon := newMockDaemon()
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+
+	bot := newTestBot(daemon, slackSrv)
+	bot.channel = "C-default"
+	bot.router = NewRouter(RouterConfig{
+		DefaultChannel: "C-router-default",
+		Channels: map[string]string{
+			"gasboat/crew/*": "C-gasboat",
+			"kbeads/crew/*":  "C-kbeads",
+		},
+	})
+
+	if got := bot.resolveChannel("gasboat/crew/bot-a"); got != "C-gasboat" {
+		t.Errorf("expected C-gasboat, got %q", got)
+	}
+	if got := bot.resolveChannel("kbeads/crew/bot-b"); got != "C-kbeads" {
+		t.Errorf("expected C-kbeads, got %q", got)
+	}
+}
+
+// --- replaceAgentCardWithWrapUp tests ---
+
+func TestReplaceAgentCardWithWrapUp_UpdatesExistingCard(t *testing.T) {
+	var updatedText string
+	slackSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err == nil {
+			if text := r.FormValue("text"); text != "" {
+				updatedText = text
+			}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"ok": true, "ts": "1111.2222"})
+	}))
+	defer slackSrv.Close()
+
+	daemon := newMockDaemon()
+	bot := newTestBot(daemon, slackSrv)
+
+	bot.mu.Lock()
+	bot.agentCards["my-agent"] = MessageRef{ChannelID: "C123", Timestamp: "1111.2222"}
+	bot.mu.Unlock()
+
+	wrapup := `{"accomplishments":"Fixed the bug","blockers":"","handoff_notes":"Ready for review"}`
+	bot.replaceAgentCardWithWrapUp(context.Background(), "my-agent", "done", wrapup)
+
+	if updatedText == "" {
+		t.Error("expected agent card to be updated")
+	}
+	if !strings.Contains(updatedText, "done") {
+		t.Errorf("expected 'done' in updated text, got %q", updatedText)
+	}
+}
+
+func TestReplaceAgentCardWithWrapUp_NoCard_FallsBackToUpdateAgentCard(t *testing.T) {
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+
+	daemon := newMockDaemon()
+	bot := newTestBot(daemon, slackSrv)
+
+	// No card exists — should not panic, falls back to updateAgentCard.
+	bot.replaceAgentCardWithWrapUp(context.Background(), "no-such-agent", "done", `{"accomplishments":"test"}`)
+}
+
+func TestReplaceAgentCardWithWrapUp_FailedState(t *testing.T) {
+	var updatedText string
+	slackSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err == nil {
+			if text := r.FormValue("text"); text != "" {
+				updatedText = text
+			}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"ok": true, "ts": "1111.2222"})
+	}))
+	defer slackSrv.Close()
+
+	daemon := newMockDaemon()
+	bot := newTestBot(daemon, slackSrv)
+
+	bot.mu.Lock()
+	bot.agentCards["fail-agent"] = MessageRef{ChannelID: "C123", Timestamp: "2222.3333"}
+	bot.mu.Unlock()
+
+	wrapup := `{"accomplishments":"","blockers":"OOM killed","handoff_notes":""}`
+	bot.replaceAgentCardWithWrapUp(context.Background(), "fail-agent", "failed", wrapup)
+
+	if updatedText == "" {
+		t.Error("expected agent card to be updated")
+	}
+	if !strings.Contains(updatedText, "failed") {
+		t.Errorf("expected 'failed' in updated text, got %q", updatedText)
+	}
+}
+
+func TestReplaceAgentCardWithWrapUp_EmptyWrapup(t *testing.T) {
+	var updatedText string
+	slackSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err == nil {
+			if text := r.FormValue("text"); text != "" {
+				updatedText = text
+			}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"ok": true, "ts": "1111.2222"})
+	}))
+	defer slackSrv.Close()
+
+	daemon := newMockDaemon()
+	bot := newTestBot(daemon, slackSrv)
+
+	bot.mu.Lock()
+	bot.agentCards["my-agent"] = MessageRef{ChannelID: "C123", Timestamp: "1111.2222"}
+	bot.mu.Unlock()
+
+	// Empty wrapup JSON — should still update the card with just the header.
+	bot.replaceAgentCardWithWrapUp(context.Background(), "my-agent", "done", `{}`)
+
+	if updatedText == "" {
+		t.Error("expected agent card to be updated even with empty wrapup")
+	}
+}
+

--- a/gasboat/controller/internal/bridge/bot_notifications_test.go
+++ b/gasboat/controller/internal/bridge/bot_notifications_test.go
@@ -1,0 +1,465 @@
+package bridge
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"gasboat/controller/internal/beadsapi"
+)
+
+// slackCall records a single Slack API call made to the fake server.
+type slackCall struct {
+	Method   string
+	Channel  string
+	Text     string
+	ThreadTS string
+}
+
+// capturingSlackServer returns an httptest.Server that records all Slack API
+// calls (chat.postMessage, chat.update) for assertion.
+func capturingSlackServer(t *testing.T) (*httptest.Server, *[]slackCall, *sync.Mutex) {
+	t.Helper()
+	var calls []slackCall
+	var mu sync.Mutex
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		mu.Lock()
+		calls = append(calls, slackCall{
+			Method:   strings.TrimPrefix(r.URL.Path, "/"),
+			Channel:  r.FormValue("channel"),
+			Text:     r.FormValue("text"),
+			ThreadTS: r.FormValue("thread_ts"),
+		})
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"ok": true, "ts": "1111.2222", "message_ts": "1111.2222"})
+	}))
+	return srv, &calls, &mu
+}
+
+func getCalls(calls *[]slackCall, mu *sync.Mutex) []slackCall {
+	mu.Lock()
+	defer mu.Unlock()
+	return append([]slackCall{}, *calls...)
+}
+
+// --- NotifyAgentCrash tests ---
+
+func TestNotifyAgentCrash_Basic(t *testing.T) {
+	daemon := newMockDaemon()
+	srv, calls, mu := capturingSlackServer(t)
+	defer srv.Close()
+
+	bot := newTestBot(daemon, srv)
+	bot.channel = "C-test"
+
+	bead := BeadEvent{
+		ID:       "bd-crash-1",
+		Assignee: "my-agent",
+		Fields: map[string]string{
+			"agent_state": "failed",
+			"pod_phase":   "failed",
+			"pod_name":    "agent-pod-xyz",
+		},
+	}
+
+	err := bot.NotifyAgentCrash(context.Background(), bead)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := getCalls(calls, mu)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 Slack call, got %d", len(got))
+	}
+	if got[0].Method != "chat.postMessage" {
+		t.Errorf("expected chat.postMessage, got %s", got[0].Method)
+	}
+	if got[0].Channel != "C-test" {
+		t.Errorf("expected channel C-test, got %s", got[0].Channel)
+	}
+	if !strings.Contains(got[0].Text, "Agent crashed") {
+		t.Errorf("expected text to contain 'Agent crashed', got %s", got[0].Text)
+	}
+}
+
+func TestNotifyAgentCrash_FallsBackToTitle(t *testing.T) {
+	daemon := newMockDaemon()
+	srv, calls, mu := capturingSlackServer(t)
+	defer srv.Close()
+
+	bot := newTestBot(daemon, srv)
+	bot.channel = "C-test"
+
+	bead := BeadEvent{
+		ID:    "bd-crash-2",
+		Title: "fallback-agent",
+		Fields: map[string]string{
+			"agent_state": "failed",
+		},
+	}
+
+	err := bot.NotifyAgentCrash(context.Background(), bead)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := getCalls(calls, mu)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 Slack call, got %d", len(got))
+	}
+	if !strings.Contains(got[0].Text, "fallback-agent") {
+		t.Errorf("expected text to contain 'fallback-agent', got %s", got[0].Text)
+	}
+}
+
+func TestNotifyAgentCrash_FallsBackToID(t *testing.T) {
+	daemon := newMockDaemon()
+	srv, calls, mu := capturingSlackServer(t)
+	defer srv.Close()
+
+	bot := newTestBot(daemon, srv)
+	bot.channel = "C-test"
+
+	bead := BeadEvent{
+		ID:     "bd-crash-3",
+		Fields: map[string]string{},
+	}
+
+	err := bot.NotifyAgentCrash(context.Background(), bead)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := getCalls(calls, mu)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 call, got %d", len(got))
+	}
+	if !strings.Contains(got[0].Text, "bd-crash-3") {
+		t.Errorf("expected text to contain bead ID, got %s", got[0].Text)
+	}
+}
+
+func TestNotifyAgentCrash_ThreadBoundAgent(t *testing.T) {
+	daemon := newMockDaemon()
+	// Seed an agent bead with thread binding fields.
+	daemon.mu.Lock()
+	daemon.beads["my-thread-agent"] = &beadsapi.BeadDetail{
+		ID:    "bd-agent-thread",
+		Title: "my-thread-agent",
+		Type:  "agent",
+		Fields: map[string]string{
+			"agent":                "my-thread-agent",
+			"slack_thread_channel": "C-thread-chan",
+			"slack_thread_ts":      "9999.0001",
+		},
+	}
+	daemon.mu.Unlock()
+
+	srv, calls, mu := capturingSlackServer(t)
+	defer srv.Close()
+
+	bot := newTestBot(daemon, srv)
+	bot.channel = "C-default"
+
+	bead := BeadEvent{
+		ID:       "bd-crash-thread",
+		Assignee: "my-thread-agent",
+		Fields:   map[string]string{},
+	}
+
+	err := bot.NotifyAgentCrash(context.Background(), bead)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := getCalls(calls, mu)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 call, got %d", len(got))
+	}
+	if got[0].Channel != "C-thread-chan" {
+		t.Errorf("expected crash posted to thread-bound channel C-thread-chan, got %s", got[0].Channel)
+	}
+	if got[0].ThreadTS != "9999.0001" {
+		t.Errorf("expected thread_ts 9999.0001, got %s", got[0].ThreadTS)
+	}
+}
+
+// --- NotifyJackOn tests ---
+
+func TestNotifyJackOn_Basic(t *testing.T) {
+	daemon := newMockDaemon()
+	srv, calls, mu := capturingSlackServer(t)
+	defer srv.Close()
+
+	bot := newTestBot(daemon, srv)
+	bot.channel = "C-test"
+
+	bead := BeadEvent{
+		ID:       "bd-jack-1",
+		Title:    "Jack for deploy",
+		Assignee: "deploy-agent",
+		Fields: map[string]string{
+			"target": "production-db",
+			"ttl":    "30m",
+			"reason": "Schema migration",
+		},
+	}
+
+	err := bot.NotifyJackOn(context.Background(), bead)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := getCalls(calls, mu)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 call, got %d", len(got))
+	}
+	if got[0].Method != "chat.postMessage" {
+		t.Errorf("expected chat.postMessage, got %s", got[0].Method)
+	}
+	if !strings.Contains(got[0].Text, "Jack raised") {
+		t.Errorf("expected text to contain 'Jack raised', got %s", got[0].Text)
+	}
+	if !strings.Contains(got[0].Text, "production-db") {
+		t.Errorf("expected text to contain target, got %s", got[0].Text)
+	}
+}
+
+func TestNotifyJackOn_NoOptionalFields(t *testing.T) {
+	daemon := newMockDaemon()
+	srv, calls, mu := capturingSlackServer(t)
+	defer srv.Close()
+
+	bot := newTestBot(daemon, srv)
+	bot.channel = "C-test"
+
+	bead := BeadEvent{
+		ID:     "bd-jack-2",
+		Fields: map[string]string{"target": "staging-api"},
+	}
+
+	err := bot.NotifyJackOn(context.Background(), bead)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := getCalls(calls, mu)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 call, got %d", len(got))
+	}
+}
+
+// --- NotifyJackOnBatch tests ---
+
+func TestNotifyJackOnBatch_Basic(t *testing.T) {
+	daemon := newMockDaemon()
+	srv, calls, mu := capturingSlackServer(t)
+	defer srv.Close()
+
+	bot := newTestBot(daemon, srv)
+	bot.channel = "C-test"
+
+	beads := []BeadEvent{
+		{ID: "jack-1", Title: "J1", Fields: map[string]string{"target": "svc-a"}, Assignee: "agent-1"},
+		{ID: "jack-2", Title: "J2", Fields: map[string]string{"target": "svc-b"}},
+		{ID: "jack-3", Title: "J3", Fields: map[string]string{"target": "svc-c"}},
+	}
+
+	err := bot.NotifyJackOnBatch(context.Background(), beads)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := getCalls(calls, mu)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 call, got %d", len(got))
+	}
+	if got[0].Channel != "C-test" {
+		t.Errorf("expected channel C-test, got %s", got[0].Channel)
+	}
+	if !strings.Contains(got[0].Text, "3 additional jacks raised") {
+		t.Errorf("expected batch count in text, got %s", got[0].Text)
+	}
+}
+
+func TestNotifyJackOnBatch_MoreThanFive(t *testing.T) {
+	daemon := newMockDaemon()
+	srv, calls, mu := capturingSlackServer(t)
+	defer srv.Close()
+
+	bot := newTestBot(daemon, srv)
+	bot.channel = "C-test"
+
+	beads := make([]BeadEvent, 8)
+	for i := range beads {
+		beads[i] = BeadEvent{
+			ID:     "jack-batch-" + string(rune('a'+i)),
+			Fields: map[string]string{"target": "svc"},
+		}
+	}
+
+	err := bot.NotifyJackOnBatch(context.Background(), beads)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := getCalls(calls, mu)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 call, got %d", len(got))
+	}
+	if !strings.Contains(got[0].Text, "8 additional jacks raised") {
+		t.Errorf("expected 8 in text, got %s", got[0].Text)
+	}
+}
+
+func TestNotifyJackOnBatch_FewerThanFive(t *testing.T) {
+	daemon := newMockDaemon()
+	srv, calls, mu := capturingSlackServer(t)
+	defer srv.Close()
+
+	bot := newTestBot(daemon, srv)
+	bot.channel = "C-test"
+
+	beads := []BeadEvent{
+		{ID: "j1", Fields: map[string]string{"target": "a"}},
+		{ID: "j2", Fields: map[string]string{"target": "b"}},
+	}
+
+	err := bot.NotifyJackOnBatch(context.Background(), beads)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := getCalls(calls, mu)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 call, got %d", len(got))
+	}
+	if !strings.Contains(got[0].Text, "2 additional jacks raised") {
+		t.Errorf("expected 2 in text, got %s", got[0].Text)
+	}
+}
+
+// --- NotifyJackOff tests ---
+
+func TestNotifyJackOff_Basic(t *testing.T) {
+	daemon := newMockDaemon()
+	srv, calls, mu := capturingSlackServer(t)
+	defer srv.Close()
+
+	bot := newTestBot(daemon, srv)
+	bot.channel = "C-test"
+
+	bead := BeadEvent{
+		ID:       "bd-jack-off-1",
+		Title:    "Jack lowered",
+		Assignee: "ops-agent",
+		Fields: map[string]string{
+			"target": "production-db",
+			"reason": "Migration complete",
+		},
+	}
+
+	err := bot.NotifyJackOff(context.Background(), bead)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := getCalls(calls, mu)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 call, got %d", len(got))
+	}
+	if !strings.Contains(got[0].Text, "Jack lowered") {
+		t.Errorf("expected text to contain 'Jack lowered', got %s", got[0].Text)
+	}
+}
+
+func TestNotifyJackOff_NoOptionalFields(t *testing.T) {
+	daemon := newMockDaemon()
+	srv, calls, mu := capturingSlackServer(t)
+	defer srv.Close()
+
+	bot := newTestBot(daemon, srv)
+	bot.channel = "C-test"
+
+	bead := BeadEvent{
+		ID:     "bd-jack-off-2",
+		Fields: map[string]string{"target": "staging"},
+	}
+
+	err := bot.NotifyJackOff(context.Background(), bead)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := getCalls(calls, mu)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 call, got %d", len(got))
+	}
+}
+
+// --- NotifyJackExpired tests ---
+
+func TestNotifyJackExpired_Basic(t *testing.T) {
+	daemon := newMockDaemon()
+	srv, calls, mu := capturingSlackServer(t)
+	defer srv.Close()
+
+	bot := newTestBot(daemon, srv)
+	bot.channel = "C-test"
+
+	bead := BeadEvent{
+		ID:       "bd-jack-exp-1",
+		Title:    "Expired jack",
+		Assignee: "ops-agent",
+		Fields: map[string]string{
+			"target": "production-db",
+			"reason": "TTL exceeded",
+		},
+	}
+
+	err := bot.NotifyJackExpired(context.Background(), bead)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := getCalls(calls, mu)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 call, got %d", len(got))
+	}
+	if !strings.Contains(got[0].Text, "Jack expired") {
+		t.Errorf("expected text to contain 'Jack expired', got %s", got[0].Text)
+	}
+	if !strings.Contains(got[0].Text, "bd-jack-exp-1") {
+		t.Errorf("expected text to contain bead ID, got %s", got[0].Text)
+	}
+}
+
+func TestNotifyJackExpired_NoOptionalFields(t *testing.T) {
+	daemon := newMockDaemon()
+	srv, calls, mu := capturingSlackServer(t)
+	defer srv.Close()
+
+	bot := newTestBot(daemon, srv)
+	bot.channel = "C-test"
+
+	bead := BeadEvent{
+		ID:     "bd-jack-exp-2",
+		Fields: map[string]string{"target": "staging"},
+	}
+
+	err := bot.NotifyJackExpired(context.Background(), bead)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := getCalls(calls, mu)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 call, got %d", len(got))
+	}
+}

--- a/gasboat/controller/internal/bridge/bot_thread_forward_extra_test.go
+++ b/gasboat/controller/internal/bridge/bot_thread_forward_extra_test.go
@@ -1,0 +1,269 @@
+package bridge
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"gasboat/controller/internal/beadsapi"
+
+	"github.com/slack-go/slack"
+	"github.com/slack-go/slack/slackevents"
+)
+
+func TestFetchMessageFiles_NilAPI(t *testing.T) {
+	b := &Bot{
+		api:    nil,
+		logger: slog.Default(),
+	}
+	files := b.fetchMessageFiles(context.Background(), "C123", "1234.5678")
+	if files != nil {
+		t.Errorf("expected nil files when api is nil, got %v", files)
+	}
+}
+
+func TestFetchMessageFiles_APIError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"ok": false, "error": "channel_not_found"})
+	}))
+	defer srv.Close()
+
+	api := slack.New("xoxb-test", slack.OptionAPIURL(srv.URL+"/"))
+	b := &Bot{
+		api:    api,
+		logger: slog.Default(),
+	}
+
+	files := b.fetchMessageFiles(context.Background(), "C-invalid", "1234.5678")
+	if files != nil {
+		t.Errorf("expected nil files on API error, got %v", files)
+	}
+}
+
+func TestFetchMessageFiles_NoMatchingTimestamp(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"ok": true,
+			"messages": []map[string]any{
+				{
+					"ts":   "9999.9999",
+					"text": "some message",
+				},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	api := slack.New("xoxb-test", slack.OptionAPIURL(srv.URL+"/"))
+	b := &Bot{
+		api:    api,
+		logger: slog.Default(),
+	}
+
+	files := b.fetchMessageFiles(context.Background(), "C123", "1234.5678")
+	if files != nil {
+		t.Errorf("expected nil files when no matching timestamp, got %v", files)
+	}
+}
+
+func TestFetchMessageFiles_MatchingTimestampWithFiles(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"ok": true,
+			"messages": []map[string]any{
+				{
+					"ts":   "1234.5678",
+					"text": "hello",
+					"files": []map[string]any{
+						{
+							"id":       "F123",
+							"name":     "test.png",
+							"mimetype": "image/png",
+							"size":     1024,
+						},
+					},
+				},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	api := slack.New("xoxb-test", slack.OptionAPIURL(srv.URL+"/"))
+	b := &Bot{
+		api:    api,
+		logger: slog.Default(),
+	}
+
+	files := b.fetchMessageFiles(context.Background(), "C123", "1234.5678")
+	if len(files) != 1 {
+		t.Fatalf("expected 1 file, got %d", len(files))
+	}
+	if files[0].ID != "F123" {
+		t.Errorf("expected file ID=F123, got %s", files[0].ID)
+	}
+}
+
+func TestSlackFilesToFields_WithImageFile(t *testing.T) {
+	files := []slack.File{
+		{ID: "F1", Mimetype: "image/png"},
+		{ID: "F2", Mimetype: "text/plain"},
+	}
+	fields := slackFilesToFields(files)
+	if fields == nil {
+		t.Fatal("expected non-nil fields")
+	}
+	if fields["slack_attachment_count"] != "2" {
+		t.Errorf("expected attachment count=2, got %s", fields["slack_attachment_count"])
+	}
+	if fields["slack_has_images"] != "true" {
+		t.Error("expected slack_has_images=true")
+	}
+}
+
+func TestSlackFilesToFields_NoImageFile(t *testing.T) {
+	files := []slack.File{
+		{ID: "F1", Mimetype: "text/plain"},
+	}
+	fields := slackFilesToFields(files)
+	if fields == nil {
+		t.Fatal("expected non-nil fields")
+	}
+	if _, ok := fields["slack_has_images"]; ok {
+		t.Error("expected no slack_has_images when no images")
+	}
+}
+
+func TestHandleThreadForward_MessageRefPersisted(t *testing.T) {
+	daemon := newMockDaemon()
+	daemon.beads["hq"] = &beadsapi.BeadDetail{
+		ID:    "bd-agent-hq",
+		Title: "hq",
+		Type:  "agent",
+		Fields: map[string]string{
+			"agent": "hq",
+		},
+	}
+
+	dir := t.TempDir()
+	state, err := NewStateManager(filepath.Join(dir, "state.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = state.SetThreadAgent("C-test", "1111.2222", "hq")
+	_ = state.SetListenThread("C-test", "1111.2222")
+
+	slackSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"ok": true, "user": map[string]any{
+			"id":        "U-HUMAN",
+			"real_name": "Test User",
+		}})
+	}))
+	defer slackSrv.Close()
+
+	b := newTestBot(daemon, slackSrv)
+	b.state = state
+	b.lastThreadNudge = make(map[string]time.Time)
+
+	ev := &slackevents.MessageEvent{
+		User:            "U-HUMAN",
+		Channel:         "C-test",
+		Text:            "follow up message",
+		TimeStamp:       "1111.3333",
+		ThreadTimeStamp: "1111.2222",
+	}
+
+	b.handleThreadForward(context.Background(), ev, "hq")
+
+	var beadID string
+	for id, bead := range daemon.beads {
+		if bead.Type == "task" && hasLabel(bead.Labels, "slack-thread-reply") {
+			beadID = id
+			break
+		}
+	}
+	if beadID == "" {
+		t.Fatal("expected a thread-reply bead to be created")
+	}
+
+	ref, ok := state.GetChatMessage(beadID)
+	if !ok {
+		t.Fatal("expected message ref to be persisted in state")
+	}
+	if ref.ChannelID != "C-test" {
+		t.Errorf("expected channel C-test, got %s", ref.ChannelID)
+	}
+	if ref.Timestamp != "1111.2222" {
+		t.Errorf("expected thread ts 1111.2222, got %s", ref.Timestamp)
+	}
+}
+
+func TestFetchMessageFiles_MultipleMessages_MatchesCorrectOne(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"ok": true,
+			"messages": []map[string]any{
+				{
+					"ts":   "1111.0000",
+					"text": "wrong message",
+					"files": []map[string]any{
+						{"id": "WRONG", "name": "wrong.txt"},
+					},
+				},
+				{
+					"ts":   "1234.5678",
+					"text": "right message",
+					"files": []map[string]any{
+						{"id": "RIGHT", "name": "right.txt"},
+					},
+				},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	api := slack.New("xoxb-test", slack.OptionAPIURL(srv.URL+"/"))
+	b := &Bot{
+		api:    api,
+		logger: slog.Default(),
+	}
+
+	files := b.fetchMessageFiles(context.Background(), "C123", "1234.5678")
+	if len(files) != 1 {
+		t.Fatalf("expected 1 file, got %d", len(files))
+	}
+	if files[0].ID != "RIGHT" {
+		t.Errorf("expected file ID=RIGHT, got %s", files[0].ID)
+	}
+}
+
+func TestFetchMessageFiles_EmptyMessages(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"ok":       true,
+			"messages": []map[string]any{},
+		})
+	}))
+	defer srv.Close()
+
+	api := slack.New("xoxb-test", slack.OptionAPIURL(srv.URL+"/"))
+	b := &Bot{
+		api:    api,
+		logger: slog.Default(),
+	}
+
+	files := b.fetchMessageFiles(context.Background(), "C123", "1234.5678")
+	if files != nil {
+		t.Errorf("expected nil files for empty messages, got %v", files)
+	}
+}

--- a/gasboat/controller/internal/bridge/bot_unreleased_extra_test.go
+++ b/gasboat/controller/internal/bridge/bot_unreleased_extra_test.go
@@ -1,0 +1,189 @@
+package bridge
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/slack-go/slack"
+)
+
+func TestHandleUnreleasedCommand_NoGitHub(t *testing.T) {
+	daemon := newMockDaemon()
+
+	// Capture the ephemeral message posted.
+	var postedText string
+	slackSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/chat.postEphemeral" {
+			_ = r.ParseForm()
+			postedText = r.FormValue("text")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"ok": true, "message_ts": "1234.5678"})
+	}))
+	defer slackSrv.Close()
+
+	bot := newTestBot(daemon, slackSrv)
+	// github is nil by default in newTestBot.
+
+	bot.handleUnreleasedCommand(context.Background(), slack.SlashCommand{
+		ChannelID: "C123",
+		UserID:    "U456",
+	})
+
+	if postedText == "" {
+		t.Fatal("expected ephemeral message to be posted")
+	}
+	if postedText != ":x: GitHub client not configured (GITHUB_TOKEN not set)" {
+		t.Errorf("unexpected message: %s", postedText)
+	}
+}
+
+func TestHandleUnreleasedCommand_WithRepos(t *testing.T) {
+	daemon := newMockDaemon()
+
+	ghSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/org/myrepo/tags":
+			writeJSON(w, []ghTag{{Name: "2026.60.1"}})
+		case "/repos/org/myrepo/compare/2026.60.1...main":
+			writeJSON(w, ghCompare{
+				AheadBy: 1,
+				Commits: []struct {
+					SHA    string `json:"sha"`
+					Commit struct {
+						Message string `json:"message"`
+						Author  struct {
+							Name string `json:"name"`
+						} `json:"author"`
+					} `json:"commit"`
+				}{
+					{SHA: "abc1234567890", Commit: struct {
+						Message string `json:"message"`
+						Author  struct {
+							Name string `json:"name"`
+						} `json:"author"`
+					}{Message: "fix: something", Author: struct {
+						Name string `json:"name"`
+					}{Name: "Dev"}}},
+				},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ghSrv.Close()
+
+	var ephemeralPosted bool
+	slackSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/chat.postEphemeral" {
+			ephemeralPosted = true
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"ok": true, "message_ts": "1234.5678"})
+	}))
+	defer slackSrv.Close()
+
+	bot := newTestBot(daemon, slackSrv)
+	bot.github = newTestGitHubClient(ghSrv.URL, "")
+	bot.repos = []RepoRef{{Owner: "org", Repo: "myrepo"}}
+	bot.version = "test-v1"
+
+	bot.handleUnreleasedCommand(context.Background(), slack.SlashCommand{
+		ChannelID: "C123",
+		UserID:    "U456",
+	})
+
+	if !ephemeralPosted {
+		t.Error("expected ephemeral message to be posted")
+	}
+}
+
+func TestHandleUnreleasedCommand_UpToDate(t *testing.T) {
+	daemon := newMockDaemon()
+
+	ghSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/org/repo/tags":
+			writeJSON(w, []ghTag{{Name: "2026.61.1"}})
+		case "/repos/org/repo/compare/2026.61.1...main":
+			writeJSON(w, ghCompare{AheadBy: 0})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ghSrv.Close()
+
+	var ephemeralPosted bool
+	slackSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/chat.postEphemeral" {
+			ephemeralPosted = true
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"ok": true, "message_ts": "1234.5678"})
+	}))
+	defer slackSrv.Close()
+
+	bot := newTestBot(daemon, slackSrv)
+	bot.github = newTestGitHubClient(ghSrv.URL, "")
+	bot.repos = []RepoRef{{Owner: "org", Repo: "repo"}}
+	bot.version = "v1"
+
+	bot.handleUnreleasedCommand(context.Background(), slack.SlashCommand{
+		ChannelID: "C123",
+		UserID:    "U456",
+	})
+
+	if !ephemeralPosted {
+		t.Error("expected ephemeral message to be posted")
+	}
+}
+
+func TestHandleUnreleasedCommand_WithControllerVersion(t *testing.T) {
+	daemon := newMockDaemon()
+
+	ctrlSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/version" {
+			writeJSON(w, controllerVersionInfo{
+				Version:    "v3.0.0",
+				Commit:     "deadbeef12345678",
+				AgentImage: "agent:latest",
+				Namespace:  "gasboat",
+			})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer ctrlSrv.Close()
+
+	ghSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	}))
+	defer ghSrv.Close()
+
+	var ephemeralPosted bool
+	slackSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/chat.postEphemeral" {
+			ephemeralPosted = true
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"ok": true, "message_ts": "1234.5678"})
+	}))
+	defer slackSrv.Close()
+
+	bot := newTestBot(daemon, slackSrv)
+	bot.github = newTestGitHubClient(ghSrv.URL, "")
+	bot.controllerURL = ctrlSrv.URL
+	bot.version = "v1"
+
+	bot.handleUnreleasedCommand(context.Background(), slack.SlashCommand{
+		ChannelID: "C123",
+		UserID:    "U456",
+	})
+
+	if !ephemeralPosted {
+		t.Error("expected ephemeral message to be posted")
+	}
+}

--- a/gasboat/controller/internal/bridge/claimed_extra_test.go
+++ b/gasboat/controller/internal/bridge/claimed_extra_test.go
@@ -1,0 +1,262 @@
+package bridge
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"gasboat/controller/internal/beadsapi"
+)
+
+func TestClaimed_NudgeAgent_AgentNotFound(t *testing.T) {
+	daemon := newMockDaemon()
+	// No agent bead seeded — FindAgentBead will fail.
+
+	c := &Claimed{
+		daemon:     daemon,
+		logger:     slog.Default(),
+		httpClient: &http.Client{Timeout: 5 * time.Second},
+		nudged:     make(map[string]time.Time),
+	}
+
+	// nudgeAgent should log error but not panic.
+	c.nudgeAgent(context.Background(), BeadEvent{
+		ID:       "kd-abc",
+		Type:     "task",
+		Title:    "Some task",
+		Assignee: "nonexistent-agent",
+	})
+	// No panic = pass.
+}
+
+func TestClaimed_NudgeAgent_NoCoopURL(t *testing.T) {
+	daemon := newMockDaemon()
+	// Agent exists but has no coop_url in notes.
+	daemon.beads["my-agent"] = &beadsapi.BeadDetail{
+		ID:    "my-agent",
+		Notes: "", // empty notes
+	}
+
+	c := &Claimed{
+		daemon:     daemon,
+		logger:     slog.Default(),
+		httpClient: &http.Client{Timeout: 5 * time.Second},
+		nudged:     make(map[string]time.Time),
+	}
+
+	c.nudgeAgent(context.Background(), BeadEvent{
+		ID:       "kd-abc",
+		Type:     "task",
+		Title:    "Some task",
+		Assignee: "my-agent",
+	})
+	// No panic = pass; should log error about missing coop_url.
+}
+
+func TestClaimed_NudgeAgent_Success(t *testing.T) {
+	var nudgeMu sync.Mutex
+	var nudgeMessage string
+
+	coopServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/agent/nudge" {
+			var body map[string]string
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			nudgeMu.Lock()
+			nudgeMessage = body["message"]
+			nudgeMu.Unlock()
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer coopServer.Close()
+
+	daemon := newMockDaemon()
+	daemon.beads["my-agent"] = &beadsapi.BeadDetail{
+		ID:    "my-agent",
+		Notes: "coop_url: " + coopServer.URL,
+	}
+
+	c := &Claimed{
+		daemon:     daemon,
+		logger:     slog.Default(),
+		httpClient: &http.Client{Timeout: 5 * time.Second},
+		nudged:     make(map[string]time.Time),
+	}
+
+	c.nudgeAgent(context.Background(), BeadEvent{
+		ID:       "kd-abc",
+		Type:     "task",
+		Title:    "Fix the bug",
+		Assignee: "my-agent",
+	})
+
+	time.Sleep(50 * time.Millisecond)
+	nudgeMu.Lock()
+	msg := nudgeMessage
+	nudgeMu.Unlock()
+
+	if msg == "" {
+		t.Fatal("expected nudge to be sent")
+	}
+	want := `Your claimed bead kd-abc "Fix the bug" was updated — run 'kd show kd-abc' to review`
+	if msg != want {
+		t.Errorf("unexpected nudge message:\n  got:  %s\n  want: %s", msg, want)
+	}
+}
+
+func TestClaimed_HandleClosed_AgentNotFound(t *testing.T) {
+	daemon := newMockDaemon()
+	// No agent bead — FindAgentBead will fail.
+
+	c := &Claimed{
+		daemon:     daemon,
+		logger:     slog.Default(),
+		httpClient: &http.Client{Timeout: 5 * time.Second},
+		nudged:     make(map[string]time.Time),
+	}
+
+	data := marshalSSEBeadPayload(BeadEvent{
+		ID:       "kd-closed",
+		Type:     "task",
+		Title:    "Closed task",
+		Assignee: "nonexistent-agent",
+	})
+	c.handleClosed(context.Background(), data)
+	// Should not panic; logs error and returns.
+}
+
+func TestClaimed_HandleClosed_NoCoopURL(t *testing.T) {
+	daemon := newMockDaemon()
+	daemon.beads["my-agent"] = &beadsapi.BeadDetail{
+		ID:    "my-agent",
+		Notes: "", // no coop_url
+	}
+
+	c := &Claimed{
+		daemon:     daemon,
+		logger:     slog.Default(),
+		httpClient: &http.Client{Timeout: 5 * time.Second},
+		nudged:     make(map[string]time.Time),
+	}
+
+	data := marshalSSEBeadPayload(BeadEvent{
+		ID:       "kd-closed-2",
+		Type:     "task",
+		Title:    "Closed task",
+		Assignee: "my-agent",
+	})
+	c.handleClosed(context.Background(), data)
+	// Should not panic; logs warning about missing coop_url.
+}
+
+func TestClaimed_HandleClosed_CoopNudgeFails(t *testing.T) {
+	coopServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Return 500 to simulate failure.
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer coopServer.Close()
+
+	daemon := newMockDaemon()
+	daemon.beads["my-agent"] = &beadsapi.BeadDetail{
+		ID:    "my-agent",
+		Notes: "coop_url: " + coopServer.URL,
+	}
+
+	c := &Claimed{
+		daemon:     daemon,
+		logger:     slog.Default(),
+		httpClient: &http.Client{Timeout: 5 * time.Second},
+		nudged:     make(map[string]time.Time),
+	}
+
+	data := marshalSSEBeadPayload(BeadEvent{
+		ID:       "kd-closed-fail",
+		Type:     "task",
+		Title:    "Closed task",
+		Assignee: "my-agent",
+	})
+	c.handleClosed(context.Background(), data)
+	// Should not panic; logs error about nudge failure.
+}
+
+func TestClaimed_HandleClosed_RateLimitedSecondCall(t *testing.T) {
+	nudgeCount := 0
+	var mu sync.Mutex
+
+	coopServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/agent/nudge" {
+			mu.Lock()
+			nudgeCount++
+			mu.Unlock()
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer coopServer.Close()
+
+	daemon := newMockDaemon()
+	daemon.beads["my-agent"] = &beadsapi.BeadDetail{
+		ID:    "my-agent",
+		Notes: "coop_url: " + coopServer.URL,
+	}
+
+	c := &Claimed{
+		daemon:     daemon,
+		logger:     slog.Default(),
+		httpClient: &http.Client{Timeout: 5 * time.Second},
+		nudged:     make(map[string]time.Time),
+	}
+
+	data := marshalSSEBeadPayload(BeadEvent{
+		ID:       "kd-closed-rl",
+		Type:     "task",
+		Title:    "Rate limited close",
+		Assignee: "my-agent",
+	})
+
+	// First call: nudge fires.
+	c.handleClosed(context.Background(), data)
+	time.Sleep(50 * time.Millisecond)
+
+	// Second call within TTL: should be rate-limited.
+	c.handleClosed(context.Background(), data)
+	time.Sleep(50 * time.Millisecond)
+
+	mu.Lock()
+	count := nudgeCount
+	mu.Unlock()
+
+	if count != 1 {
+		t.Errorf("expected 1 nudge (rate limited), got %d", count)
+	}
+}
+
+func TestClaimed_ShouldNudge_CleansUpExpired(t *testing.T) {
+	c := &Claimed{
+		logger: slog.Default(),
+		nudged: make(map[string]time.Time),
+	}
+
+	// Manually insert an expired entry.
+	c.nudgedMu.Lock()
+	c.nudged["old-bead"] = time.Now().Add(-10 * time.Minute)
+	c.nudgedMu.Unlock()
+
+	// Call shouldNudge for a new bead — should clean up the expired entry.
+	c.shouldNudge("new-bead")
+
+	c.nudgedMu.Lock()
+	_, oldExists := c.nudged["old-bead"]
+	c.nudgedMu.Unlock()
+
+	if oldExists {
+		t.Error("expected expired entry to be cleaned up")
+	}
+}

--- a/gasboat/controller/internal/bridge/dashboard_extra_test.go
+++ b/gasboat/controller/internal/bridge/dashboard_extra_test.go
@@ -1,0 +1,662 @@
+package bridge
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"gasboat/controller/internal/beadsapi"
+
+	"github.com/slack-go/slack"
+)
+
+// --- Block builder tests ---
+
+func TestDashboardAgentWorkingBlock_Basic(t *testing.T) {
+	a := beadsapi.AgentBead{
+		AgentName: "hq",
+		Project:   "gasboat",
+		Mode:      "crew",
+		Role:      "lead",
+		Metadata:  map[string]string{},
+	}
+	block := dashboardAgentWorkingBlock(a, "")
+	section, ok := block.(*slack.SectionBlock)
+	if !ok {
+		t.Fatalf("expected *slack.SectionBlock, got %T", block)
+	}
+	text := section.Text.Text
+	if !strings.Contains(text, ":large_green_circle:") {
+		t.Error("expected green circle emoji in working block")
+	}
+	if !strings.Contains(text, "hq") {
+		t.Error("expected agent name in working block")
+	}
+	if !strings.Contains(text, "gasboat") {
+		t.Error("expected project in working block")
+	}
+	if !strings.Contains(text, "crew/lead") {
+		t.Error("expected mode/role in working block")
+	}
+}
+
+func TestDashboardAgentWorkingBlock_WithCoopmuxURL(t *testing.T) {
+	a := beadsapi.AgentBead{
+		AgentName: "hq",
+		Project:   "gasboat",
+		Metadata:  map[string]string{"pod_name": "agent-hq-abc"},
+	}
+	block := dashboardAgentWorkingBlock(a, "https://coopmux.example.com")
+	section := block.(*slack.SectionBlock)
+	text := section.Text.Text
+	if !strings.Contains(text, "https://coopmux.example.com#agent-hq-abc") {
+		t.Errorf("expected coopmux link in working block, got %s", text)
+	}
+}
+
+func TestDashboardAgentWorkingBlock_NoProjectNoRole(t *testing.T) {
+	a := beadsapi.AgentBead{
+		AgentName: "hq",
+		Metadata:  map[string]string{},
+	}
+	block := dashboardAgentWorkingBlock(a, "")
+	section := block.(*slack.SectionBlock)
+	text := section.Text.Text
+	if strings.Contains(text, "·") {
+		t.Errorf("expected no separator when no project/role, got %s", text)
+	}
+}
+
+func TestDashboardAgentStartingBlock_Basic(t *testing.T) {
+	a := beadsapi.AgentBead{
+		AgentName: "new-bot",
+		Project:   "gasboat",
+	}
+	block := dashboardAgentStartingBlock(a)
+	section, ok := block.(*slack.SectionBlock)
+	if !ok {
+		t.Fatalf("expected *slack.SectionBlock, got %T", block)
+	}
+	text := section.Text.Text
+	if !strings.Contains(text, ":hourglass_flowing_sand:") {
+		t.Error("expected hourglass emoji in starting block")
+	}
+	if !strings.Contains(text, "new-bot") {
+		t.Error("expected agent name in starting block")
+	}
+	if !strings.Contains(text, "gasboat") {
+		t.Error("expected project in starting block")
+	}
+}
+
+func TestDashboardAgentStartingBlock_NoProject(t *testing.T) {
+	a := beadsapi.AgentBead{AgentName: "new-bot"}
+	block := dashboardAgentStartingBlock(a)
+	section := block.(*slack.SectionBlock)
+	if strings.Contains(section.Text.Text, "·") {
+		t.Error("expected no separator when no project")
+	}
+}
+
+func TestDashboardAgentIdleBlock_NoPending(t *testing.T) {
+	a := beadsapi.AgentBead{
+		AgentName: "idle-bot",
+		Project:   "gasboat",
+		Metadata:  map[string]string{},
+	}
+	block := dashboardAgentIdleBlock(a, 0, "")
+	section := block.(*slack.SectionBlock)
+	text := section.Text.Text
+	if !strings.Contains(text, ":white_circle:") {
+		t.Error("expected white circle for idle agent with no pending decisions")
+	}
+	if strings.Contains(text, "pending") {
+		t.Error("expected no 'pending' text when pendingCount=0")
+	}
+}
+
+func TestDashboardAgentIdleBlock_WithPending(t *testing.T) {
+	a := beadsapi.AgentBead{
+		AgentName: "idle-bot",
+		Project:   "gasboat",
+		Metadata:  map[string]string{},
+	}
+	block := dashboardAgentIdleBlock(a, 3, "")
+	section := block.(*slack.SectionBlock)
+	text := section.Text.Text
+	if !strings.Contains(text, ":large_blue_circle:") {
+		t.Error("expected blue circle for idle agent with pending decisions")
+	}
+	if !strings.Contains(text, "3 pending") {
+		t.Error("expected '3 pending' in idle block with pending decisions")
+	}
+}
+
+func TestDashboardAgentIdleBlock_WithCoopmuxURL(t *testing.T) {
+	a := beadsapi.AgentBead{
+		AgentName: "idle-bot",
+		Metadata:  map[string]string{"pod_name": "pod-idle"},
+	}
+	block := dashboardAgentIdleBlock(a, 0, "https://coopmux.example.com")
+	section := block.(*slack.SectionBlock)
+	if !strings.Contains(section.Text.Text, "https://coopmux.example.com#pod-idle") {
+		t.Error("expected coopmux link in idle block")
+	}
+}
+
+func TestDashboardAgentDeadBlock_Done(t *testing.T) {
+	a := beadsapi.AgentBead{
+		AgentName:  "done-bot",
+		AgentState: "done",
+		Project:    "gasboat",
+		Metadata:   map[string]string{},
+	}
+	block := dashboardAgentDeadBlock(a, "")
+	section := block.(*slack.SectionBlock)
+	text := section.Text.Text
+	if !strings.Contains(text, ":white_check_mark:") {
+		t.Error("expected checkmark emoji for done agent")
+	}
+	if !strings.Contains(text, "done") {
+		t.Error("expected 'done' state text")
+	}
+}
+
+func TestDashboardAgentDeadBlock_RateLimited(t *testing.T) {
+	a := beadsapi.AgentBead{
+		AgentName:  "limited-bot",
+		AgentState: "rate_limited",
+		Metadata:   map[string]string{},
+	}
+	block := dashboardAgentDeadBlock(a, "")
+	section := block.(*slack.SectionBlock)
+	text := section.Text.Text
+	if !strings.Contains(text, ":warning:") {
+		t.Error("expected warning emoji for rate_limited agent")
+	}
+}
+
+func TestDashboardAgentDeadBlock_Failed(t *testing.T) {
+	a := beadsapi.AgentBead{
+		AgentName:  "dead-bot",
+		AgentState: "failed",
+		Project:    "gasboat",
+		Metadata:   map[string]string{},
+	}
+	block := dashboardAgentDeadBlock(a, "")
+	section := block.(*slack.SectionBlock)
+	text := section.Text.Text
+	if !strings.Contains(text, ":red_circle:") {
+		t.Error("expected red circle emoji for failed agent")
+	}
+}
+
+func TestDashboardAgentDeadBlock_EmptyState_FallsToPodPhase(t *testing.T) {
+	a := beadsapi.AgentBead{
+		AgentName:  "dead-bot",
+		AgentState: "",
+		PodPhase:   "failed",
+		Metadata:   map[string]string{},
+	}
+	block := dashboardAgentDeadBlock(a, "")
+	section := block.(*slack.SectionBlock)
+	text := section.Text.Text
+	if !strings.Contains(text, "failed") {
+		t.Error("expected pod phase 'failed' as fallback state text")
+	}
+}
+
+func TestDashboardAgentDeadBlock_WithCoopmuxURL(t *testing.T) {
+	a := beadsapi.AgentBead{
+		AgentName:  "dead-bot",
+		AgentState: "done",
+		Metadata:   map[string]string{"pod_name": "pod-dead"},
+	}
+	block := dashboardAgentDeadBlock(a, "https://coopmux.example.com")
+	section := block.(*slack.SectionBlock)
+	if !strings.Contains(section.Text.Text, "https://coopmux.example.com#pod-dead") {
+		t.Error("expected coopmux link in dead block")
+	}
+}
+
+// --- renderBlocks tests ---
+
+func TestRenderBlocks_EmptyAgents(t *testing.T) {
+	d := &Dashboard{cfg: DashboardConfig{}}
+	blocks, hash := d.renderBlocks(nil, nil)
+
+	if len(blocks) < 2 {
+		t.Fatalf("expected at least 2 blocks (header + summary), got %d", len(blocks))
+	}
+	if hash != "" {
+		t.Errorf("expected empty hash for no agents, got %q", hash)
+	}
+
+	section, ok := blocks[0].(*slack.SectionBlock)
+	if !ok {
+		t.Fatalf("expected header to be *slack.SectionBlock, got %T", blocks[0])
+	}
+	if !strings.Contains(section.Text.Text, dashboardMarker) {
+		t.Error("expected dashboard marker in header block")
+	}
+}
+
+func TestRenderBlocks_MixedAgents(t *testing.T) {
+	agents := []beadsapi.AgentBead{
+		{ID: "bd-1", AgentName: "worker-1", AgentState: "working", Project: "gasboat", Metadata: map[string]string{}},
+		{ID: "bd-2", AgentName: "idle-1", AgentState: "", Project: "gasboat", Metadata: map[string]string{}},
+		{ID: "bd-3", AgentName: "dead-1", AgentState: "done", Project: "gasboat", Metadata: map[string]string{}},
+		{ID: "bd-4", AgentName: "spawn-1", AgentState: "spawning", Project: "gasboat", Metadata: map[string]string{}},
+	}
+
+	d := &Dashboard{cfg: DashboardConfig{}}
+	blocks, hash := d.renderBlocks(agents, nil)
+
+	if len(blocks) < 4 {
+		t.Fatalf("expected many blocks for mixed agents, got %d", len(blocks))
+	}
+	if hash == "" {
+		t.Error("expected non-empty hash for agents")
+	}
+
+	allText := blocksToText(blocks)
+	if !strings.Contains(allText, "Working (1)") {
+		t.Error("expected Working section header")
+	}
+	if !strings.Contains(allText, "Idle (1)") {
+		t.Error("expected Idle section header")
+	}
+	if !strings.Contains(allText, "Stopped (1)") {
+		t.Error("expected Stopped section header")
+	}
+	if !strings.Contains(allText, "Starting (1)") {
+		t.Error("expected Starting section header")
+	}
+}
+
+func TestRenderBlocks_WithDecisions(t *testing.T) {
+	agents := []beadsapi.AgentBead{
+		{ID: "bd-1", AgentName: "worker-1", AgentState: "working", Project: "gasboat", Metadata: map[string]string{}},
+	}
+	decisions := []*beadsapi.BeadDetail{
+		{
+			ID:       "dec-1",
+			Title:    "Approve deployment",
+			Fields:   map[string]string{"requesting_agent_bead_id": "bd-1"},
+			Assignee: "worker-1",
+		},
+	}
+
+	d := &Dashboard{cfg: DashboardConfig{}}
+	blocks, _ := d.renderBlocks(agents, decisions)
+
+	allText := blocksToText(blocks)
+	if !strings.Contains(allText, "Pending Decisions (1)") {
+		t.Error("expected Pending Decisions section")
+	}
+	if !strings.Contains(allText, "dec-1") {
+		t.Error("expected decision ID in output")
+	}
+}
+
+func TestRenderBlocks_DecisionWithEscalatedLabel(t *testing.T) {
+	decisions := []*beadsapi.BeadDetail{
+		{
+			ID:     "dec-esc",
+			Title:  "Urgent approval",
+			Fields: map[string]string{},
+			Labels: []string{"escalated"},
+		},
+	}
+
+	d := &Dashboard{cfg: DashboardConfig{}}
+	blocks, _ := d.renderBlocks(nil, decisions)
+
+	allText := blocksToText(blocks)
+	if !strings.Contains(allText, ":rotating_light:") {
+		t.Error("expected rotating_light emoji for escalated decision")
+	}
+}
+
+func TestRenderBlocks_DecisionQuestionTruncation(t *testing.T) {
+	longQuestion := strings.Repeat("x", 100)
+	decisions := []*beadsapi.BeadDetail{
+		{
+			ID:     "dec-long",
+			Title:  "fallback title",
+			Fields: map[string]string{"question": longQuestion},
+		},
+	}
+
+	d := &Dashboard{cfg: DashboardConfig{}}
+	blocks, _ := d.renderBlocks(nil, decisions)
+
+	allText := blocksToText(blocks)
+	if !strings.Contains(allText, "...") {
+		t.Error("expected truncation ellipsis for long question")
+	}
+}
+
+func TestRenderBlocks_DecisionFallsBackToTitle(t *testing.T) {
+	decisions := []*beadsapi.BeadDetail{
+		{
+			ID:     "dec-notitle",
+			Title:  "My title",
+			Fields: map[string]string{},
+		},
+	}
+
+	d := &Dashboard{cfg: DashboardConfig{}}
+	blocks, _ := d.renderBlocks(nil, decisions)
+
+	allText := blocksToText(blocks)
+	if !strings.Contains(allText, "My title") {
+		t.Error("expected decision title as fallback when no question field")
+	}
+}
+
+func TestRenderBlocks_OverflowMessages(t *testing.T) {
+	var agents []beadsapi.AgentBead
+	for i := 0; i < 15; i++ {
+		agents = append(agents, beadsapi.AgentBead{
+			ID:         "bd-" + string(rune('a'+i)),
+			AgentName:  "worker-" + string(rune('a'+i)),
+			AgentState: "working",
+			Project:    "gasboat",
+			Metadata:   map[string]string{},
+		})
+	}
+
+	d := &Dashboard{cfg: DashboardConfig{MaxWorkingShown: 3}}
+	blocks, _ := d.renderBlocks(agents, nil)
+
+	allText := blocksToText(blocks)
+	if !strings.Contains(allText, "+12 more working agents") {
+		t.Errorf("expected overflow message for working agents, got: %s", allText)
+	}
+}
+
+func TestRenderBlocks_IdleOverflow(t *testing.T) {
+	var agents []beadsapi.AgentBead
+	for i := 0; i < 10; i++ {
+		agents = append(agents, beadsapi.AgentBead{
+			ID:        "bd-idle-" + string(rune('a'+i)),
+			AgentName: "idle-" + string(rune('a'+i)),
+			Metadata:  map[string]string{},
+		})
+	}
+
+	d := &Dashboard{cfg: DashboardConfig{MaxIdleShown: 2}}
+	blocks, _ := d.renderBlocks(agents, nil)
+
+	allText := blocksToText(blocks)
+	if !strings.Contains(allText, "+8 more idle agents") {
+		t.Errorf("expected idle overflow message, got: %s", allText)
+	}
+}
+
+func TestRenderBlocks_DeadOverflow(t *testing.T) {
+	var agents []beadsapi.AgentBead
+	for i := 0; i < 8; i++ {
+		agents = append(agents, beadsapi.AgentBead{
+			ID:         "bd-dead-" + string(rune('a'+i)),
+			AgentName:  "dead-" + string(rune('a'+i)),
+			AgentState: "done",
+			Metadata:   map[string]string{},
+		})
+	}
+
+	d := &Dashboard{cfg: DashboardConfig{MaxDeadShown: 2}}
+	blocks, _ := d.renderBlocks(agents, nil)
+
+	allText := blocksToText(blocks)
+	if !strings.Contains(allText, "+6 more dead agents") {
+		t.Errorf("expected dead overflow message, got: %s", allText)
+	}
+}
+
+func TestRenderBlocks_DecisionsOverflow(t *testing.T) {
+	var decisions []*beadsapi.BeadDetail
+	for i := 0; i < 8; i++ {
+		decisions = append(decisions, &beadsapi.BeadDetail{
+			ID:     "dec-" + string(rune('a'+i)),
+			Title:  "Decision " + string(rune('a'+i)),
+			Fields: map[string]string{},
+		})
+	}
+
+	d := &Dashboard{cfg: DashboardConfig{MaxDecisionsShown: 3}}
+	blocks, _ := d.renderBlocks(nil, decisions)
+
+	allText := blocksToText(blocks)
+	if !strings.Contains(allText, "+5 more pending decisions") {
+		t.Errorf("expected decisions overflow message, got: %s", allText)
+	}
+}
+
+// --- buildBlocks tests (requires real beadsapi.Client via httptest) ---
+
+func TestBuildBlocks_Success(t *testing.T) {
+	// Mock beads daemon that returns agent and decision listings.
+	daemonSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"beads": []map[string]any{
+				{
+					"id":    "bd-agent-1",
+					"title": "hq",
+					"type":  "agent",
+					"fields": map[string]any{
+						"agent":       "hq",
+						"project":     "gasboat",
+						"role":        "crew",
+						"agent_state": "working",
+					},
+				},
+			},
+			"total": 1,
+		})
+	}))
+	defer daemonSrv.Close()
+
+	daemon, err := beadsapi.New(beadsapi.Config{HTTPAddr: daemonSrv.URL})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	slackSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"ok": true})
+	}))
+	defer slackSrv.Close()
+
+	api := slack.New("xoxb-test", slack.OptionAPIURL(slackSrv.URL+"/"))
+	d := &Dashboard{
+		api:    api,
+		daemon: daemon,
+		cfg:    DashboardConfig{ChannelID: "C123"},
+	}
+
+	blocks, hash, buildErr := d.buildBlocks(t.Context())
+	if buildErr != nil {
+		t.Fatalf("buildBlocks returned error: %v", buildErr)
+	}
+	if len(blocks) == 0 {
+		t.Error("expected non-empty blocks from buildBlocks")
+	}
+	if hash == "" {
+		t.Error("expected non-empty hash from buildBlocks")
+	}
+}
+
+// --- Hash tests ---
+
+func TestBuildDashboardHash_WithDecisions(t *testing.T) {
+	agents := []beadsapi.AgentBead{
+		{ID: "bd-1", AgentName: "bot-1", AgentState: "", Project: "gasboat"},
+	}
+	decisions := []*beadsapi.BeadDetail{
+		{ID: "dec-1", Fields: map[string]string{"requesting_agent_bead_id": "bd-1"}},
+	}
+
+	hashWithDec := buildDashboardHash(agents, decisions)
+	hashWithoutDec := buildDashboardHash(agents, nil)
+
+	if hashWithDec == hashWithoutDec {
+		t.Error("hash with decisions should differ from hash without")
+	}
+	if !strings.Contains(hashWithDec, "decision:1") {
+		t.Errorf("expected 'decision:1' in hash, got %q", hashWithDec)
+	}
+}
+
+func TestBuildDashboardHash_SpawningState(t *testing.T) {
+	agents := []beadsapi.AgentBead{
+		{ID: "bd-1", AgentName: "bot-1", AgentState: "spawning", Project: "gasboat"},
+	}
+
+	hash := buildDashboardHash(agents, nil)
+	if !strings.Contains(hash, "starting") {
+		t.Errorf("expected 'starting' in hash for spawning agent, got %q", hash)
+	}
+}
+
+func TestBuildDashboardHash_PodPhaseFailed(t *testing.T) {
+	agents := []beadsapi.AgentBead{
+		{ID: "bd-1", AgentName: "bot-1", AgentState: "", PodPhase: "failed", Project: "gasboat"},
+	}
+
+	hash := buildDashboardHash(agents, nil)
+	if !strings.Contains(hash, "dead") {
+		t.Errorf("expected 'dead' in hash for pod phase failed, got %q", hash)
+	}
+}
+
+// --- MarkDirty test ---
+
+func TestDashboard_MarkDirty(t *testing.T) {
+	d := &Dashboard{}
+	d.MarkDirty()
+
+	d.mu.Lock()
+	dirty := d.dirty
+	d.mu.Unlock()
+
+	if !dirty {
+		t.Error("expected dirty=true after MarkDirty()")
+	}
+}
+
+// --- NewDashboard tests ---
+
+func TestNewDashboard_NoChannel_DisablesItself(t *testing.T) {
+	slackSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"ok": true})
+	}))
+	defer slackSrv.Close()
+
+	api := slack.New("xoxb-test", slack.OptionAPIURL(slackSrv.URL+"/"))
+	daemonSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"beads": []any{}, "total": 0})
+	}))
+	defer daemonSrv.Close()
+	daemon, _ := beadsapi.New(beadsapi.Config{HTTPAddr: daemonSrv.URL})
+
+	d := NewDashboard(api, daemon, nil, slog.Default(), DashboardConfig{
+		Enabled:   true,
+		ChannelID: "",
+	})
+	if d.cfg.Enabled {
+		t.Error("expected dashboard to be disabled when no channel configured")
+	}
+}
+
+func TestNewDashboard_WithChannel_StaysEnabled(t *testing.T) {
+	slackSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"ok": true})
+	}))
+	defer slackSrv.Close()
+
+	api := slack.New("xoxb-test", slack.OptionAPIURL(slackSrv.URL+"/"))
+	daemonSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"beads": []any{}, "total": 0})
+	}))
+	defer daemonSrv.Close()
+	daemon, _ := beadsapi.New(beadsapi.Config{HTTPAddr: daemonSrv.URL})
+
+	d := NewDashboard(api, daemon, nil, slog.Default(), DashboardConfig{
+		Enabled:   true,
+		ChannelID: "C123",
+	})
+	if !d.cfg.Enabled {
+		t.Error("expected dashboard to stay enabled when channel configured")
+	}
+}
+
+// --- Classification sorting tests ---
+
+func TestRenderBlocks_AgentClassification(t *testing.T) {
+	agents := []beadsapi.AgentBead{
+		{ID: "1", AgentName: "a-failed", AgentState: "failed", Metadata: map[string]string{}},
+		{ID: "2", AgentName: "b-pod-failed", PodPhase: "failed", Metadata: map[string]string{}},
+		{ID: "3", AgentName: "c-rate-limited", AgentState: "rate_limited", Metadata: map[string]string{}},
+	}
+
+	d := &Dashboard{cfg: DashboardConfig{}}
+	blocks, _ := d.renderBlocks(agents, nil)
+
+	allText := blocksToText(blocks)
+	if !strings.Contains(allText, "Stopped (3)") {
+		t.Errorf("expected 3 stopped agents, got: %s", allText)
+	}
+}
+
+// --- StartingOverflow test ---
+
+func TestRenderBlocks_StartingOverflow(t *testing.T) {
+	var agents []beadsapi.AgentBead
+	for i := 0; i < 8; i++ {
+		agents = append(agents, beadsapi.AgentBead{
+			ID:         "bd-start-" + string(rune('a'+i)),
+			AgentName:  "start-" + string(rune('a'+i)),
+			AgentState: "spawning",
+			Metadata:   map[string]string{},
+		})
+	}
+
+	d := &Dashboard{cfg: DashboardConfig{MaxIdleShown: 2}} // starting uses MaxIdleShown
+	blocks, _ := d.renderBlocks(agents, nil)
+
+	allText := blocksToText(blocks)
+	if !strings.Contains(allText, "+6 more starting agents") {
+		t.Errorf("expected starting overflow message, got: %s", allText)
+	}
+}
+
+// --- helpers ---
+
+func blocksToText(blocks []slack.Block) string {
+	var parts []string
+	for _, b := range blocks {
+		switch v := b.(type) {
+		case *slack.SectionBlock:
+			if v.Text != nil {
+				parts = append(parts, v.Text.Text)
+			}
+		case *slack.ContextBlock:
+			for _, el := range v.ContextElements.Elements {
+				if txt, ok := el.(*slack.TextBlockObject); ok {
+					parts = append(parts, txt.Text)
+				}
+			}
+		}
+	}
+	return strings.Join(parts, " | ")
+}

--- a/gasboat/controller/internal/bridge/decisions_mock_test.go
+++ b/gasboat/controller/internal/bridge/decisions_mock_test.go
@@ -163,6 +163,9 @@ func (m *mockDaemon) ListProjectBeads(_ context.Context) (map[string]beadsapi.Pr
 				if ch := b.Fields["slack_channel"]; ch != "" {
 					info.SlackChannels = []string{ch}
 				}
+				if prefix := b.Fields["prefix"]; prefix != "" {
+					info.Prefix = prefix
+				}
 			}
 			result[b.Title] = info
 		}

--- a/gasboat/docs/audit-2026-068-complexity-drift.md
+++ b/gasboat/docs/audit-2026-068-complexity-drift.md
@@ -1,0 +1,269 @@
+# Gasboat Complexity & Drift Audit
+
+**Date**: 2026-03-09 (Day 068)
+**Scope**: Go controller, Helm chart, build systems, test coverage, package identity
+
+---
+
+## Executive Summary
+
+Gasboat is a **67K-line Go codebase** (37K source, 30K test) across 12 internal packages and 7 command binaries. The architecture is **well-layered** with zero circular dependencies and clean separation of concerns. However, three areas demand attention:
+
+1. **The bridge package is a monolith** — 49 source files, 15K lines, doing Slack bot + GitHub + GitLab + JIRA + Wasteland + SSE multiplexing + IP gating in a single Go package.
+2. **Build system drift** — Dockerfile pins specific versions for coop/kbeads but RWX CI overrides them with `latest`, producing different images locally vs CI.
+3. **Test gaps in the most-churned code** — the files that change most often (bot.go, bot_commands.go, bot_decisions.go, bot_agents.go) have zero test coverage.
+
+---
+
+## 1. Package Identity Map
+
+The codebase has a clean 5-layer architecture with no circular dependencies:
+
+```diagram
+Layer 5: Entry Points
+  cmd/controller/     cmd/slack-bridge/     cmd/gb/
+  cmd/gitlab-bridge/  cmd/jira-bridge/      cmd/wl-bridge/
+  cmd/advice-viewer/
+
+Layer 4: Orchestration
+  reconciler ──→ beadsapi, config, podmanager
+  statusreporter ──→ podmanager, reconciler (IsPodReady only)
+  bridge ──→ beadsapi (K8s optional via gate.go only)
+
+Layer 3: Domain Logic
+  poolmanager ──→ beadsapi, config
+  scheduler ──→ beadsapi
+  subscriber ──→ beadsapi
+  advice ──→ beadsapi
+  secretreconciler ──→ config
+  tui/decision ──→ beadsapi, advice
+
+Layer 2: Configuration
+  config ──→ beadsapi (types only)
+
+Layer 1: Foundation (zero internal deps)
+  beadsapi     podmanager
+```
+
+**Key finding**: Bridge is genuinely K8s-independent as claimed — only `gate.go` (Bouncer for Traefik IP whitelisting) imports k8s.io, and it's optional with graceful degradation.
+
+### Package Size Distribution
+
+| Package | Source Lines | Test Lines | Ratio | Files |
+|---------|-------------|------------|-------|-------|
+| bridge | 15,436 | 14,307 | 0.93 | 49 src |
+| beadsapi | 1,563 | 3,077 | 1.97 | 12 src |
+| reconciler | 1,206 | 1,235 | 1.02 | 5 src |
+| podmanager | 1,050 | 1,746 | 1.66 | 3 src |
+| tui/decision | 1,047 | 610 | 0.58 | 4 src |
+| scheduler | 490 | 167 | 0.34 | 2 src |
+| poolmanager | 485 | 346 | 0.71 | 1 src |
+| subscriber | 473 | 714 | 1.51 | 2 src |
+| advice | 421 | 375 | 0.89 | 3 src |
+| config | 393 | 211 | 0.54 | 1 src |
+| statusreporter | 295 | 933 | 3.16 | 1 src |
+| secretreconciler | 219 | 283 | 1.29 | 1 src |
+
+Bridge is 10x larger than the next biggest package and contains 49 source files — more than all other packages combined.
+
+---
+
+## 2. Complexity Hotspots
+
+### Longest Functions (top 10)
+
+| Lines | Location | Function | Risk |
+|-------|----------|----------|------|
+| 330 | bridge/init.go:67 | `configs()` | Schema drift — massive map literal defining all bead types/views |
+| 266 | bridge/bot_decisions.go:39 | `NotifyDecision()` | Deep nesting, mixed concerns (Slack API + bead state + threading) |
+| 228 | bridge/init_prompts.go:6 | `configBeadEntries()` | Static config data — low risk but hard to review |
+| 221 | reconciler/reconciler.go:109 | `Reconcile()` | Core loop — orphan deletion + drift detection + pod creation in one func |
+| 210 | bridge/dashboard.go:160 | dashboard rendering | Complex Slack block construction |
+| 190 | bridge/bot_mentions.go:25 | mention handler | Multi-path agent routing with 5+ fallback strategies |
+| 155 | bridge/bot_mentions.go:342 | thread reply handler | Nested conditionals for thread management |
+| 152 | podmanager/initclone.go:20 | `InitCloneScript()` | Shell script generation via fmt.Sprintf — fragile |
+| 141 | bridge/gitlab_sync.go:394 | `GitLabWebhookHandler` | Webhook parsing + sync logic mixed |
+| 131 | tui/decision/model.go:233 | `Update()` | Bubbletea state machine |
+
+### Structural Concerns
+
+**Magic strings for bead field access**: Fields like `agent_state`, `pod_phase`, `project` are accessed via `bead.Fields["agent_state"]` across 20+ files. No typed accessor, no compile-time safety.
+
+**Shell script generation in Go**: `initclone.go` builds multi-line bash scripts via `fmt.Sprintf`. Changes to the script require understanding both Go string escaping and bash semantics.
+
+**Reconciler mixes phases**: `Reconcile()` handles orphan deletion, drift detection, and pod creation in one 221-line function. Each phase has different failure modes that get mixed together.
+
+---
+
+## 3. Git Churn Analysis
+
+Most frequently changed files in the last 2 months:
+
+| Changes | File | Why |
+|---------|------|-----|
+| 96 | helm/gasboat/Chart.yaml | Release bumps (calver) |
+| 68 | helm/gasboat/values.yaml | New features, config updates |
+| 67 | images/agent/entrypoint.sh | Agent bootstrapping evolution |
+| 61 | **bridge/bot.go** | Core bot logic, new features |
+| 59 | images/agent/Dockerfile | Tool version updates |
+| 47 | beadsapi/client.go | API evolution, new endpoints |
+| 38 | bridge/init.go | New config types/views |
+| 38 | cmd/slack-bridge/main.go | Startup wiring |
+| 37 | cmd/controller/podspec.go | Pod spec changes |
+| 37 | .rwx/docker.yml | Build system updates |
+
+**Key insight**: `bridge/bot.go` (61 changes) is the 4th most-churned file and has **zero test coverage**. The files changing most are the ones least tested.
+
+---
+
+## 4. Test Coverage Gaps
+
+### Untested Critical Code (HIGH risk, mission-critical)
+
+| File | Lines | Why It Matters |
+|------|-------|---------------|
+| bridge/bot.go | 632 | Socket Mode event dispatcher — all Slack interactions route through this |
+| bridge/bot_commands.go | 742 | Slash command handlers (/spawn, /decisions, /roster) |
+| bridge/bot_decisions.go | 580 | Decision notification creation, resolution, dismissal |
+| bridge/bot_agents.go | 674 | Agent card creation, lifecycle tracking, status updates |
+| reconciler/upgrade.go | 374 | Pod upgrade strategies (Skip/Rolling/Last), drain orchestration |
+| cmd/gb/agent_start.go | 455 | Agent launch orchestration, pod spec generation |
+| cmd/gb/agent_k8s_lifecycle.go | 398 | K8s pod lifecycle management |
+
+**Total: 3,855 lines of untested mission-critical code.**
+
+### Untested Important Code (MEDIUM risk)
+
+| File | Lines | Why It Matters |
+|------|-------|---------------|
+| bridge/state.go | 354 | JSON persistence for Slack thread state across restarts |
+| reconciler/imagedigest.go | 288 | Image digest resolution and caching |
+| bridge/jira_poller.go | 522 | JIRA change polling infrastructure |
+| cmd/gb/decision.go | 547 | CLI decision workflow |
+| cmd/gb/hook.go | 433 | Hook processing pipeline |
+| bridge/bot_decisions_modal.go | 467 | Slack modal rendering for decisions |
+
+### Packages With Zero Tests
+
+- `cmd/gitlab-bridge/` (238 lines)
+- `cmd/jira-bridge/` (292 lines)
+- `cmd/wl-bridge/` (278 lines)
+
+### Well-Tested Packages (reference)
+
+| Package | Test:Source Ratio | Notes |
+|---------|-------------------|-------|
+| statusreporter | 3.16 | Excellent — core status sync well-verified |
+| beadsapi | 1.97 | Comprehensive HTTP client tests with mock servers |
+| podmanager | 1.66 | Good K8s operation coverage |
+| subscriber | 1.51 | SSE stream and edge cases covered |
+| secretreconciler | 1.29 | ExternalSecret provisioning tested |
+
+---
+
+## 5. Drift Risks
+
+### CRITICAL: Build System Drift (Dockerfile vs RWX CI)
+
+The Dockerfile pins `COOP_VERSION=2026.66.2` and `BEADS_VERSION=2026.67.2`, but RWX CI overrides both with `latest`:
+
+```yaml
+# .rwx/docker.yml — on push to main
+init:
+  coop-version: latest    # ignores Dockerfile pin
+  kd-version: latest      # ignores Dockerfile pin
+```
+
+**Impact**: `make image-agent` locally produces a different image than CI for the same commit. CLAUDE.md states "The Dockerfile is the reference spec; RWX CI mirrors it" — this is not true for coop/kbeads versions.
+
+### CRITICAL: COOP_MAX_PODS Default Mismatch
+
+Three different defaults exist:
+
+| Location | Default | Context |
+|----------|---------|---------|
+| config/config.go:287 | 30 | Go code fallback |
+| helm/values.yaml:160 | 4 | Helm chart default |
+| templates/controller/deployment.yaml:149 | 4 | Template fallback |
+
+When deployed via Helm, the limit is 4. When running standalone, it's 30. A 7.5x discrepancy.
+
+### HIGH: Inconsistent Image Tag Patterns in Helm
+
+Three different patterns exist for resolving image tags:
+
+1. **Helper function** (agents, coopmux, slack-bridge): `{{ include "gasboat.imageTag" ... }}` — respects `global.latestMode`
+2. **Inline if/else** (beads3d): `{{ if .Values.beads3d.image.tag }}...{{ else }}{{ .Chart.AppVersion }}{{ end }}` — ignores latestMode
+3. **Chained default** (nats, postgres): `{{ .Values.nats.image.tag | default "2.10-alpine" }}` — ignores latestMode, inline defaults
+
+### MEDIUM: Dynamically-Resolved CLI Versions
+
+kubectl, gh, glab, yq, helm are resolved to "latest" at build time in RWX CI with no version pinning. A breaking upstream release would automatically propagate to all agent images.
+
+---
+
+## 6. Bridge Package — Identity Crisis
+
+The bridge package has 49 source files handling 8+ distinct responsibilities:
+
+| Responsibility | Files | Lines |
+|---------------|-------|-------|
+| Slack bot (Socket Mode) | bot.go, bot_*.go (14 files) | ~5,500 |
+| Decision workflow | decisions.go, api_decisions*.go | ~1,200 |
+| GitHub integration | github.go | ~400 |
+| GitLab integration | gitlab.go, gitlab_*.go | ~1,200 |
+| JIRA integration | jira.go, jira_*.go | ~1,100 |
+| Wasteland integration | wasteland*.go | ~900 |
+| Config/init | init.go, init_*.go | ~700 |
+| SSE/state/dedup | sse.go, state.go, dedup.go | ~700 |
+| Dashboard/agents | dashboard.go, agents.go | ~600 |
+| IP gating | gate.go | ~200 |
+
+This is a **God Package** — it works because it's all in one directory, but the test coverage suffers (42% of files untested) and changes to any part risk affecting everything else.
+
+The claim "Zero K8s dependencies" is technically true (only gate.go, optional) but obscures the real concern: the package mixes Slack interaction handling, webhook processing, SSE multiplexing, external service integration (GitHub/GitLab/JIRA/Wasteland), config registration, state persistence, and IP management.
+
+---
+
+## 7. Recommendations
+
+### Immediate (block releases)
+
+1. **Align COOP_MAX_PODS default** between config.go and Helm values — pick one value.
+2. **Fix Dockerfile/RWX coop-version drift** — either make RWX read Dockerfile ARGs or document the intentional divergence.
+
+### Short-term (next 2 sprints)
+
+3. **Add tests for the 4 most-churned untested files**: bot.go, bot_commands.go, bot_decisions.go, bot_agents.go. These change constantly and have zero test safety net.
+4. **Add tests for reconciler/upgrade.go** — pod upgrade strategy is critical and untested.
+5. **Standardize Helm image tag patterns** — migrate beads3d and nats to use the `gasboat.imageTag` helper.
+
+### Medium-term (next quarter)
+
+6. **Extract bridge sub-packages**: Consider splitting into `bridge/slack/`, `bridge/github/`, `bridge/gitlab/`, `bridge/jira/`, `bridge/wasteland/`, keeping the SSE/state core in `bridge/`. This would make test boundaries clearer and allow independent evolution.
+7. **Add typed bead field accessors** to replace `bead.Fields["agent_state"]` with compile-time safe structs.
+8. **Pin dynamic CLI versions** (kubectl, gh, glab, yq) in `.rwx/agent-clis.lock` for reproducible builds.
+
+---
+
+## Appendix: Verification Commands
+
+```bash
+# Run all tests
+make test
+
+# Check test coverage
+cd controller && go test -cover ./...
+
+# Run race detector
+cd controller && go test -race ./...
+
+# Lint
+quench check
+
+# Helm lint
+helm lint helm/gasboat/
+
+# Build both binaries
+make build && make build-bridge
+```

--- a/gasboat/images/agent/entrypoint.sh
+++ b/gasboat/images/agent/entrypoint.sh
@@ -306,63 +306,18 @@ if [ -d "/ms-playwright" ] && [ -z "${PLAYWRIGHT_BROWSERS_PATH:-}" ]; then
     echo "[entrypoint] Set PLAYWRIGHT_BROWSERS_PATH=/ms-playwright"
 fi
 
-# ── Claude settings ──────────────────────────────────────────────────────
-#
-# User-level settings (permissions, plugins, model) and workspace hooks are
-# both materialized from config beads via `gb setup claude`. The command
-# fetches claude-settings:* and claude-hooks:* config beads, merges them by
-# specificity (global → role), and writes:
-#   ~/.claude/settings.json           — user-level (permissions, plugins)
-#   {workspace}/.claude/settings.json — workspace-level (hooks)
-#
-# When config beads are unavailable, --defaults installs hardcoded fallbacks.
-# Mock mode: skip Claude settings entirely (claudeless doesn't use them).
-
-if [ "${MOCK_MODE}" = "1" ]; then
-    echo "[entrypoint] Mock mode — skipping Claude settings materialization"
-    # Write minimal workspace settings so hooks still work with claudeless.
-    mkdir -p "${WORKSPACE}/.claude"
-    echo '{}' > "${CLAUDE_DIR}/settings.json"
-else
-
-# Disable interactive features that interrupt autonomous agents.
-export CLAUDE_CODE_ENABLE_TASKS="${CLAUDE_CODE_ENABLE_TASKS:-false}"
-
-# Materialize settings + hooks from config beads.
-# gb setup claude writes both:
-#   ~/.claude/settings.json           (user-level: permissions, plugins, model)
-#   {workspace}/.claude/settings.json (workspace-level: hooks)
-mkdir -p "${WORKSPACE}/.claude"
-MATERIALIZED=0
-
-if command -v gb &>/dev/null; then
-    echo "[entrypoint] Materializing settings and hooks from config beads (role: ${ROLE})"
-    if gb setup claude --workspace="${WORKSPACE}" --role="${ROLE}" 2>&1; then
-        if grep -q '"hooks"' "${WORKSPACE}/.claude/settings.json" 2>/dev/null; then
-            MATERIALIZED=1
-            echo "[entrypoint] Settings and hooks materialized from config beads"
-        fi
-    fi
-fi
-
-if [ "${MATERIALIZED}" = "0" ]; then
-    echo "[entrypoint] No config beads found, installing defaults"
-    gb setup claude --defaults --workspace="${WORKSPACE}" 2>&1 || \
-        echo "[entrypoint] WARNING: gb setup --defaults failed"
-fi
-
-# ── Skip Claude onboarding wizard ─────────────────────────────────────────
-
-printf '{"hasCompletedOnboarding":true,"lastOnboardingVersion":"2.1.37","preferredTheme":"dark","bypassPermissionsModeAccepted":true}\n' > "${HOME}/.claude.json"
-
-fi  # end of MOCK_MODE != 1 (Claude settings block)
-
 # ── Resolve coop working directory ────────────────────────────────────────
 #
 # If the init container cloned the primary project repo (at
 # /home/agent/bot/{project}/work), use that as the cwd so agents start
 # inside the actual codebase. Falls back to the scaffold workspace.
 # This mirrors resolveCoopWorkdir() in gb agent start --k8s.
+#
+# IMPORTANT: This must run BEFORE Claude settings materialization so that
+# workspace-level hooks (.claude/settings.json) are written to the directory
+# where Claude Code will actually start. Previously, hooks were written to
+# /home/agent/workspace but Claude started in /home/agent/bot/{project}/work,
+# so SessionStart hooks (gb hook prime) never fired.
 
 COOP_WORKDIR="${WORKSPACE}"
 if [ -n "${PROJECT}" ] && [ -d "/home/agent/bot/${PROJECT}/work/.git" ]; then
@@ -386,17 +341,56 @@ else
     echo "[entrypoint] No project repo found, using scaffold workspace: ${COOP_WORKDIR}"
 fi
 
-# ── Re-materialize settings to final workspace ─────────────────────────────
-# gb setup claude was run above with --workspace="${WORKSPACE}", but if
-# COOP_WORKDIR differs (project repo exists), Claude starts in COOP_WORKDIR
-# and won't find the hooks/CLAUDE.md written to WORKSPACE. Re-run setup
-# targeting the final working directory so hooks fire correctly.
-if [ "${MOCK_MODE}" != "1" ] && [ "${COOP_WORKDIR}" != "${WORKSPACE}" ] && command -v gb &>/dev/null; then
-    echo "[entrypoint] Re-materializing settings to final workspace: ${COOP_WORKDIR}"
+# ── Claude settings ──────────────────────────────────────────────────────
+#
+# User-level settings (permissions, plugins, model) and workspace hooks are
+# both materialized from config beads via `gb setup claude`. The command
+# fetches claude-settings:* and claude-hooks:* config beads, merges them by
+# specificity (global → role), and writes:
+#   ~/.claude/settings.json              — user-level (permissions, plugins)
+#   {COOP_WORKDIR}/.claude/settings.json — workspace-level (hooks)
+#
+# When config beads are unavailable, --defaults installs hardcoded fallbacks.
+# Mock mode: skip Claude settings entirely (claudeless doesn't use them).
+
+if [ "${MOCK_MODE}" = "1" ]; then
+    echo "[entrypoint] Mock mode — skipping Claude settings materialization"
+    # Write minimal workspace settings so hooks still work with claudeless.
     mkdir -p "${COOP_WORKDIR}/.claude"
-    gb setup claude --workspace="${COOP_WORKDIR}" --role="${ROLE}" 2>&1 || \
-        echo "[entrypoint] WARNING: re-materialization to ${COOP_WORKDIR} failed"
+    echo '{}' > "${CLAUDE_DIR}/settings.json"
+else
+
+# Disable interactive features that interrupt autonomous agents.
+export CLAUDE_CODE_ENABLE_TASKS="${CLAUDE_CODE_ENABLE_TASKS:-false}"
+
+# Materialize settings + hooks from config beads.
+# gb setup claude writes both:
+#   ~/.claude/settings.json              (user-level: permissions, plugins, model)
+#   {COOP_WORKDIR}/.claude/settings.json (workspace-level: hooks)
+mkdir -p "${COOP_WORKDIR}/.claude"
+MATERIALIZED=0
+
+if command -v gb &>/dev/null; then
+    echo "[entrypoint] Materializing settings and hooks from config beads (role: ${ROLE})"
+    if gb setup claude --workspace="${COOP_WORKDIR}" --role="${ROLE}" 2>&1; then
+        if grep -q '"hooks"' "${COOP_WORKDIR}/.claude/settings.json" 2>/dev/null; then
+            MATERIALIZED=1
+            echo "[entrypoint] Settings and hooks materialized from config beads"
+        fi
+    fi
 fi
+
+if [ "${MATERIALIZED}" = "0" ]; then
+    echo "[entrypoint] No config beads found, installing defaults"
+    gb setup claude --defaults --workspace="${COOP_WORKDIR}" 2>&1 || \
+        echo "[entrypoint] WARNING: gb setup --defaults failed"
+fi
+
+# ── Skip Claude onboarding wizard ─────────────────────────────────────────
+
+printf '{"hasCompletedOnboarding":true,"lastOnboardingVersion":"2.1.37","preferredTheme":"dark","bypassPermissionsModeAccepted":true}\n' > "${HOME}/.claude.json"
+
+fi  # end of MOCK_MODE != 1 (Claude settings block)
 
 # ── Start coop + Claude ──────────────────────────────────────────────────
 #


### PR DESCRIPTION
## Summary
- Subtree pull of gasboat main into gasboats monorepo
- Includes 3 merged PRs + lint fix:
  - **#174**: docs: gasboat complexity and drift audit
  - **#181**: test(bridge): comprehensive coverage for bridge package (52% -> 69%)
  - **#182**: fix(agent): materialize hooks to coop working directory
  - Lint fix: remove ineffectual agentDisplay assignment (bot_decisions.go)
- Clean merge, no conflicts

## Test plan
- [ ] CI passes on gasboats monorepo

🤖 Generated with [Claude Code](https://claude.com/claude-code)