### PR TITLE
fix(kbeads): improve formula list UX and warn on duplicate titles

### DIFF
--- a/kbeads/cmd/kd/formula_create.go
+++ b/kbeads/cmd/kd/formula_create.go
@@ -134,6 +134,25 @@ Examples:
 			return fmt.Errorf("encoding fields: %w", err)
 		}
 
+		// Warn if a formula with the same title already exists.
+		dupCheck, dupErr := beadsClient.ListBeads(context.Background(), &client.ListBeadsRequest{
+			Type:   []string{"formula"},
+			Status: []string{"open", "in_progress"},
+			Search: name,
+			Labels: labels,
+			Limit:  100,
+		})
+		if dupErr == nil {
+			for _, eb := range dupCheck.Beads {
+				if eb.Title == name {
+					fmt.Fprintf(os.Stderr, "Warning: formula %q already exists (%s, created %s)\n",
+						name, eb.ID, eb.CreatedAt.Format("2006-01-02"))
+					fmt.Fprintf(os.Stderr, "Consider updating it with: kd formula update %s --file <file>\n", eb.ID)
+					fmt.Fprintln(os.Stderr, "Or close the old one first: kd close "+eb.ID)
+				}
+			}
+		}
+
 		req := &client.CreateBeadRequest{
 			Title:       name,
 			Description: description,

--- a/kbeads/cmd/kd/formula_list.go
+++ b/kbeads/cmd/kd/formula_list.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 	"text/tabwriter"
 
@@ -62,8 +63,22 @@ func printFormulaList(beads []*model.Bead, total int) {
 		return
 	}
 
+	// Sort by title then by creation date (newest last) so duplicates are grouped.
+	sort.Slice(beads, func(i, j int) bool {
+		if beads[i].Title != beads[j].Title {
+			return beads[i].Title < beads[j].Title
+		}
+		return beads[i].CreatedAt.Before(beads[j].CreatedAt)
+	})
+
+	// Track duplicate titles.
+	titleCount := map[string]int{}
+	for _, b := range beads {
+		titleCount[b.Title]++
+	}
+
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-	fmt.Fprintln(w, "ID\tTITLE\tSTEPS\tVARS\tAGENT\tLABELS")
+	fmt.Fprintln(w, "ID\tTITLE\tSTEPS\tVARS\tAGENT\tCREATED\tLABELS")
 	for _, b := range beads {
 		title := b.Title
 		if len(title) > 50 {
@@ -72,11 +87,25 @@ func printFormulaList(beads []*model.Bead, total int) {
 
 		steps, vars, agent := formulaFieldSummary(b)
 		lblStr := strings.Join(b.Labels, ", ")
+		created := b.CreatedAt.Format("2006-01-02")
 
-		fmt.Fprintf(w, "%s\t%s\t%d\t%d\t%s\t%s\n", b.ID, title, steps, vars, agent, lblStr)
+		fmt.Fprintf(w, "%s\t%s\t%d\t%d\t%s\t%s\t%s\n", b.ID, title, steps, vars, agent, created, lblStr)
 	}
 	w.Flush()
 	fmt.Printf("\n%d formulas (%d total)\n", len(beads), total)
+
+	// Warn about duplicate titles.
+	var dups []string
+	for title, count := range titleCount {
+		if count > 1 {
+			dups = append(dups, fmt.Sprintf("  %q (%d copies)", title, count))
+		}
+	}
+	if len(dups) > 0 {
+		sort.Strings(dups)
+		fmt.Fprintf(os.Stderr, "\nWarning: duplicate formula titles found:\n%s\n", strings.Join(dups, "\n"))
+		fmt.Fprintln(os.Stderr, "Consider closing older versions with: kd close <id>")
+	}
 }
 
 // formulaFieldSummary extracts step count, var count, and assigned agent from a formula bead's fields.


### PR DESCRIPTION
## Summary
- Sort `kd formula list` output by title to group duplicates together
- Add CREATED column so users can distinguish between formula versions
- Warn on stderr when duplicate formula titles are detected in list output
- Warn during `kd formula create` if a formula with the same title already exists (uses server-side Search for efficiency)
- Cleaned up 8 stale/superseded formula beads (old RC Release Pipeline versions, test templates)

## Test plan
- [x] `go build ./cmd/kd` compiles
- [x] `go test ./...` passes
- [ ] Run `kd formula list --all-projects` and verify formulas are sorted by title with CREATED column
- [ ] Create a formula with a title that already exists and verify the duplicate warning appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)