### PR TITLE
fix(ci): fix lint-go and test-coop failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,9 +79,11 @@ jobs:
           go-version-file: gasboat/controller/go.mod
       - uses: golangci/golangci-lint-action@v6
         with:
+          version: v2.1
           working-directory: gasboat/controller
       - uses: golangci/golangci-lint-action@v6
         with:
+          version: v2.1
           working-directory: kbeads
 
   # Rust tests (coop)
@@ -92,7 +94,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-      - run: cd coop && cargo test --workspace
+      - run: cd coop && RUSTC_WRAPPER="" cargo test --workspace
 
   # JS build (beads3d)
   test-beads3d:


### PR DESCRIPTION
## Summary
- Pin golangci-lint to v2.1 to support Go 1.25 (was failing because v1.64.8 was built with Go 1.24)
- Unset `RUSTC_WRAPPER` for coop tests since sccache is not available in GitHub Actions runners

These two failures blocked the docker build step for the 2026.68.1 release — no images were published.

## Test plan
- [ ] CI passes on this PR (lint-go, test-coop should both pass now)
- [ ] After merge, cut new release to build and push docker images
- [ ] Deploy new release to gasboat namespace

🤖 Generated with [Claude Code](https://claude.com/claude-code)