### PR TITLE
feat(roles-server): config bead CRUD web UI

### DIFF
--- a/gasboat/.rwx/docker.yml
+++ b/gasboat/.rwx/docker.yml
@@ -12,6 +12,7 @@
 #   push-jira-bridge    -> ghcr.io/groblegark/gasboats/jira-bridge
 #   push-gitlab-bridge  -> ghcr.io/groblegark/gasboats/gitlab-bridge
 #   push-advice-viewer  -> ghcr.io/groblegark/gasboats/advice-viewer
+#   push-roles-server   -> ghcr.io/groblegark/gasboats/roles-server
 #
 # For manual push of a single image:
 #   rwx run .rwx/docker.yml --init commit-sha=$(git rev-parse HEAD) --target push-agent
@@ -44,7 +45,7 @@ on:
         coop-version: latest
         kd-version: latest
       status-checks:
-        - tasks: [build-controller, build-gb, build-slack-bridge, build-jira-bridge, build-gitlab-bridge, build-advice-viewer, download-coop, download-kd]
+        - tasks: [build-controller, build-gb, build-slack-bridge, build-jira-bridge, build-gitlab-bridge, build-advice-viewer, build-roles-server, download-coop, download-kd]
           name: Docker
   dispatch:
     - key: gasboat-agent-rebuild
@@ -195,6 +196,29 @@ tasks:
       artifacts:
         - key: advice-viewer-binary
           path: advice-viewer
+
+  # ── Build roles-server binary → artifact ───────────────────────────
+  - key: build-roles-server
+    use: go-deps
+    run: |
+      cd controller
+      REF_NAME="${REF_NAME#refs/tags/}"
+      REF_NAME="${REF_NAME#refs/heads/}"
+      CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
+        -ldflags="-s -w -X main.version=${REF_NAME} -X main.commit=${COMMIT_SHA}" \
+        -o ../roles-server ./cmd/roles-server/
+    env:
+      COMMIT_SHA: ${{ init.commit-sha }}
+      REF_NAME: ${{ init.ref-name }}
+    filter:
+      - controller/**/*.go
+      - controller/**/*.html
+      - controller/go.mod
+      - controller/go.sum
+    outputs:
+      artifacts:
+        - key: roles-server-binary
+          path: roles-server
 
   # ── Build jira-bridge binary → artifact ────────────────────────────
   - key: build-jira-bridge
@@ -471,6 +495,36 @@ tasks:
       REPO="ghcr.io/groblegark/gasboats/advice-viewer"
       crane append --base ubuntu:24.04 --new_tag "${REPO}:${TAG}" --new_layer /tmp/layer.tar --platform linux/amd64
       crane mutate "${REPO}:${TAG}" --entrypoint /advice-viewer --user nobody -t "${REPO}:${TAG}"
+      crane tag "${REPO}:${TAG}" latest
+      APP_VERSION=$(grep '^appVersion:' helm/gasboat/Chart.yaml | sed 's/appVersion: *"\?\([^"]*\)"\?/\1/')
+      if [ -n "$APP_VERSION" ] && [ "$APP_VERSION" != "$TAG" ]; then
+        crane tag "${REPO}:${TAG}" "$APP_VERSION"
+      fi
+      echo "Pushed ${REPO}:${TAG}"
+    env:
+      REF_NAME: ${{ init.ref-name }}
+      GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
+      GITHUB_USER: ${{ secrets.GITHUB_USER }}
+
+  # ── Push roles-server (minimal static binary) ──────────────────────
+  - key: push-roles-server
+    use: [build-roles-server, install-crane]
+    if: ${{ init.ref-name != 'pr' }}
+    cache: false
+    run: |
+      set -ex
+      TAG="${REF_NAME#refs/tags/}"
+      TAG="${TAG#refs/heads/}"
+
+      mkdir -p /tmp/layer/etc/ssl/certs
+      cp ${{ tasks.build-roles-server.artifacts.roles-server-binary }} /tmp/layer/roles-server
+      chmod 755 /tmp/layer/roles-server
+      cp /etc/ssl/certs/ca-certificates.crt /tmp/layer/etc/ssl/certs/
+      tar -cf /tmp/layer.tar -C /tmp/layer .
+
+      REPO="ghcr.io/groblegark/gasboats/roles-server"
+      crane append --base ubuntu:24.04 --new_tag "${REPO}:${TAG}" --new_layer /tmp/layer.tar --platform linux/amd64
+      crane mutate "${REPO}:${TAG}" --entrypoint /roles-server --user nobody -t "${REPO}:${TAG}"
       crane tag "${REPO}:${TAG}" latest
       APP_VERSION=$(grep '^appVersion:' helm/gasboat/Chart.yaml | sed 's/appVersion: *"\?\([^"]*\)"\?/\1/')
       if [ -n "$APP_VERSION" ] && [ "$APP_VERSION" != "$TAG" ]; then

--- a/gasboat/Makefile
+++ b/gasboat/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build build-bridge build-jira-bridge build-gitlab-bridge build-advice-viewer test lint e2e verify image image-agent image-bridge image-jira-bridge image-gitlab-bridge image-advice-viewer image-all push push-agent push-bridge push-jira-bridge push-gitlab-bridge push-advice-viewer push-all helm-package helm-template release release-dry-run clean
+.PHONY: build build-bridge build-jira-bridge build-gitlab-bridge build-advice-viewer build-roles-server test lint e2e verify image image-agent image-bridge image-jira-bridge image-gitlab-bridge image-advice-viewer image-roles-server image-all push push-agent push-bridge push-jira-bridge push-gitlab-bridge push-advice-viewer push-roles-server push-all helm-package helm-template release release-dry-run clean
 
 VERSION  ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
 COMMIT   ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)
@@ -23,6 +23,9 @@ build-gitlab-bridge:
 
 build-advice-viewer:
 	cd controller && go build -ldflags="-s -w -X main.version=$(VERSION) -X main.commit=$(COMMIT)" -o bin/advice-viewer ./cmd/advice-viewer/
+
+build-roles-server:
+	cd controller && go build -ldflags="-s -w -X main.version=$(VERSION) -X main.commit=$(COMMIT)" -o bin/roles-server ./cmd/roles-server/
 
 test:
 	$(MAKE) -C controller test
@@ -88,7 +91,16 @@ image-advice-viewer:
 		-t $(REGISTRY)/advice-viewer:latest \
 		-f images/advice-viewer/Dockerfile .
 
-image-all: image image-agent image-bridge image-jira-bridge image-gitlab-bridge image-advice-viewer
+image-roles-server:
+	docker build \
+		--platform linux/amd64 \
+		--build-arg VERSION=$(VERSION) \
+		--build-arg COMMIT=$(COMMIT) \
+		-t $(REGISTRY)/roles-server:$(VERSION) \
+		-t $(REGISTRY)/roles-server:latest \
+		-f images/roles-server/Dockerfile .
+
+image-all: image image-agent image-bridge image-jira-bridge image-gitlab-bridge image-advice-viewer image-roles-server
 
 push: image
 	docker push $(REGISTRY)/controller:$(VERSION)
@@ -114,7 +126,11 @@ push-advice-viewer: image-advice-viewer
 	docker push $(REGISTRY)/advice-viewer:$(VERSION)
 	docker push $(REGISTRY)/advice-viewer:latest
 
-push-all: push push-agent push-bridge push-jira-bridge push-gitlab-bridge push-advice-viewer
+push-roles-server: image-roles-server
+	docker push $(REGISTRY)/roles-server:$(VERSION)
+	docker push $(REGISTRY)/roles-server:latest
+
+push-all: push push-agent push-bridge push-jira-bridge push-gitlab-bridge push-advice-viewer push-roles-server
 
 # ── Helm ────────────────────────────────────────────────────────────────
 

--- a/gasboat/controller/cmd/roles-server/api.go
+++ b/gasboat/controller/cmd/roles-server/api.go
@@ -1,0 +1,374 @@
+package main
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"sort"
+	"strings"
+	"sync"
+
+	"gasboat/controller/internal/beadsapi"
+)
+
+// RolesAPI serves the read-only roles API endpoints.
+type RolesAPI struct {
+	client *beadsapi.Client
+	logger *slog.Logger
+}
+
+// NewRolesAPI creates a new roles API handler.
+func NewRolesAPI(client *beadsapi.Client, logger *slog.Logger) *RolesAPI {
+	return &RolesAPI{client: client, logger: logger}
+}
+
+// RegisterRoutes registers API routes on the given mux.
+func (a *RolesAPI) RegisterRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("GET /api/roles", a.handleListRoles)
+	mux.HandleFunc("GET /api/roles/{role}", a.handleGetRole)
+	mux.HandleFunc("GET /api/config-beads", a.handleListConfigBeads)
+	mux.HandleFunc("GET /api/advice", a.handleListAdvice)
+	mux.HandleFunc("GET /api/projects", a.handleListProjects)
+}
+
+// roleInfo is the JSON representation of a role.
+type roleInfo struct {
+	Name         string       `json:"name"`
+	ConfigBeads  []configBead `json:"config_beads"`
+	AdviceBeads  []adviceBead `json:"advice_beads"`
+	AgentCount   int          `json:"agent_count"`
+	ActiveAgents []string     `json:"active_agents,omitempty"`
+}
+
+// configBead is a simplified config bead for the API response.
+type configBead struct {
+	ID     string   `json:"id"`
+	Title  string   `json:"title"`
+	Labels []string `json:"labels"`
+	Value  any      `json:"value,omitempty"`
+}
+
+// adviceBead is a simplified advice bead for the API response.
+type adviceBead struct {
+	ID          string   `json:"id"`
+	Title       string   `json:"title"`
+	Labels      []string `json:"labels"`
+	Description string   `json:"description,omitempty"`
+	Status      string   `json:"status"`
+}
+
+// handleListRoles lists all known roles derived from config beads, advice beads,
+// and active agent beads. A role is any unique "role:X" label found across
+// config and advice beads.
+func (a *RolesAPI) handleListRoles(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	// Fetch config beads, advice beads, and agents in parallel.
+	var (
+		configResult *beadsapi.ListBeadsResult
+		adviceResult *beadsapi.ListBeadsResult
+		agents       []beadsapi.AgentBead
+		configErr    error
+		adviceErr    error
+		agentsErr    error
+		wg           sync.WaitGroup
+	)
+
+	wg.Add(3)
+	go func() {
+		defer wg.Done()
+		configResult, configErr = a.client.ListBeadsFiltered(ctx, beadsapi.ListBeadsQuery{
+			Types: []string{"config"},
+		})
+	}()
+	go func() {
+		defer wg.Done()
+		adviceResult, adviceErr = a.client.ListBeadsFiltered(ctx, beadsapi.ListBeadsQuery{
+			Types:    []string{"advice"},
+			Statuses: []string{"open", "in_progress"},
+		})
+	}()
+	go func() {
+		defer wg.Done()
+		agents, agentsErr = a.client.ListAgentBeads(ctx)
+	}()
+	wg.Wait()
+
+	if configErr != nil {
+		a.logger.Error("failed to list config beads", "error", configErr)
+		writeError(w, http.StatusInternalServerError, "failed to list config beads")
+		return
+	}
+	if adviceErr != nil {
+		a.logger.Error("failed to list advice beads", "error", adviceErr)
+		writeError(w, http.StatusInternalServerError, "failed to list advice beads")
+		return
+	}
+	if agentsErr != nil {
+		a.logger.Error("failed to list agent beads", "error", agentsErr)
+		writeError(w, http.StatusInternalServerError, "failed to list agent beads")
+		return
+	}
+
+	// Extract unique roles from all label sources.
+	roles := make(map[string]*roleInfo)
+	ensureRole := func(name string) *roleInfo {
+		ri, ok := roles[name]
+		if !ok {
+			ri = &roleInfo{Name: name}
+			roles[name] = ri
+		}
+		return ri
+	}
+
+	// Always include "global" as a pseudo-role for global config.
+	ensureRole("global")
+
+	for _, b := range configResult.Beads {
+		cb := toConfigBead(b)
+		for _, label := range b.Labels {
+			if name, ok := strings.CutPrefix(label, "role:"); ok {
+				ri := ensureRole(name)
+				ri.ConfigBeads = append(ri.ConfigBeads, cb)
+			}
+			if label == "global" {
+				ri := ensureRole("global")
+				ri.ConfigBeads = append(ri.ConfigBeads, cb)
+			}
+		}
+	}
+
+	for _, b := range adviceResult.Beads {
+		ab := toAdviceBead(b)
+		for _, label := range b.Labels {
+			if name, ok := strings.CutPrefix(label, "role:"); ok {
+				ri := ensureRole(name)
+				ri.AdviceBeads = append(ri.AdviceBeads, ab)
+			}
+			if label == "global" {
+				ri := ensureRole("global")
+				ri.AdviceBeads = append(ri.AdviceBeads, ab)
+			}
+		}
+	}
+
+	for _, ag := range agents {
+		if ag.Role != "" {
+			ri := ensureRole(ag.Role)
+			ri.AgentCount++
+			ri.ActiveAgents = append(ri.ActiveAgents, ag.AgentName)
+		}
+	}
+
+	// Sort roles by name.
+	result := make([]roleInfo, 0, len(roles))
+	for _, ri := range roles {
+		result = append(result, *ri)
+	}
+	sort.Slice(result, func(i, j int) bool {
+		if result[i].Name == "global" {
+			return true
+		}
+		if result[j].Name == "global" {
+			return false
+		}
+		return result[i].Name < result[j].Name
+	})
+
+	writeJSON(w, map[string]any{"roles": result})
+}
+
+// handleGetRole returns the detailed configuration for a specific role,
+// including its resolved config beads, advice beads, and active agents.
+func (a *RolesAPI) handleGetRole(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	roleName := r.PathValue("role")
+
+	var labelFilter []string
+	if roleName == "global" {
+		labelFilter = []string{"global"}
+	} else {
+		labelFilter = []string{"role:" + roleName}
+	}
+
+	// Fetch config beads, advice beads, and agents in parallel.
+	var (
+		configResult *beadsapi.ListBeadsResult
+		adviceResult *beadsapi.ListBeadsResult
+		agents       []beadsapi.AgentBead
+		configErr    error
+		adviceErr    error
+		agentsErr    error
+		wg           sync.WaitGroup
+	)
+
+	wg.Add(3)
+	go func() {
+		defer wg.Done()
+		configResult, configErr = a.client.ListBeadsFiltered(ctx, beadsapi.ListBeadsQuery{
+			Types:  []string{"config"},
+			Labels: labelFilter,
+		})
+	}()
+	go func() {
+		defer wg.Done()
+		adviceResult, adviceErr = a.client.ListBeadsFiltered(ctx, beadsapi.ListBeadsQuery{
+			Types:    []string{"advice"},
+			Statuses: []string{"open", "in_progress"},
+			Labels:   labelFilter,
+		})
+	}()
+	go func() {
+		defer wg.Done()
+		agents, agentsErr = a.client.ListAgentBeads(ctx)
+	}()
+	wg.Wait()
+
+	if configErr != nil {
+		a.logger.Error("failed to list config beads for role", "role", roleName, "error", configErr)
+		writeError(w, http.StatusInternalServerError, "failed to list config beads")
+		return
+	}
+	if adviceErr != nil {
+		a.logger.Error("failed to list advice beads for role", "role", roleName, "error", adviceErr)
+		writeError(w, http.StatusInternalServerError, "failed to list advice beads")
+		return
+	}
+	if agentsErr != nil {
+		a.logger.Error("failed to list agent beads", "error", agentsErr)
+		writeError(w, http.StatusInternalServerError, "failed to list agent beads")
+		return
+	}
+
+	configs := make([]configBead, 0, len(configResult.Beads))
+	for _, b := range configResult.Beads {
+		configs = append(configs, toConfigBead(b))
+	}
+
+	advices := make([]adviceBead, 0, len(adviceResult.Beads))
+	for _, b := range adviceResult.Beads {
+		advices = append(advices, toAdviceBead(b))
+	}
+
+	var activeAgents []string
+	for _, ag := range agents {
+		if ag.Role == roleName {
+			activeAgents = append(activeAgents, ag.AgentName)
+		}
+	}
+
+	ri := roleInfo{
+		Name:         roleName,
+		ConfigBeads:  configs,
+		AdviceBeads:  advices,
+		AgentCount:   len(activeAgents),
+		ActiveAgents: activeAgents,
+	}
+
+	writeJSON(w, ri)
+}
+
+// handleListConfigBeads lists all config beads, optionally filtered by label.
+func (a *RolesAPI) handleListConfigBeads(w http.ResponseWriter, r *http.Request) {
+	q := beadsapi.ListBeadsQuery{
+		Types: []string{"config"},
+	}
+	if labels := r.URL.Query().Get("labels"); labels != "" {
+		q.Labels = strings.Split(labels, ",")
+	}
+
+	result, err := a.client.ListBeadsFiltered(r.Context(), q)
+	if err != nil {
+		a.logger.Error("failed to list config beads", "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to list config beads")
+		return
+	}
+
+	beads := make([]configBead, 0, len(result.Beads))
+	for _, b := range result.Beads {
+		beads = append(beads, toConfigBead(b))
+	}
+
+	writeJSON(w, map[string]any{"config_beads": beads, "total": result.Total})
+}
+
+// handleListAdvice lists advice beads, optionally filtered by label.
+func (a *RolesAPI) handleListAdvice(w http.ResponseWriter, r *http.Request) {
+	q := beadsapi.ListBeadsQuery{
+		Types:    []string{"advice"},
+		Statuses: []string{"open", "in_progress"},
+	}
+	if labels := r.URL.Query().Get("labels"); labels != "" {
+		q.Labels = strings.Split(labels, ",")
+	}
+
+	result, err := a.client.ListBeadsFiltered(r.Context(), q)
+	if err != nil {
+		a.logger.Error("failed to list advice beads", "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to list advice beads")
+		return
+	}
+
+	beads := make([]adviceBead, 0, len(result.Beads))
+	for _, b := range result.Beads {
+		beads = append(beads, toAdviceBead(b))
+	}
+
+	writeJSON(w, map[string]any{"advice_beads": beads, "total": result.Total})
+}
+
+// handleListProjects lists all registered projects.
+func (a *RolesAPI) handleListProjects(w http.ResponseWriter, r *http.Request) {
+	projects, err := a.client.ListProjectBeads(r.Context())
+	if err != nil {
+		a.logger.Error("failed to list projects", "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to list projects")
+		return
+	}
+
+	writeJSON(w, map[string]any{"projects": projects})
+}
+
+// toConfigBead converts a BeadDetail to a configBead response.
+func toConfigBead(b *beadsapi.BeadDetail) configBead {
+	cb := configBead{
+		ID:     b.ID,
+		Title:  b.Title,
+		Labels: b.Labels,
+	}
+	if raw, ok := b.Fields["value"]; ok && raw != "" {
+		var parsed any
+		if json.Unmarshal([]byte(raw), &parsed) == nil {
+			cb.Value = parsed
+		} else {
+			cb.Value = raw
+		}
+	}
+	return cb
+}
+
+// toAdviceBead converts a BeadDetail to an adviceBead response.
+func toAdviceBead(b *beadsapi.BeadDetail) adviceBead {
+	return adviceBead{
+		ID:          b.ID,
+		Title:       b.Title,
+		Labels:      b.Labels,
+		Description: b.Description,
+		Status:      b.Status,
+	}
+}
+
+// writeJSON writes a JSON response with status 200.
+func writeJSON(w http.ResponseWriter, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	_ = enc.Encode(v)
+}
+
+// writeError writes a JSON error response.
+func writeError(w http.ResponseWriter, code int, message string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	_ = json.NewEncoder(w).Encode(map[string]string{"error": message})
+}

--- a/gasboat/controller/cmd/roles-server/api_test.go
+++ b/gasboat/controller/cmd/roles-server/api_test.go
@@ -1,0 +1,384 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"gasboat/controller/internal/beadsapi"
+)
+
+// mockDaemon is a test HTTP server that returns canned bead responses.
+func mockDaemon(t *testing.T) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+
+	// Serve canned bead listings based on query params.
+	mux.HandleFunc("/v1/beads", func(w http.ResponseWriter, r *http.Request) {
+		beadType := r.URL.Query().Get("type")
+		w.Header().Set("Content-Type", "application/json")
+
+		switch {
+		case beadType == "config":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"beads": []map[string]any{
+					{
+						"id":     "cfg-1",
+						"title":  "claude-settings",
+						"type":   "config",
+						"kind":   "config",
+						"status": "open",
+						"labels": []string{"global"},
+						"fields": map[string]any{
+							"value": `{"model":"sonnet"}`,
+						},
+					},
+					{
+						"id":     "cfg-2",
+						"title":  "claude-instructions",
+						"type":   "config",
+						"kind":   "config",
+						"status": "open",
+						"labels": []string{"role:crew"},
+						"fields": map[string]any{
+							"value": `{"lifecycle":"persistent"}`,
+						},
+					},
+					{
+						"id":     "cfg-3",
+						"title":  "claude-settings",
+						"type":   "config",
+						"kind":   "config",
+						"status": "open",
+						"labels": []string{"role:captain"},
+						"fields": map[string]any{
+							"value": `{"model":"opus"}`,
+						},
+					},
+				},
+				"total": 3,
+			})
+		case beadType == "advice":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"beads": []map[string]any{
+					{
+						"id":          "adv-1",
+						"title":       "Use gb prime for context recovery",
+						"type":        "advice",
+						"kind":        "data",
+						"status":      "open",
+						"labels":      []string{"global"},
+						"description": "Run gb prime after compaction",
+					},
+					{
+						"id":          "adv-2",
+						"title":       "Crew-specific advice",
+						"type":        "advice",
+						"kind":        "data",
+						"status":      "open",
+						"labels":      []string{"role:crew"},
+						"description": "Crew agents should ...",
+					},
+				},
+				"total": 2,
+			})
+		case beadType == "agent":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"beads": []map[string]any{
+					{
+						"id":     "agent-1",
+						"title":  "test-bot",
+						"type":   "agent",
+						"kind":   "config",
+						"status": "open",
+						"labels": []string{"role:crew", "project:gasboat"},
+						"fields": map[string]any{
+							"agent":   "test-bot",
+							"role":    "crew",
+							"mode":    "crew",
+							"project": "gasboat",
+						},
+					},
+				},
+				"total": 1,
+			})
+		case beadType == "project":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"beads": []map[string]any{
+					{
+						"id":     "proj-1",
+						"title":  "gasboat",
+						"type":   "project",
+						"kind":   "config",
+						"status": "open",
+						"labels": []string{},
+						"fields": map[string]any{
+							"git_url":        "https://github.com/groblegark/gasboats.git",
+							"default_branch": "main",
+						},
+					},
+				},
+				"total": 1,
+			})
+		default:
+			_ = json.NewEncoder(w).Encode(map[string]any{"beads": []any{}, "total": 0})
+		}
+	})
+
+	return httptest.NewServer(mux)
+}
+
+func setupTestAPI(t *testing.T) (*RolesAPI, *httptest.Server) {
+	t.Helper()
+	daemon := mockDaemon(t)
+	client, err := beadsapi.New(beadsapi.Config{HTTPAddr: daemon.URL})
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+	t.Cleanup(func() {
+		client.Close()
+		daemon.Close()
+	})
+	return NewRolesAPI(client, setupLogger("error")), daemon
+}
+
+func TestListRoles(t *testing.T) {
+	api, _ := setupTestAPI(t)
+	mux := http.NewServeMux()
+	api.RegisterRoutes(mux)
+
+	req := httptest.NewRequest("GET", "/api/roles", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp struct {
+		Roles []roleInfo `json:"roles"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if len(resp.Roles) < 3 {
+		t.Fatalf("expected at least 3 roles (global, crew, captain), got %d", len(resp.Roles))
+	}
+
+	// Verify "global" sorts first.
+	if resp.Roles[0].Name != "global" {
+		t.Errorf("expected first role to be 'global', got %q", resp.Roles[0].Name)
+	}
+
+	// Verify crew role has config and advice beads.
+	var crewRole *roleInfo
+	for i := range resp.Roles {
+		if resp.Roles[i].Name == "crew" {
+			crewRole = &resp.Roles[i]
+			break
+		}
+	}
+	if crewRole == nil {
+		t.Fatal("expected to find 'crew' role")
+	}
+	if len(crewRole.ConfigBeads) == 0 {
+		t.Error("expected crew role to have config beads")
+	}
+	if len(crewRole.AdviceBeads) == 0 {
+		t.Error("expected crew role to have advice beads")
+	}
+	if crewRole.AgentCount != 1 {
+		t.Errorf("expected crew role to have 1 active agent, got %d", crewRole.AgentCount)
+	}
+}
+
+func TestGetRole(t *testing.T) {
+	api, _ := setupTestAPI(t)
+	mux := http.NewServeMux()
+	api.RegisterRoutes(mux)
+
+	req := httptest.NewRequest("GET", "/api/roles/crew", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp roleInfo
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if resp.Name != "crew" {
+		t.Errorf("expected role name 'crew', got %q", resp.Name)
+	}
+	if len(resp.ConfigBeads) == 0 {
+		t.Error("expected crew role to have config beads")
+	}
+}
+
+func TestGetRoleGlobal(t *testing.T) {
+	api, _ := setupTestAPI(t)
+	mux := http.NewServeMux()
+	api.RegisterRoutes(mux)
+
+	req := httptest.NewRequest("GET", "/api/roles/global", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp roleInfo
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if resp.Name != "global" {
+		t.Errorf("expected role name 'global', got %q", resp.Name)
+	}
+	if len(resp.ConfigBeads) == 0 {
+		t.Error("expected global role to have config beads")
+	}
+	if len(resp.AdviceBeads) == 0 {
+		t.Error("expected global role to have advice beads")
+	}
+	// Global role should NOT include agents that have a specific role.
+	if resp.AgentCount != 0 {
+		t.Errorf("expected global role to have 0 agents (agents have role=crew), got %d", resp.AgentCount)
+	}
+}
+
+func TestGetRoleNonexistent(t *testing.T) {
+	api, _ := setupTestAPI(t)
+	mux := http.NewServeMux()
+	api.RegisterRoutes(mux)
+
+	req := httptest.NewRequest("GET", "/api/roles/nonexistent", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp roleInfo
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if resp.AgentCount != 0 {
+		t.Errorf("expected 0 agents for nonexistent role, got %d", resp.AgentCount)
+	}
+}
+
+func TestListConfigBeads(t *testing.T) {
+	api, _ := setupTestAPI(t)
+	mux := http.NewServeMux()
+	api.RegisterRoutes(mux)
+
+	req := httptest.NewRequest("GET", "/api/config-beads", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp struct {
+		ConfigBeads []configBead `json:"config_beads"`
+		Total       int          `json:"total"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if len(resp.ConfigBeads) != 3 {
+		t.Errorf("expected 3 config beads, got %d", len(resp.ConfigBeads))
+	}
+}
+
+func TestListAdvice(t *testing.T) {
+	api, _ := setupTestAPI(t)
+	mux := http.NewServeMux()
+	api.RegisterRoutes(mux)
+
+	req := httptest.NewRequest("GET", "/api/advice", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp struct {
+		AdviceBeads []adviceBead `json:"advice_beads"`
+		Total       int          `json:"total"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if len(resp.AdviceBeads) != 2 {
+		t.Errorf("expected 2 advice beads, got %d", len(resp.AdviceBeads))
+	}
+}
+
+func TestListProjects(t *testing.T) {
+	api, _ := setupTestAPI(t)
+	mux := http.NewServeMux()
+	api.RegisterRoutes(mux)
+
+	req := httptest.NewRequest("GET", "/api/projects", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp struct {
+		Projects map[string]any `json:"projects"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if _, ok := resp.Projects["gasboat"]; !ok {
+		t.Error("expected 'gasboat' project in response")
+	}
+}
+
+func TestHealthz(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"status":"ok","version":"test"}`))
+	})
+
+	req := httptest.NewRequest("GET", "/healthz", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+}
+
+func TestConfigBeadLabelFilter(t *testing.T) {
+	api, _ := setupTestAPI(t)
+	mux := http.NewServeMux()
+	api.RegisterRoutes(mux)
+
+	req := httptest.NewRequest("GET", "/api/config-beads?labels=role:crew", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}

--- a/gasboat/controller/cmd/roles-server/main.go
+++ b/gasboat/controller/cmd/roles-server/main.go
@@ -1,0 +1,136 @@
+// Command roles-server is a read-only HTTP API for viewing agent roles
+// and their configuration (config beads, advice beads, projects).
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"gasboat/controller/internal/beadsapi"
+)
+
+var (
+	version = "dev"
+	commit  = "unknown"
+)
+
+func main() {
+	cfg := parseConfig()
+
+	logger := setupLogger(cfg.logLevel)
+	logger.Info("starting roles-server",
+		"version", version,
+		"commit", commit,
+		"beads_http", cfg.beadsHTTPAddr,
+		"listen_addr", cfg.listenAddr)
+
+	daemon, err := beadsapi.New(beadsapi.Config{
+		HTTPAddr: cfg.beadsHTTPAddr,
+		Token:    os.Getenv("BEADS_DAEMON_TOKEN"),
+	})
+	if err != nil {
+		logger.Error("failed to create beads daemon client", "error", err)
+		os.Exit(1)
+	}
+	defer daemon.Close()
+
+	api := NewRolesAPI(daemon, logger)
+
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"status":"ok","version":"%s"}`, version)
+	})
+	mux.HandleFunc("/readyz", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"status":"ok"}`)
+	})
+
+	api.RegisterRoutes(mux)
+
+	tmpl := newTemplateSet()
+	mux.HandleFunc("/", handleIndex(daemon, logger, tmpl))
+	webUI := NewWebUI(daemon, logger, tmpl)
+	webUI.RegisterRoutes(mux)
+	adviceUI := NewAdviceUI(daemon, logger, tmpl)
+	adviceUI.RegisterRoutes(mux)
+	instrUI := NewInstructionsUI(daemon, logger, tmpl)
+	instrUI.RegisterRoutes(mux)
+	rolesUI := NewRolesUI(daemon, logger, tmpl)
+	rolesUI.RegisterRoutes(mux)
+
+	httpSrv := &http.Server{
+		Addr:              cfg.listenAddr,
+		Handler:           mux,
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
+	defer cancel()
+
+	go func() {
+		logger.Info("starting HTTP server", "addr", cfg.listenAddr)
+		if err := httpSrv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			logger.Error("HTTP server failed", "error", err)
+		}
+	}()
+
+	<-ctx.Done()
+	logger.Info("shutting down roles-server")
+
+	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer shutdownCancel()
+	if err := httpSrv.Shutdown(shutdownCtx); err != nil {
+		logger.Error("HTTP server shutdown error", "error", err)
+	}
+}
+
+type config struct {
+	beadsHTTPAddr string
+	listenAddr    string
+	logLevel      string
+}
+
+func parseConfig() *config {
+	return &config{
+		beadsHTTPAddr: envOrDefault("BEADS_HTTP_ADDR", "http://localhost:8080"),
+		listenAddr:    envOrDefault("LISTEN_ADDR", ":8092"),
+		logLevel:      envOrDefault("LOG_LEVEL", "info"),
+	}
+}
+
+func envOrDefault(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}
+
+func setupLogger(level string) *slog.Logger {
+	var logLevel slog.Level
+	switch level {
+	case "debug":
+		logLevel = slog.LevelDebug
+	case "warn":
+		logLevel = slog.LevelWarn
+	case "error":
+		logLevel = slog.LevelError
+	default:
+		logLevel = slog.LevelInfo
+	}
+	return slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: logLevel}))
+}
+
+func init() {
+	if v := os.Getenv("VERSION"); v != "" {
+		version = v
+	}
+}

--- a/gasboat/controller/cmd/roles-server/templates.go
+++ b/gasboat/controller/cmd/roles-server/templates.go
@@ -1,0 +1,355 @@
+package main
+
+const configBeadListTmpl = `
+{{define "config_bead_list"}}
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Config Beads</title>
+<style>
+  body { font-family: system-ui, sans-serif; max-width: 960px; margin: 0 auto; padding: 1rem; background: #f8f9fa; }
+  h1 { color: #333; }
+  .btn { display: inline-block; padding: 0.4rem 0.8rem; text-decoration: none; border-radius: 4px; font-size: 0.9rem; border: none; cursor: pointer; }
+  .btn-primary { background: #0d6efd; color: #fff; }
+  .btn-sm { padding: 0.25rem 0.5rem; font-size: 0.8rem; }
+  .btn-outline { border: 1px solid #6c757d; color: #6c757d; background: transparent; }
+  .btn-danger { border: 1px solid #dc3545; color: #dc3545; background: transparent; }
+  table { width: 100%; border-collapse: collapse; background: #fff; border-radius: 8px; overflow: hidden; box-shadow: 0 1px 3px rgba(0,0,0,0.1); }
+  th, td { text-align: left; padding: 0.6rem 0.8rem; border-bottom: 1px solid #e9ecef; }
+  th { background: #f1f3f5; font-weight: 600; color: #495057; }
+  .label { display: inline-block; background: #e9ecef; padding: 0.15rem 0.4rem; border-radius: 3px; font-size: 0.8rem; margin-right: 0.2rem; }
+  .actions { white-space: nowrap; }
+  .actions a { margin-right: 0.3rem; }
+  .toolbar { display: flex; justify-content: space-between; align-items: center; margin-bottom: 1rem; }
+</style>
+</head>
+<body>
+{{template "nav"}}
+<div class="toolbar">
+  <h1>Config Beads</h1>
+  <a href="/config-beads/new" class="btn btn-primary">New Config Bead</a>
+</div>
+<table>
+  <thead>
+    <tr><th>ID</th><th>Category</th><th>Labels</th><th>Actions</th></tr>
+  </thead>
+  <tbody>
+  {{range .}}
+    <tr>
+      <td><code>{{.ID}}</code></td>
+      <td>{{.Title}}</td>
+      <td>{{range .Labels}}<span class="label">{{.}}</span>{{end}}</td>
+      <td class="actions">
+        <a href="/config-beads/{{.ID}}/edit" class="btn btn-sm btn-outline">Edit</a>
+        {{if eq .Title "claude-instructions"}}<a href="/config-beads/{{.ID}}/instructions" class="btn btn-sm btn-outline">Sections</a>{{end}}
+        <a href="/config-beads/{{.ID}}/delete" class="btn btn-sm btn-danger">Delete</a>
+      </td>
+    </tr>
+  {{else}}
+    <tr><td colspan="4">No config beads found.</td></tr>
+  {{end}}
+  </tbody>
+</table>
+</body>
+</html>
+{{end}}
+`
+
+const configBeadFormTmpl = `
+{{define "config_bead_form"}}
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>{{if .IsEdit}}Edit{{else}}New{{end}} Config Bead</title>
+<style>
+  body { font-family: system-ui, sans-serif; max-width: 700px; margin: 0 auto; padding: 1rem; background: #f8f9fa; }
+  h1 { color: #333; }
+  .form-group { margin-bottom: 1rem; }
+  label { display: block; font-weight: 600; margin-bottom: 0.3rem; color: #495057; }
+  select, input[type=text], textarea { width: 100%; padding: 0.5rem; border: 1px solid #ced4da; border-radius: 4px; font-size: 0.95rem; box-sizing: border-box; }
+  textarea { font-family: monospace; min-height: 200px; resize: vertical; }
+  .hint { font-size: 0.8rem; color: #6c757d; margin-top: 0.2rem; }
+  .error { background: #f8d7da; border: 1px solid #f5c2c7; color: #842029; padding: 0.6rem 1rem; border-radius: 4px; margin-bottom: 1rem; }
+  .btn { display: inline-block; padding: 0.5rem 1rem; text-decoration: none; border-radius: 4px; font-size: 0.95rem; border: none; cursor: pointer; }
+  .btn-primary { background: #0d6efd; color: #fff; }
+  .btn-secondary { background: #6c757d; color: #fff; }
+  .toolbar { display: flex; gap: 0.5rem; }
+</style>
+</head>
+<body>
+{{template "nav"}}
+<h1>{{if .IsEdit}}Edit{{else}}New{{end}} Config Bead</h1>
+{{if .Error}}<div class="error">{{.Error}}</div>{{end}}
+<form method="POST">
+  <div class="form-group">
+    <label for="title">Category</label>
+    <select name="title" id="title">
+      <option value="">-- select category --</option>
+      {{range .Categories}}
+      <option value="{{.}}"{{if eq . $.Title}} selected{{end}}>{{.}}</option>
+      {{end}}
+    </select>
+    <div class="hint">Config bead category (e.g., claude-settings, claude-instructions).</div>
+  </div>
+  <div class="form-group">
+    <label for="labels">Labels</label>
+    <input type="text" name="labels" id="labels" value="{{.Labels}}" placeholder="global, role:crew, project:gasboat">
+    <div class="hint">Comma-separated labels for scope targeting. More specific labels override less specific ones: global &lt; rig:X &lt; role:X &lt; agent:X.</div>
+  </div>
+  <div class="form-group">
+    <label for="value">Value (JSON)</label>
+    <textarea name="value" id="value" placeholder='{"model": "sonnet", "permissions": {...}}'>{{.Value}}</textarea>
+    <div class="hint">JSON object with the configuration value for this bead.</div>
+  </div>
+  <div class="toolbar">
+    <button type="submit" class="btn btn-primary">{{if .IsEdit}}Save Changes{{else}}Create{{end}}</button>
+    <a href="/config-beads" class="btn btn-secondary">Cancel</a>
+  </div>
+</form>
+</body>
+</html>
+{{end}}
+`
+
+const configBeadDeleteConfirmTmpl = `
+{{define "config_bead_delete_confirm"}}
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Delete Config Bead</title>
+<style>
+  body { font-family: system-ui, sans-serif; max-width: 600px; margin: 0 auto; padding: 1rem; background: #f8f9fa; }
+  h1 { color: #842029; }
+  .card { background: #fff; border: 1px solid #e9ecef; border-radius: 8px; padding: 1.2rem; margin-bottom: 1rem; }
+  .field { margin-bottom: 0.5rem; }
+  .field-label { font-weight: 600; color: #495057; }
+  .label { display: inline-block; background: #e9ecef; padding: 0.15rem 0.4rem; border-radius: 3px; font-size: 0.8rem; margin-right: 0.2rem; }
+  .btn { display: inline-block; padding: 0.5rem 1rem; text-decoration: none; border-radius: 4px; font-size: 0.95rem; border: none; cursor: pointer; }
+  .btn-danger { background: #dc3545; color: #fff; }
+  .btn-secondary { background: #6c757d; color: #fff; }
+  .toolbar { display: flex; gap: 0.5rem; }
+</style>
+</head>
+<body>
+{{template "nav"}}
+<h1>Delete Config Bead</h1>
+<p>Are you sure you want to delete this config bead? This action cannot be undone.</p>
+<div class="card">
+  <div class="field"><span class="field-label">ID:</span> <code>{{.ID}}</code></div>
+  <div class="field"><span class="field-label">Category:</span> {{.Title}}</div>
+  <div class="field"><span class="field-label">Labels:</span> {{range .Labels}}<span class="label">{{.}}</span>{{end}}</div>
+</div>
+<form method="POST">
+  <div class="toolbar">
+    <button type="submit" class="btn btn-danger">Delete</button>
+    <a href="/config-beads" class="btn btn-secondary">Cancel</a>
+  </div>
+</form>
+</body>
+</html>
+{{end}}
+`
+
+const adviceListTmpl = `
+{{define "advice_list"}}
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Advice Beads</title>
+<style>
+  body { font-family: system-ui, sans-serif; max-width: 960px; margin: 0 auto; padding: 1rem; background: #f8f9fa; }
+  h1 { color: #333; }
+  .btn { display: inline-block; padding: 0.4rem 0.8rem; text-decoration: none; border-radius: 4px; font-size: 0.9rem; border: none; cursor: pointer; }
+  .btn-primary { background: #0d6efd; color: #fff; }
+  .btn-sm { padding: 0.25rem 0.5rem; font-size: 0.8rem; }
+  .btn-outline { border: 1px solid #6c757d; color: #6c757d; background: transparent; }
+  .btn-danger { border: 1px solid #dc3545; color: #dc3545; background: transparent; }
+  table { width: 100%; border-collapse: collapse; background: #fff; border-radius: 8px; overflow: hidden; box-shadow: 0 1px 3px rgba(0,0,0,0.1); }
+  th, td { text-align: left; padding: 0.6rem 0.8rem; border-bottom: 1px solid #e9ecef; }
+  th { background: #f1f3f5; font-weight: 600; color: #495057; }
+  .label { display: inline-block; background: #e9ecef; padding: 0.15rem 0.4rem; border-radius: 3px; font-size: 0.8rem; margin-right: 0.2rem; }
+  .status { display: inline-block; padding: 0.15rem 0.4rem; border-radius: 3px; font-size: 0.8rem; background: #d1e7dd; color: #0f5132; }
+  .actions { white-space: nowrap; }
+  .actions a { margin-right: 0.3rem; }
+  .toolbar { display: flex; justify-content: space-between; align-items: center; margin-bottom: 1rem; }
+</style>
+</head>
+<body>
+{{template "nav"}}
+<div class="toolbar">
+  <h1>Advice Beads</h1>
+  <a href="/advice/new" class="btn btn-primary">New Advice</a>
+</div>
+<table>
+  <thead>
+    <tr><th>ID</th><th>Title</th><th>Labels</th><th>Status</th><th>Actions</th></tr>
+  </thead>
+  <tbody>
+  {{range .}}
+    <tr>
+      <td><code>{{.ID}}</code></td>
+      <td>{{.Title}}</td>
+      <td>{{range .Labels}}<span class="label">{{.}}</span>{{end}}</td>
+      <td><span class="status">{{.Status}}</span></td>
+      <td class="actions">
+        <a href="/advice/{{.ID}}/edit" class="btn btn-sm btn-outline">Edit</a>
+        <a href="/advice/{{.ID}}/delete" class="btn btn-sm btn-danger">Delete</a>
+      </td>
+    </tr>
+  {{else}}
+    <tr><td colspan="5">No advice beads found.</td></tr>
+  {{end}}
+  </tbody>
+</table>
+</body>
+</html>
+{{end}}
+`
+
+const adviceFormTmpl = `
+{{define "advice_form"}}
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>{{if .IsEdit}}Edit{{else}}New{{end}} Advice</title>
+<style>
+  body { font-family: system-ui, sans-serif; max-width: 700px; margin: 0 auto; padding: 1rem; background: #f8f9fa; }
+  h1 { color: #333; }
+  .form-group { margin-bottom: 1rem; }
+  label { display: block; font-weight: 600; margin-bottom: 0.3rem; color: #495057; }
+  input[type=text], textarea { width: 100%; padding: 0.5rem; border: 1px solid #ced4da; border-radius: 4px; font-size: 0.95rem; box-sizing: border-box; }
+  textarea { min-height: 200px; resize: vertical; }
+  .hint { font-size: 0.8rem; color: #6c757d; margin-top: 0.2rem; }
+  .error { background: #f8d7da; border: 1px solid #f5c2c7; color: #842029; padding: 0.6rem 1rem; border-radius: 4px; margin-bottom: 1rem; }
+  .btn { display: inline-block; padding: 0.5rem 1rem; text-decoration: none; border-radius: 4px; font-size: 0.95rem; border: none; cursor: pointer; }
+  .btn-primary { background: #0d6efd; color: #fff; }
+  .btn-secondary { background: #6c757d; color: #fff; }
+  .toolbar { display: flex; gap: 0.5rem; }
+</style>
+</head>
+<body>
+{{template "nav"}}
+<h1>{{if .IsEdit}}Edit{{else}}New{{end}} Advice</h1>
+{{if .Error}}<div class="error">{{.Error}}</div>{{end}}
+<form method="POST">
+  <div class="form-group">
+    <label for="title">Title</label>
+    <input type="text" name="title" id="title" value="{{.Title}}" placeholder="Short descriptive title">
+    <div class="hint">A brief name for this advice (e.g., "Use gb prime for context recovery").</div>
+  </div>
+  <div class="form-group">
+    <label for="labels">Labels</label>
+    <input type="text" name="labels" id="labels" value="{{.Labels}}" placeholder="global, role:crew, project:gasboat">
+    <div class="hint">Comma-separated labels. Advice is shown to agents matching these labels.</div>
+  </div>
+  <div class="form-group">
+    <label for="description">Description</label>
+    <textarea name="description" id="description" placeholder="Detailed advice content shown to agents...">{{.Description}}</textarea>
+    <div class="hint">The full advice text injected into agent context. Supports markdown.</div>
+  </div>
+  <div class="toolbar">
+    <button type="submit" class="btn btn-primary">{{if .IsEdit}}Save Changes{{else}}Create{{end}}</button>
+    <a href="/advice" class="btn btn-secondary">Cancel</a>
+  </div>
+</form>
+</body>
+</html>
+{{end}}
+`
+
+const adviceDeleteConfirmTmpl = `
+{{define "advice_delete_confirm"}}
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Delete Advice</title>
+<style>
+  body { font-family: system-ui, sans-serif; max-width: 600px; margin: 0 auto; padding: 1rem; background: #f8f9fa; }
+  h1 { color: #842029; }
+  .card { background: #fff; border: 1px solid #e9ecef; border-radius: 8px; padding: 1.2rem; margin-bottom: 1rem; }
+  .field { margin-bottom: 0.5rem; }
+  .field-label { font-weight: 600; color: #495057; }
+  .label { display: inline-block; background: #e9ecef; padding: 0.15rem 0.4rem; border-radius: 3px; font-size: 0.8rem; margin-right: 0.2rem; }
+  .btn { display: inline-block; padding: 0.5rem 1rem; text-decoration: none; border-radius: 4px; font-size: 0.95rem; border: none; cursor: pointer; }
+  .btn-danger { background: #dc3545; color: #fff; }
+  .btn-secondary { background: #6c757d; color: #fff; }
+  .toolbar { display: flex; gap: 0.5rem; }
+</style>
+</head>
+<body>
+{{template "nav"}}
+<h1>Delete Advice</h1>
+<p>Are you sure you want to delete this advice bead? This action cannot be undone.</p>
+<div class="card">
+  <div class="field"><span class="field-label">ID:</span> <code>{{.ID}}</code></div>
+  <div class="field"><span class="field-label">Title:</span> {{.Title}}</div>
+  <div class="field"><span class="field-label">Labels:</span> {{range .Labels}}<span class="label">{{.}}</span>{{end}}</div>
+</div>
+<form method="POST">
+  <div class="toolbar">
+    <button type="submit" class="btn btn-danger">Delete</button>
+    <a href="/advice" class="btn btn-secondary">Cancel</a>
+  </div>
+</form>
+</body>
+</html>
+{{end}}
+`
+
+const instructionsFormTmpl = `
+{{define "instructions_form"}}
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Edit Claude Instructions</title>
+<style>
+  body { font-family: system-ui, sans-serif; max-width: 900px; margin: 0 auto; padding: 1rem; background: #f8f9fa; }
+  h1 { color: #333; }
+  h2 { color: #495057; font-size: 1.1rem; margin-top: 1.5rem; margin-bottom: 0.3rem; border-bottom: 1px solid #dee2e6; padding-bottom: 0.3rem; }
+  .meta { color: #6c757d; font-size: 0.9rem; margin-bottom: 1rem; }
+  .form-group { margin-bottom: 1rem; }
+  textarea { width: 100%; padding: 0.5rem; border: 1px solid #ced4da; border-radius: 4px; font-size: 0.9rem; box-sizing: border-box; min-height: 120px; resize: vertical; font-family: monospace; }
+  .hint { font-size: 0.8rem; color: #6c757d; margin-top: 0.2rem; }
+  .error { background: #f8d7da; border: 1px solid #f5c2c7; color: #842029; padding: 0.6rem 1rem; border-radius: 4px; margin-bottom: 1rem; }
+  .btn { display: inline-block; padding: 0.5rem 1rem; text-decoration: none; border-radius: 4px; font-size: 0.95rem; border: none; cursor: pointer; }
+  .btn-primary { background: #0d6efd; color: #fff; }
+  .btn-secondary { background: #6c757d; color: #fff; }
+  .toolbar { display: flex; gap: 0.5rem; margin-top: 1.5rem; }
+</style>
+</head>
+<body>
+{{template "nav"}}
+<h1>Edit Claude Instructions</h1>
+<div class="meta">Bead ID: <code>{{.ID}}</code> | Labels: {{.Labels}}</div>
+{{if .Error}}<div class="error">{{.Error}}</div>{{end}}
+<form method="POST">
+  {{range .Sections}}
+  <h2>{{.Label}}</h2>
+  <div class="form-group">
+    <textarea name="section_{{.Key}}" placeholder="{{.Hint}}">{{.Value}}</textarea>
+    <div class="hint">{{.Hint}}</div>
+  </div>
+  {{end}}
+  <div class="toolbar">
+    <button type="submit" class="btn btn-primary">Save Changes</button>
+    <a href="/config-beads" class="btn btn-secondary">Cancel</a>
+  </div>
+</form>
+</body>
+</html>
+{{end}}
+`

--- a/gasboat/controller/cmd/roles-server/templates_nav.go
+++ b/gasboat/controller/cmd/roles-server/templates_nav.go
@@ -1,0 +1,61 @@
+package main
+
+const navTmpl = `
+{{define "nav"}}
+<nav style="background:#212529;padding:0.5rem 1rem;margin:-1rem -1rem 1rem -1rem;display:flex;gap:1.5rem;align-items:center;">
+  <a href="/" style="color:#fff;text-decoration:none;font-weight:700;font-size:1.1rem;">Roles Server</a>
+  <a href="/config-beads" style="color:#adb5bd;text-decoration:none;">Config Beads</a>
+  <a href="/advice" style="color:#adb5bd;text-decoration:none;">Advice</a>
+  <a href="/roles" style="color:#adb5bd;text-decoration:none;">Roles</a>
+  <a href="/api/roles" style="color:#adb5bd;text-decoration:none;">API</a>
+</nav>
+{{end}}
+`
+
+const indexTmpl = `
+{{define "index"}}
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Roles Server</title>
+<style>
+  body { font-family: system-ui, sans-serif; max-width: 960px; margin: 0 auto; padding: 1rem; background: #f8f9fa; }
+  h1 { color: #333; }
+  .cards { display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 1rem; margin-top: 1rem; }
+  .card { background: #fff; border: 1px solid #e9ecef; border-radius: 8px; padding: 1.2rem; text-decoration: none; color: inherit; transition: box-shadow 0.15s; }
+  .card:hover { box-shadow: 0 2px 8px rgba(0,0,0,0.12); }
+  .card-title { font-size: 0.9rem; color: #6c757d; margin-bottom: 0.3rem; }
+  .card-value { font-size: 2rem; font-weight: 700; color: #212529; }
+  .card-link { display: block; margin-top: 0.5rem; color: #0d6efd; font-size: 0.85rem; }
+</style>
+</head>
+<body>
+{{template "nav"}}
+<h1>Dashboard</h1>
+<div class="cards">
+  <a href="/config-beads" class="card">
+    <div class="card-title">Config Beads</div>
+    <div class="card-value">{{.ConfigCount}}</div>
+    <span class="card-link">Manage config beads</span>
+  </a>
+  <a href="/advice" class="card">
+    <div class="card-title">Advice Beads</div>
+    <div class="card-value">{{.AdviceCount}}</div>
+    <span class="card-link">Manage advice beads</span>
+  </a>
+  <a href="/roles" class="card">
+    <div class="card-title">Roles</div>
+    <div class="card-value">{{.RoleCount}}</div>
+    <span class="card-link">View roles</span>
+  </a>
+  <div class="card">
+    <div class="card-title">Active Agents</div>
+    <div class="card-value">{{.AgentCount}}</div>
+  </div>
+</div>
+</body>
+</html>
+{{end}}
+`

--- a/gasboat/controller/cmd/roles-server/templates_roles.go
+++ b/gasboat/controller/cmd/roles-server/templates_roles.go
@@ -1,0 +1,118 @@
+package main
+
+const rolesListTmpl = `
+{{define "roles_list"}}
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Roles</title>
+<style>
+  body { font-family: system-ui, sans-serif; max-width: 960px; margin: 0 auto; padding: 1rem; background: #f8f9fa; }
+  h1 { color: #333; }
+  table { width: 100%; border-collapse: collapse; background: #fff; border-radius: 8px; overflow: hidden; box-shadow: 0 1px 3px rgba(0,0,0,0.1); }
+  th, td { text-align: left; padding: 0.6rem 0.8rem; border-bottom: 1px solid #e9ecef; }
+  th { background: #f1f3f5; font-weight: 600; color: #495057; }
+  .badge { display: inline-block; background: #e9ecef; padding: 0.15rem 0.5rem; border-radius: 3px; font-size: 0.85rem; }
+  .badge-primary { background: #cfe2ff; color: #084298; }
+  a { color: #0d6efd; text-decoration: none; }
+  a:hover { text-decoration: underline; }
+</style>
+</head>
+<body>
+{{template "nav"}}
+<h1>Roles</h1>
+<table>
+  <thead>
+    <tr><th>Role</th><th>Config Beads</th><th>Advice Beads</th><th>Active Agents</th></tr>
+  </thead>
+  <tbody>
+  {{range .Roles}}
+    <tr>
+      <td><a href="/roles/{{.Name}}">{{.Name}}</a></td>
+      <td><span class="badge">{{.ConfigCount}}</span></td>
+      <td><span class="badge">{{.AdviceCount}}</span></td>
+      <td><span class="badge badge-primary">{{.AgentCount}}</span></td>
+    </tr>
+  {{else}}
+    <tr><td colspan="4">No roles found.</td></tr>
+  {{end}}
+  </tbody>
+</table>
+</body>
+</html>
+{{end}}
+`
+
+const rolePreviewTmpl = `
+{{define "role_preview"}}
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Role: {{.Name}}</title>
+<style>
+  body { font-family: system-ui, sans-serif; max-width: 960px; margin: 0 auto; padding: 1rem; background: #f8f9fa; }
+  h1 { color: #333; }
+  h2 { color: #495057; font-size: 1.2rem; margin-top: 1.5rem; border-bottom: 1px solid #dee2e6; padding-bottom: 0.3rem; }
+  .meta { color: #6c757d; font-size: 0.9rem; margin-bottom: 1rem; }
+  .card { background: #fff; border: 1px solid #e9ecef; border-radius: 8px; padding: 1rem; margin-bottom: 0.8rem; }
+  .card-title { font-weight: 600; color: #212529; margin-bottom: 0.3rem; }
+  .card-meta { font-size: 0.8rem; color: #6c757d; margin-bottom: 0.5rem; }
+  .label { display: inline-block; background: #e9ecef; padding: 0.15rem 0.4rem; border-radius: 3px; font-size: 0.8rem; margin-right: 0.2rem; }
+  pre { background: #f1f3f5; padding: 0.8rem; border-radius: 4px; font-size: 0.85rem; overflow-x: auto; max-height: 300px; white-space: pre-wrap; word-wrap: break-word; }
+  .agent-list { display: flex; flex-wrap: wrap; gap: 0.4rem; }
+  .agent-badge { background: #d1e7dd; color: #0f5132; padding: 0.2rem 0.5rem; border-radius: 3px; font-size: 0.85rem; }
+  .empty { color: #6c757d; font-style: italic; }
+  a { color: #0d6efd; text-decoration: none; }
+  a:hover { text-decoration: underline; }
+  .back { margin-bottom: 1rem; display: inline-block; }
+</style>
+</head>
+<body>
+{{template "nav"}}
+<a href="/roles" class="back">&larr; All Roles</a>
+<h1>Role: {{.Name}}</h1>
+
+<h2>Active Agents ({{len .ActiveAgents}})</h2>
+{{if .ActiveAgents}}
+<div class="agent-list">
+  {{range .ActiveAgents}}<span class="agent-badge">{{.}}</span>{{end}}
+</div>
+{{else}}
+<p class="empty">No active agents with this role.</p>
+{{end}}
+
+<h2>Config Beads ({{len .ConfigBeads}})</h2>
+{{range .ConfigBeads}}
+<div class="card">
+  <div class="card-title">{{.Title}}</div>
+  <div class="card-meta">
+    <code>{{.ID}}</code>
+    {{range .Labels}}<span class="label">{{.}}</span>{{end}}
+  </div>
+  {{if .Value}}<pre>{{.Value}}</pre>{{end}}
+</div>
+{{else}}
+<p class="empty">No config beads for this role.</p>
+{{end}}
+
+<h2>Advice Beads ({{len .AdviceBeads}})</h2>
+{{range .AdviceBeads}}
+<div class="card">
+  <div class="card-title">{{.Title}}</div>
+  <div class="card-meta">
+    <code>{{.ID}}</code>
+    {{range .Labels}}<span class="label">{{.}}</span>{{end}}
+  </div>
+  {{if .Description}}<pre>{{.Description}}</pre>{{end}}
+</div>
+{{else}}
+<p class="empty">No advice beads for this role.</p>
+{{end}}
+</body>
+</html>
+{{end}}
+`

--- a/gasboat/controller/cmd/roles-server/web.go
+++ b/gasboat/controller/cmd/roles-server/web.go
@@ -1,0 +1,330 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"html/template"
+	"log/slog"
+	"net/http"
+	"strings"
+
+	"gasboat/controller/internal/beadsapi"
+)
+
+// configBeadCategories are the known config bead categories (title values).
+var configBeadCategories = []string{
+	"claude-settings",
+	"claude-hooks",
+	"claude-mcp",
+	"claude-instructions",
+	"type",
+	"view",
+	"context",
+}
+
+// templateSet holds all parsed HTML templates.
+type templateSet struct {
+	t *template.Template
+}
+
+func newTemplateSet() *templateSet {
+	allTemplates := navTmpl + indexTmpl +
+		configBeadFormTmpl + configBeadListTmpl + configBeadDeleteConfirmTmpl +
+		adviceListTmpl + adviceFormTmpl + adviceDeleteConfirmTmpl +
+		instructionsFormTmpl +
+		rolesListTmpl + rolePreviewTmpl
+	t := template.Must(template.New("").Funcs(template.FuncMap{
+		"join":     strings.Join,
+		"toJSON":   toJSONString,
+		"contains": sliceContains,
+	}).Parse(allTemplates))
+	return &templateSet{t: t}
+}
+
+// WebUI serves HTML pages for managing config beads.
+type WebUI struct {
+	client *beadsapi.Client
+	logger *slog.Logger
+	tmpl   *templateSet
+}
+
+// NewWebUI creates a new web UI handler.
+func NewWebUI(client *beadsapi.Client, logger *slog.Logger, ts *templateSet) *WebUI {
+	return &WebUI{client: client, logger: logger, tmpl: ts}
+}
+
+// RegisterRoutes registers web UI routes on the given mux.
+func (ui *WebUI) RegisterRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("GET /config-beads", ui.handleListConfigBeadsPage)
+	mux.HandleFunc("GET /config-beads/new", ui.handleNewConfigBead)
+	mux.HandleFunc("POST /config-beads/new", ui.handleCreateConfigBead)
+	mux.HandleFunc("GET /config-beads/{id}/edit", ui.handleEditConfigBead)
+	mux.HandleFunc("POST /config-beads/{id}/edit", ui.handleUpdateConfigBead)
+	mux.HandleFunc("GET /config-beads/{id}/delete", ui.handleDeleteConfirm)
+	mux.HandleFunc("POST /config-beads/{id}/delete", ui.handleDeleteConfigBead)
+}
+
+type formData struct {
+	ID         string
+	Title      string
+	Labels     string
+	Value      string
+	Categories []string
+	Error      string
+	IsEdit     bool
+}
+
+func (ui *WebUI) handleListConfigBeadsPage(w http.ResponseWriter, r *http.Request) {
+	result, err := ui.client.ListBeadsFiltered(r.Context(), beadsapi.ListBeadsQuery{
+		Types: []string{"config"},
+	})
+	if err != nil {
+		ui.logger.Error("failed to list config beads", "error", err)
+		http.Error(w, "failed to list config beads", http.StatusInternalServerError)
+		return
+	}
+
+	beads := make([]configBead, 0, len(result.Beads))
+	for _, b := range result.Beads {
+		beads = append(beads, toConfigBead(b))
+	}
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	if err := ui.tmpl.t.ExecuteTemplate(w, "config_bead_list", beads); err != nil {
+		ui.logger.Error("template execution failed", "error", err)
+	}
+}
+
+func (ui *WebUI) handleNewConfigBead(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	if err := ui.tmpl.t.ExecuteTemplate(w, "config_bead_form", formData{
+		Categories: configBeadCategories,
+	}); err != nil {
+		ui.logger.Error("template execution failed", "error", err)
+	}
+}
+
+func (ui *WebUI) handleCreateConfigBead(w http.ResponseWriter, r *http.Request) {
+	fd := formData{Categories: configBeadCategories}
+
+	if err := r.ParseForm(); err != nil {
+		ui.renderFormError(w, fd, "invalid form data")
+		return
+	}
+
+	fd.Title = strings.TrimSpace(r.FormValue("title"))
+	fd.Labels = strings.TrimSpace(r.FormValue("labels"))
+	fd.Value = strings.TrimSpace(r.FormValue("value"))
+
+	if fd.Title == "" {
+		ui.renderFormError(w, fd, "title (category) is required")
+		return
+	}
+
+	if fd.Value != "" && !json.Valid([]byte(fd.Value)) {
+		ui.renderFormError(w, fd, "value must be valid JSON")
+		return
+	}
+
+	labels := parseLabels(fd.Labels)
+
+	// Build fields with the value.
+	fields := make(map[string]any)
+	if fd.Value != "" {
+		fields["value"] = fd.Value
+	}
+	fieldsJSON, _ := json.Marshal(fields)
+
+	_, err := ui.client.CreateBead(r.Context(), beadsapi.CreateBeadRequest{
+		Title:     fd.Title,
+		Type:      "config",
+		Kind:      "config",
+		Labels:    labels,
+		Fields:    fieldsJSON,
+		CreatedBy: "roles-server",
+	})
+	if err != nil {
+		ui.logger.Error("failed to create config bead", "error", err)
+		ui.renderFormError(w, fd, fmt.Sprintf("failed to create: %v", err))
+		return
+	}
+
+	http.Redirect(w, r, "/config-beads", http.StatusSeeOther)
+}
+
+func (ui *WebUI) handleEditConfigBead(w http.ResponseWriter, r *http.Request) {
+	beadID := r.PathValue("id")
+	bead, err := ui.client.GetBead(r.Context(), beadID)
+	if err != nil {
+		ui.logger.Error("failed to get config bead", "id", beadID, "error", err)
+		http.Error(w, "config bead not found", http.StatusNotFound)
+		return
+	}
+
+	valueStr := ""
+	if raw, ok := bead.Fields["value"]; ok && raw != "" {
+		var parsed any
+		if json.Unmarshal([]byte(raw), &parsed) == nil {
+			pretty, _ := json.MarshalIndent(parsed, "", "  ")
+			valueStr = string(pretty)
+		} else {
+			valueStr = raw
+		}
+	}
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	if err := ui.tmpl.t.ExecuteTemplate(w, "config_bead_form", formData{
+		ID:         beadID,
+		Title:      bead.Title,
+		Labels:     strings.Join(bead.Labels, ", "),
+		Value:      valueStr,
+		Categories: configBeadCategories,
+		IsEdit:     true,
+	}); err != nil {
+		ui.logger.Error("template execution failed", "error", err)
+	}
+}
+
+func (ui *WebUI) handleUpdateConfigBead(w http.ResponseWriter, r *http.Request) {
+	beadID := r.PathValue("id")
+	fd := formData{ID: beadID, IsEdit: true, Categories: configBeadCategories}
+
+	if err := r.ParseForm(); err != nil {
+		ui.renderFormError(w, fd, "invalid form data")
+		return
+	}
+
+	fd.Title = strings.TrimSpace(r.FormValue("title"))
+	fd.Labels = strings.TrimSpace(r.FormValue("labels"))
+	fd.Value = strings.TrimSpace(r.FormValue("value"))
+
+	if fd.Title == "" {
+		ui.renderFormError(w, fd, "title (category) is required")
+		return
+	}
+
+	if fd.Value != "" && !json.Valid([]byte(fd.Value)) {
+		ui.renderFormError(w, fd, "value must be valid JSON")
+		return
+	}
+
+	ctx := r.Context()
+
+	if err := ui.client.UpdateBead(ctx, beadID, beadsapi.UpdateBeadRequest{
+		Title: &fd.Title,
+	}); err != nil {
+		ui.logger.Error("failed to update config bead title", "id", beadID, "error", err)
+		ui.renderFormError(w, fd, fmt.Sprintf("failed to update: %v", err))
+		return
+	}
+
+	if err := ui.client.UpdateBeadFields(ctx, beadID, map[string]string{
+		"value": fd.Value,
+	}); err != nil {
+		ui.logger.Error("failed to update config bead value", "id", beadID, "error", err)
+		ui.renderFormError(w, fd, fmt.Sprintf("failed to update value: %v", err))
+		return
+	}
+
+	// Sync labels: fetch current, remove stale, add new.
+	bead, err := ui.client.GetBead(ctx, beadID)
+	if err == nil {
+		syncLabels(ctx, ui.client, ui.logger, beadID, bead.Labels, parseLabels(fd.Labels))
+	}
+
+	http.Redirect(w, r, "/config-beads", http.StatusSeeOther)
+}
+
+func (ui *WebUI) handleDeleteConfirm(w http.ResponseWriter, r *http.Request) {
+	beadID := r.PathValue("id")
+	bead, err := ui.client.GetBead(r.Context(), beadID)
+	if err != nil {
+		ui.logger.Error("failed to get config bead for delete", "id", beadID, "error", err)
+		http.Error(w, "config bead not found", http.StatusNotFound)
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	if err := ui.tmpl.t.ExecuteTemplate(w, "config_bead_delete_confirm", toConfigBead(bead)); err != nil {
+		ui.logger.Error("template execution failed", "error", err)
+	}
+}
+
+func (ui *WebUI) handleDeleteConfigBead(w http.ResponseWriter, r *http.Request) {
+	beadID := r.PathValue("id")
+	if err := ui.client.DeleteBead(r.Context(), beadID); err != nil {
+		ui.logger.Error("failed to delete config bead", "id", beadID, "error", err)
+		http.Error(w, fmt.Sprintf("failed to delete: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	http.Redirect(w, r, "/config-beads", http.StatusSeeOther)
+}
+
+func (ui *WebUI) renderFormError(w http.ResponseWriter, data formData, errMsg string) {
+	data.Error = errMsg
+	if data.Categories == nil {
+		data.Categories = configBeadCategories
+	}
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.WriteHeader(http.StatusUnprocessableEntity)
+	if err := ui.tmpl.t.ExecuteTemplate(w, "config_bead_form", data); err != nil {
+		ui.logger.Error("template execution failed", "error", err)
+	}
+}
+
+// parseLabels splits a comma-separated label string into trimmed, non-empty labels.
+func parseLabels(raw string) []string {
+	var labels []string
+	for _, l := range strings.Split(raw, ",") {
+		l = strings.TrimSpace(l)
+		if l != "" {
+			labels = append(labels, l)
+		}
+	}
+	return labels
+}
+
+// syncLabels reconciles bead labels: removes stale, adds new.
+func syncLabels(ctx context.Context, client *beadsapi.Client, logger *slog.Logger, beadID string, current, desired []string) {
+	currentSet := make(map[string]bool, len(current))
+	for _, l := range current {
+		currentSet[l] = true
+	}
+	desiredSet := make(map[string]bool, len(desired))
+	for _, l := range desired {
+		desiredSet[l] = true
+	}
+	for _, l := range current {
+		if !desiredSet[l] {
+			if err := client.RemoveLabel(ctx, beadID, l); err != nil {
+				logger.Warn("failed to remove label", "bead", beadID, "label", l, "error", err)
+			}
+		}
+	}
+	for _, l := range desired {
+		if !currentSet[l] {
+			if err := client.AddLabel(ctx, beadID, l); err != nil {
+				logger.Warn("failed to add label", "bead", beadID, "label", l, "error", err)
+			}
+		}
+	}
+}
+
+func toJSONString(v any) string {
+	b, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return fmt.Sprintf("%v", v)
+	}
+	return string(b)
+}
+
+func sliceContains(slice []string, item string) bool {
+	for _, s := range slice {
+		if s == item {
+			return true
+		}
+	}
+	return false
+}

--- a/gasboat/controller/cmd/roles-server/web_advice.go
+++ b/gasboat/controller/cmd/roles-server/web_advice.go
@@ -1,0 +1,201 @@
+package main
+
+import (
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strings"
+
+	"gasboat/controller/internal/beadsapi"
+)
+
+// AdviceUI serves HTML pages for managing advice beads.
+type AdviceUI struct {
+	client *beadsapi.Client
+	logger *slog.Logger
+	tmpl   *templateSet
+}
+
+// NewAdviceUI creates a new advice UI handler.
+func NewAdviceUI(client *beadsapi.Client, logger *slog.Logger, ts *templateSet) *AdviceUI {
+	return &AdviceUI{client: client, logger: logger, tmpl: ts}
+}
+
+// RegisterRoutes registers advice UI routes on the given mux.
+func (ui *AdviceUI) RegisterRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("GET /advice", ui.handleListAdvicePage)
+	mux.HandleFunc("GET /advice/new", ui.handleNewAdvice)
+	mux.HandleFunc("POST /advice/new", ui.handleCreateAdvice)
+	mux.HandleFunc("GET /advice/{id}/edit", ui.handleEditAdvice)
+	mux.HandleFunc("POST /advice/{id}/edit", ui.handleUpdateAdvice)
+	mux.HandleFunc("GET /advice/{id}/delete", ui.handleDeleteConfirm)
+	mux.HandleFunc("POST /advice/{id}/delete", ui.handleDeleteAdvice)
+}
+
+type adviceFormData struct {
+	ID          string
+	Title       string
+	Labels      string
+	Description string
+	Error       string
+	IsEdit      bool
+}
+
+func (ui *AdviceUI) handleListAdvicePage(w http.ResponseWriter, r *http.Request) {
+	result, err := ui.client.ListBeadsFiltered(r.Context(), beadsapi.ListBeadsQuery{
+		Types:    []string{"advice"},
+		Statuses: []string{"open", "in_progress"},
+	})
+	if err != nil {
+		ui.logger.Error("failed to list advice beads", "error", err)
+		http.Error(w, "failed to list advice beads", http.StatusInternalServerError)
+		return
+	}
+
+	beads := make([]adviceBead, 0, len(result.Beads))
+	for _, b := range result.Beads {
+		beads = append(beads, toAdviceBead(b))
+	}
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	if err := ui.tmpl.t.ExecuteTemplate(w, "advice_list", beads); err != nil {
+		ui.logger.Error("template execution failed", "error", err)
+	}
+}
+
+func (ui *AdviceUI) handleNewAdvice(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	if err := ui.tmpl.t.ExecuteTemplate(w, "advice_form", adviceFormData{}); err != nil {
+		ui.logger.Error("template execution failed", "error", err)
+	}
+}
+
+func (ui *AdviceUI) handleCreateAdvice(w http.ResponseWriter, r *http.Request) {
+	fd := adviceFormData{}
+
+	if err := r.ParseForm(); err != nil {
+		ui.renderFormError(w, fd, "invalid form data")
+		return
+	}
+
+	fd.Title = strings.TrimSpace(r.FormValue("title"))
+	fd.Labels = strings.TrimSpace(r.FormValue("labels"))
+	fd.Description = strings.TrimSpace(r.FormValue("description"))
+
+	if fd.Title == "" {
+		ui.renderFormError(w, fd, "title is required")
+		return
+	}
+
+	labels := parseLabels(fd.Labels)
+
+	_, err := ui.client.CreateBead(r.Context(), beadsapi.CreateBeadRequest{
+		Title:       fd.Title,
+		Type:        "advice",
+		Kind:        "data",
+		Labels:      labels,
+		Description: fd.Description,
+		CreatedBy:   "roles-server",
+	})
+	if err != nil {
+		ui.logger.Error("failed to create advice bead", "error", err)
+		ui.renderFormError(w, fd, fmt.Sprintf("failed to create: %v", err))
+		return
+	}
+
+	http.Redirect(w, r, "/advice", http.StatusSeeOther)
+}
+
+func (ui *AdviceUI) handleEditAdvice(w http.ResponseWriter, r *http.Request) {
+	beadID := r.PathValue("id")
+	bead, err := ui.client.GetBead(r.Context(), beadID)
+	if err != nil {
+		ui.logger.Error("failed to get advice bead", "id", beadID, "error", err)
+		http.Error(w, "advice bead not found", http.StatusNotFound)
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	if err := ui.tmpl.t.ExecuteTemplate(w, "advice_form", adviceFormData{
+		ID:          beadID,
+		Title:       bead.Title,
+		Labels:      strings.Join(bead.Labels, ", "),
+		Description: bead.Description,
+		IsEdit:      true,
+	}); err != nil {
+		ui.logger.Error("template execution failed", "error", err)
+	}
+}
+
+func (ui *AdviceUI) handleUpdateAdvice(w http.ResponseWriter, r *http.Request) {
+	beadID := r.PathValue("id")
+	fd := adviceFormData{ID: beadID, IsEdit: true}
+
+	if err := r.ParseForm(); err != nil {
+		ui.renderFormError(w, fd, "invalid form data")
+		return
+	}
+
+	fd.Title = strings.TrimSpace(r.FormValue("title"))
+	fd.Labels = strings.TrimSpace(r.FormValue("labels"))
+	fd.Description = strings.TrimSpace(r.FormValue("description"))
+
+	if fd.Title == "" {
+		ui.renderFormError(w, fd, "title is required")
+		return
+	}
+
+	ctx := r.Context()
+
+	if err := ui.client.UpdateBead(ctx, beadID, beadsapi.UpdateBeadRequest{
+		Title:       &fd.Title,
+		Description: &fd.Description,
+	}); err != nil {
+		ui.logger.Error("failed to update advice bead", "id", beadID, "error", err)
+		ui.renderFormError(w, fd, fmt.Sprintf("failed to update: %v", err))
+		return
+	}
+
+	// Sync labels.
+	bead, err := ui.client.GetBead(ctx, beadID)
+	if err == nil {
+		syncLabels(ctx, ui.client, ui.logger, beadID, bead.Labels, parseLabels(fd.Labels))
+	}
+
+	http.Redirect(w, r, "/advice", http.StatusSeeOther)
+}
+
+func (ui *AdviceUI) handleDeleteConfirm(w http.ResponseWriter, r *http.Request) {
+	beadID := r.PathValue("id")
+	bead, err := ui.client.GetBead(r.Context(), beadID)
+	if err != nil {
+		ui.logger.Error("failed to get advice bead for delete", "id", beadID, "error", err)
+		http.Error(w, "advice bead not found", http.StatusNotFound)
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	if err := ui.tmpl.t.ExecuteTemplate(w, "advice_delete_confirm", toAdviceBead(bead)); err != nil {
+		ui.logger.Error("template execution failed", "error", err)
+	}
+}
+
+func (ui *AdviceUI) handleDeleteAdvice(w http.ResponseWriter, r *http.Request) {
+	beadID := r.PathValue("id")
+	if err := ui.client.DeleteBead(r.Context(), beadID); err != nil {
+		ui.logger.Error("failed to delete advice bead", "id", beadID, "error", err)
+		http.Error(w, fmt.Sprintf("failed to delete: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	http.Redirect(w, r, "/advice", http.StatusSeeOther)
+}
+
+func (ui *AdviceUI) renderFormError(w http.ResponseWriter, data adviceFormData, errMsg string) {
+	data.Error = errMsg
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.WriteHeader(http.StatusUnprocessableEntity)
+	if err := ui.tmpl.t.ExecuteTemplate(w, "advice_form", data); err != nil {
+		ui.logger.Error("template execution failed", "error", err)
+	}
+}

--- a/gasboat/controller/cmd/roles-server/web_advice_test.go
+++ b/gasboat/controller/cmd/roles-server/web_advice_test.go
@@ -1,0 +1,194 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"gasboat/controller/internal/beadsapi"
+)
+
+func setupTestAdviceUI(t *testing.T) (*AdviceUI, *http.ServeMux) {
+	t.Helper()
+	daemon := mockDaemonWithMutations(t)
+	client, err := beadsapi.New(beadsapi.Config{HTTPAddr: daemon.URL})
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+	t.Cleanup(func() {
+		client.Close()
+		daemon.Close()
+	})
+	tmpl := newTemplateSet()
+	ui := NewAdviceUI(client, setupLogger("error"), tmpl)
+	mux := http.NewServeMux()
+	ui.RegisterRoutes(mux)
+	return ui, mux
+}
+
+func TestListAdvicePage(t *testing.T) {
+	_, mux := setupTestAdviceUI(t)
+
+	req := httptest.NewRequest("GET", "/advice", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, "Advice Beads") {
+		t.Error("expected page to contain 'Advice Beads'")
+	}
+}
+
+func TestNewAdviceForm(t *testing.T) {
+	_, mux := setupTestAdviceUI(t)
+
+	req := httptest.NewRequest("GET", "/advice/new", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, "New Advice") {
+		t.Error("expected page to contain 'New Advice'")
+	}
+}
+
+func TestCreateAdvice(t *testing.T) {
+	_, mux := setupTestAdviceUI(t)
+
+	form := url.Values{}
+	form.Set("title", "Test advice")
+	form.Set("labels", "global, role:crew")
+	form.Set("description", "Some advice content")
+
+	req := httptest.NewRequest("POST", "/advice/new", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("expected 303, got %d: %s", w.Code, w.Body.String())
+	}
+	if loc := w.Header().Get("Location"); loc != "/advice" {
+		t.Errorf("expected redirect to /advice, got %q", loc)
+	}
+}
+
+func TestCreateAdviceValidation(t *testing.T) {
+	_, mux := setupTestAdviceUI(t)
+
+	form := url.Values{}
+	form.Set("title", "")
+	form.Set("description", "Some content")
+
+	req := httptest.NewRequest("POST", "/advice/new", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("expected 422, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "title is required") {
+		t.Error("expected validation error for empty title")
+	}
+}
+
+func TestEditAdviceForm(t *testing.T) {
+	_, mux := setupTestAdviceUI(t)
+
+	req := httptest.NewRequest("GET", "/advice/adv-1/edit", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, "Edit Advice") {
+		t.Error("expected page to contain 'Edit Advice'")
+	}
+}
+
+func TestEditAdviceNotFound(t *testing.T) {
+	_, mux := setupTestAdviceUI(t)
+
+	req := httptest.NewRequest("GET", "/advice/nonexistent/edit", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", w.Code)
+	}
+}
+
+func TestUpdateAdvice(t *testing.T) {
+	_, mux := setupTestAdviceUI(t)
+
+	form := url.Values{}
+	form.Set("title", "Updated advice")
+	form.Set("labels", "global")
+	form.Set("description", "Updated content")
+
+	req := httptest.NewRequest("POST", "/advice/adv-1/edit", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("expected 303, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestDeleteAdviceConfirm(t *testing.T) {
+	_, mux := setupTestAdviceUI(t)
+
+	req := httptest.NewRequest("GET", "/advice/adv-1/delete", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, "Delete Advice") {
+		t.Error("expected page to contain 'Delete Advice'")
+	}
+	if !strings.Contains(body, "adv-1") {
+		t.Error("expected page to show bead ID")
+	}
+}
+
+func TestDeleteAdvice(t *testing.T) {
+	_, mux := setupTestAdviceUI(t)
+
+	req := httptest.NewRequest("POST", "/advice/adv-1/delete", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("expected 303, got %d: %s", w.Code, w.Body.String())
+	}
+	if loc := w.Header().Get("Location"); loc != "/advice" {
+		t.Errorf("expected redirect to /advice, got %q", loc)
+	}
+}
+
+func TestDeleteAdviceNotFound(t *testing.T) {
+	_, mux := setupTestAdviceUI(t)
+
+	req := httptest.NewRequest("GET", "/advice/nonexistent/delete", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", w.Code)
+	}
+}

--- a/gasboat/controller/cmd/roles-server/web_index.go
+++ b/gasboat/controller/cmd/roles-server/web_index.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"log/slog"
+	"net/http"
+	"sync"
+
+	"gasboat/controller/internal/beadsapi"
+)
+
+type indexData struct {
+	ConfigCount int
+	AdviceCount int
+	RoleCount   int
+	AgentCount  int
+}
+
+func handleIndex(client *beadsapi.Client, logger *slog.Logger, ts *templateSet) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/" {
+			http.NotFound(w, r)
+			return
+		}
+
+		ctx := r.Context()
+		var (
+			data      indexData
+			configErr error
+			adviceErr error
+			agentsErr error
+			wg        sync.WaitGroup
+		)
+
+		wg.Add(3)
+		go func() {
+			defer wg.Done()
+			result, err := client.ListBeadsFiltered(ctx, beadsapi.ListBeadsQuery{
+				Types: []string{"config"},
+			})
+			if err != nil {
+				configErr = err
+				return
+			}
+			data.ConfigCount = result.Total
+		}()
+		go func() {
+			defer wg.Done()
+			result, err := client.ListBeadsFiltered(ctx, beadsapi.ListBeadsQuery{
+				Types:    []string{"advice"},
+				Statuses: []string{"open", "in_progress"},
+			})
+			if err != nil {
+				adviceErr = err
+				return
+			}
+			data.AdviceCount = result.Total
+		}()
+		go func() {
+			defer wg.Done()
+			agents, err := client.ListAgentBeads(ctx)
+			if err != nil {
+				agentsErr = err
+				return
+			}
+			data.AgentCount = len(agents)
+			// Count unique roles.
+			roles := make(map[string]bool)
+			for _, a := range agents {
+				if a.Role != "" {
+					roles[a.Role] = true
+				}
+			}
+			data.RoleCount = len(roles)
+		}()
+		wg.Wait()
+
+		if configErr != nil {
+			logger.Error("failed to fetch config beads for index", "error", configErr)
+		}
+		if adviceErr != nil {
+			logger.Error("failed to fetch advice beads for index", "error", adviceErr)
+		}
+		if agentsErr != nil {
+			logger.Error("failed to fetch agents for index", "error", agentsErr)
+		}
+
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		if err := ts.t.ExecuteTemplate(w, "index", data); err != nil {
+			logger.Error("template execution failed", "error", err)
+		}
+	}
+}

--- a/gasboat/controller/cmd/roles-server/web_index_test.go
+++ b/gasboat/controller/cmd/roles-server/web_index_test.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"gasboat/controller/internal/beadsapi"
+)
+
+func TestIndexPage(t *testing.T) {
+	daemon := mockDaemonWithMutations(t)
+	client, err := beadsapi.New(beadsapi.Config{HTTPAddr: daemon.URL})
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+	t.Cleanup(func() {
+		client.Close()
+		daemon.Close()
+	})
+
+	tmpl := newTemplateSet()
+	handler := handleIndex(client, setupLogger("error"), tmpl)
+
+	req := httptest.NewRequest("GET", "/", nil)
+	w := httptest.NewRecorder()
+	handler(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, "Dashboard") {
+		t.Error("expected page to contain 'Dashboard'")
+	}
+	if !strings.Contains(body, "Config Beads") {
+		t.Error("expected page to contain 'Config Beads' card")
+	}
+	if !strings.Contains(body, "Advice Beads") {
+		t.Error("expected page to contain 'Advice Beads' card")
+	}
+}
+
+func TestIndexPageNavigation(t *testing.T) {
+	daemon := mockDaemonWithMutations(t)
+	client, err := beadsapi.New(beadsapi.Config{HTTPAddr: daemon.URL})
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+	t.Cleanup(func() {
+		client.Close()
+		daemon.Close()
+	})
+
+	tmpl := newTemplateSet()
+	handler := handleIndex(client, setupLogger("error"), tmpl)
+
+	req := httptest.NewRequest("GET", "/", nil)
+	w := httptest.NewRecorder()
+	handler(w, req)
+
+	body := w.Body.String()
+	if !strings.Contains(body, "Roles Server") {
+		t.Error("expected nav to contain 'Roles Server' brand")
+	}
+	if !strings.Contains(body, "/config-beads") {
+		t.Error("expected nav to contain link to config-beads")
+	}
+	if !strings.Contains(body, "/advice") {
+		t.Error("expected nav to contain link to advice")
+	}
+	if !strings.Contains(body, "/roles") {
+		t.Error("expected nav to contain link to roles")
+	}
+}
+
+func TestIndexPage404(t *testing.T) {
+	daemon := mockDaemonWithMutations(t)
+	client, err := beadsapi.New(beadsapi.Config{HTTPAddr: daemon.URL})
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+	t.Cleanup(func() {
+		client.Close()
+		daemon.Close()
+	})
+
+	tmpl := newTemplateSet()
+	handler := handleIndex(client, setupLogger("error"), tmpl)
+
+	req := httptest.NewRequest("GET", "/nonexistent", nil)
+	w := httptest.NewRecorder()
+	handler(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for unknown path, got %d", w.Code)
+	}
+}

--- a/gasboat/controller/cmd/roles-server/web_instructions.go
+++ b/gasboat/controller/cmd/roles-server/web_instructions.go
@@ -1,0 +1,170 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strings"
+
+	"gasboat/controller/internal/beadsapi"
+)
+
+// instructionSections are the known claude-instructions value keys,
+// in display order.
+var instructionSections = []instructionSection{
+	{Key: "identity", Label: "Identity", Hint: "Agent identity description"},
+	{Key: "lifecycle", Label: "Lifecycle", Hint: "Agent lifecycle (ephemeral/persistent/single-task)"},
+	{Key: "core_rules", Label: "Core Rules", Hint: "Fundamental rules (use kd, no TodoWrite)"},
+	{Key: "commands", Label: "Commands", Hint: "CLI command reference"},
+	{Key: "workflows", Label: "Workflows", Hint: "Common workflow patterns"},
+	{Key: "decisions", Label: "Decisions", Hint: "Human decision protocol"},
+	{Key: "session_resumption", Label: "Session Resumption", Hint: "How to resume after interruption"},
+	{Key: "session_close", Label: "Session Close", Hint: "Git push checklist"},
+	{Key: "stop_gate", Label: "Stop Gate", Hint: "Stop gate contract"},
+	{Key: "prime_header", Label: "Prime Header", Hint: "Context recovery header for gb prime"},
+	{Key: "stop_gate_blocked", Label: "Stop Gate Blocked Text", Hint: "Text injected by stop-gate.sh hook"},
+	{Key: "claude_md", Label: "CLAUDE.md", Hint: "CLAUDE.md content written by gb setup"},
+}
+
+type instructionSection struct {
+	Key   string
+	Label string
+	Hint  string
+}
+
+// InstructionsUI serves HTML pages for editing claude-instructions config beads.
+type InstructionsUI struct {
+	client *beadsapi.Client
+	logger *slog.Logger
+	tmpl   *templateSet
+}
+
+// NewInstructionsUI creates a new instructions UI handler.
+func NewInstructionsUI(client *beadsapi.Client, logger *slog.Logger, ts *templateSet) *InstructionsUI {
+	return &InstructionsUI{client: client, logger: logger, tmpl: ts}
+}
+
+// RegisterRoutes registers instruction editing routes.
+func (ui *InstructionsUI) RegisterRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("GET /config-beads/{id}/instructions", ui.handleEditInstructions)
+	mux.HandleFunc("POST /config-beads/{id}/instructions", ui.handleUpdateInstructions)
+}
+
+type instructionsFormData struct {
+	ID       string
+	Labels   string
+	Sections []sectionFormData
+	Error    string
+}
+
+type sectionFormData struct {
+	Key   string
+	Label string
+	Hint  string
+	Value string
+}
+
+func (ui *InstructionsUI) handleEditInstructions(w http.ResponseWriter, r *http.Request) {
+	beadID := r.PathValue("id")
+	bead, err := ui.client.GetBead(r.Context(), beadID)
+	if err != nil {
+		ui.logger.Error("failed to get config bead", "id", beadID, "error", err)
+		http.Error(w, "config bead not found", http.StatusNotFound)
+		return
+	}
+
+	if bead.Title != "claude-instructions" {
+		http.Error(w, "this editor is only for claude-instructions config beads", http.StatusBadRequest)
+		return
+	}
+
+	// Parse the value JSON into a map.
+	values := make(map[string]string)
+	if raw, ok := bead.Fields["value"]; ok && raw != "" {
+		var parsed map[string]any
+		if json.Unmarshal([]byte(raw), &parsed) == nil {
+			for k, v := range parsed {
+				switch val := v.(type) {
+				case string:
+					values[k] = val
+				default:
+					b, _ := json.MarshalIndent(val, "", "  ")
+					values[k] = string(b)
+				}
+			}
+		}
+	}
+
+	sections := make([]sectionFormData, len(instructionSections))
+	for i, s := range instructionSections {
+		sections[i] = sectionFormData{
+			Key:   s.Key,
+			Label: s.Label,
+			Hint:  s.Hint,
+			Value: values[s.Key],
+		}
+	}
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	if err := ui.tmpl.t.ExecuteTemplate(w, "instructions_form", instructionsFormData{
+		ID:       beadID,
+		Labels:   strings.Join(bead.Labels, ", "),
+		Sections: sections,
+	}); err != nil {
+		ui.logger.Error("template execution failed", "error", err)
+	}
+}
+
+func (ui *InstructionsUI) handleUpdateInstructions(w http.ResponseWriter, r *http.Request) {
+	beadID := r.PathValue("id")
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, "invalid form data", http.StatusBadRequest)
+		return
+	}
+
+	// Build the value JSON from individual section fields.
+	valueMap := make(map[string]string)
+	for _, s := range instructionSections {
+		val := r.FormValue("section_" + s.Key)
+		if strings.TrimSpace(val) != "" {
+			valueMap[s.Key] = val
+		}
+	}
+
+	valueJSON, err := json.Marshal(valueMap)
+	if err != nil {
+		ui.logger.Error("failed to marshal instructions", "error", err)
+		http.Error(w, "failed to marshal value", http.StatusInternalServerError)
+		return
+	}
+
+	ctx := r.Context()
+	if err := ui.client.UpdateBeadFields(ctx, beadID, map[string]string{
+		"value": string(valueJSON),
+	}); err != nil {
+		ui.logger.Error("failed to update instructions", "id", beadID, "error", err)
+
+		// Re-render form with error.
+		sections := make([]sectionFormData, len(instructionSections))
+		for i, s := range instructionSections {
+			sections[i] = sectionFormData{
+				Key:   s.Key,
+				Label: s.Label,
+				Hint:  s.Hint,
+				Value: r.FormValue("section_" + s.Key),
+			}
+		}
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		_ = ui.tmpl.t.ExecuteTemplate(w, "instructions_form", instructionsFormData{
+			ID:       beadID,
+			Labels:   r.FormValue("labels"),
+			Sections: sections,
+			Error:    fmt.Sprintf("failed to update: %v", err),
+		})
+		return
+	}
+
+	http.Redirect(w, r, "/config-beads", http.StatusSeeOther)
+}

--- a/gasboat/controller/cmd/roles-server/web_instructions_test.go
+++ b/gasboat/controller/cmd/roles-server/web_instructions_test.go
@@ -1,0 +1,167 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"gasboat/controller/internal/beadsapi"
+)
+
+func mockDaemonWithInstructions(t *testing.T) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("GET /v1/beads", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"beads": []any{}, "total": 0})
+	})
+
+	mux.HandleFunc("GET /v1/beads/{id}", func(w http.ResponseWriter, r *http.Request) {
+		beadID := r.PathValue("id")
+		w.Header().Set("Content-Type", "application/json")
+
+		switch beadID {
+		case "instr-1":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":     "instr-1",
+				"title":  "claude-instructions",
+				"type":   "config",
+				"kind":   "config",
+				"status": "open",
+				"labels": []string{"role:crew"},
+				"fields": map[string]any{
+					"value": `{"identity":"You are a crew agent","lifecycle":"persistent","core_rules":"Use kd for CRUD"}`,
+				},
+			})
+		case "not-instructions":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":     "not-instructions",
+				"title":  "claude-settings",
+				"type":   "config",
+				"kind":   "config",
+				"status": "open",
+				"labels": []string{"global"},
+				"fields": map[string]any{
+					"value": `{"model":"sonnet"}`,
+				},
+			})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			_ = json.NewEncoder(w).Encode(map[string]string{"error": "not found"})
+		}
+	})
+
+	mux.HandleFunc("PATCH /v1/beads/{id}", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+	})
+
+	return httptest.NewServer(mux)
+}
+
+func setupTestInstructionsUI(t *testing.T) (*InstructionsUI, *http.ServeMux) {
+	t.Helper()
+	daemon := mockDaemonWithInstructions(t)
+	client, err := beadsapi.New(beadsapi.Config{HTTPAddr: daemon.URL})
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+	t.Cleanup(func() {
+		client.Close()
+		daemon.Close()
+	})
+	tmpl := newTemplateSet()
+	ui := NewInstructionsUI(client, setupLogger("error"), tmpl)
+	mux := http.NewServeMux()
+	ui.RegisterRoutes(mux)
+	return ui, mux
+}
+
+func TestEditInstructionsForm(t *testing.T) {
+	_, mux := setupTestInstructionsUI(t)
+
+	req := httptest.NewRequest("GET", "/config-beads/instr-1/instructions", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, "Edit Claude Instructions") {
+		t.Error("expected page to contain 'Edit Claude Instructions'")
+	}
+	if !strings.Contains(body, "You are a crew agent") {
+		t.Error("expected form to contain identity value")
+	}
+	if !strings.Contains(body, "persistent") {
+		t.Error("expected form to contain lifecycle value")
+	}
+	if !strings.Contains(body, "section_identity") {
+		t.Error("expected form to contain section_identity field")
+	}
+}
+
+func TestEditInstructionsNotFound(t *testing.T) {
+	_, mux := setupTestInstructionsUI(t)
+
+	req := httptest.NewRequest("GET", "/config-beads/nonexistent/instructions", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", w.Code)
+	}
+}
+
+func TestEditInstructionsWrongType(t *testing.T) {
+	_, mux := setupTestInstructionsUI(t)
+
+	req := httptest.NewRequest("GET", "/config-beads/not-instructions/instructions", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestUpdateInstructions(t *testing.T) {
+	_, mux := setupTestInstructionsUI(t)
+
+	form := url.Values{}
+	form.Set("section_identity", "Updated identity")
+	form.Set("section_lifecycle", "ephemeral")
+	form.Set("section_core_rules", "New rules")
+
+	req := httptest.NewRequest("POST", "/config-beads/instr-1/instructions", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("expected 303, got %d: %s", w.Code, w.Body.String())
+	}
+	if loc := w.Header().Get("Location"); loc != "/config-beads" {
+		t.Errorf("expected redirect to /config-beads, got %q", loc)
+	}
+}
+
+func TestUpdateInstructionsEmptySections(t *testing.T) {
+	_, mux := setupTestInstructionsUI(t)
+
+	// Submit with all sections empty — should still succeed.
+	form := url.Values{}
+	req := httptest.NewRequest("POST", "/config-beads/instr-1/instructions", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("expected 303, got %d: %s", w.Code, w.Body.String())
+	}
+}

--- a/gasboat/controller/cmd/roles-server/web_roles.go
+++ b/gasboat/controller/cmd/roles-server/web_roles.go
@@ -1,0 +1,275 @@
+package main
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"sort"
+	"strings"
+	"sync"
+
+	"gasboat/controller/internal/beadsapi"
+)
+
+// RolesUI serves HTML pages for viewing roles and previewing their configuration.
+type RolesUI struct {
+	client *beadsapi.Client
+	logger *slog.Logger
+	tmpl   *templateSet
+}
+
+// NewRolesUI creates a new roles UI handler.
+func NewRolesUI(client *beadsapi.Client, logger *slog.Logger, ts *templateSet) *RolesUI {
+	return &RolesUI{client: client, logger: logger, tmpl: ts}
+}
+
+// RegisterRoutes registers roles UI routes on the given mux.
+func (ui *RolesUI) RegisterRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("GET /roles", ui.handleListRoles)
+	mux.HandleFunc("GET /roles/{role}", ui.handleRolePreview)
+}
+
+type rolesListData struct {
+	Roles []roleSummary
+}
+
+type roleSummary struct {
+	Name        string
+	ConfigCount int
+	AdviceCount int
+	AgentCount  int
+}
+
+type rolePreviewData struct {
+	Name         string
+	ConfigBeads  []roleConfigBead
+	AdviceBeads  []roleAdviceBead
+	ActiveAgents []string
+}
+
+type roleConfigBead struct {
+	ID     string
+	Title  string
+	Labels []string
+	Value  string
+}
+
+type roleAdviceBead struct {
+	ID          string
+	Title       string
+	Labels      []string
+	Description string
+}
+
+func (ui *RolesUI) handleListRoles(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	var (
+		configResult *beadsapi.ListBeadsResult
+		adviceResult *beadsapi.ListBeadsResult
+		agents       []beadsapi.AgentBead
+		configErr    error
+		adviceErr    error
+		agentsErr    error
+		wg           sync.WaitGroup
+	)
+
+	wg.Add(3)
+	go func() {
+		defer wg.Done()
+		configResult, configErr = ui.client.ListBeadsFiltered(ctx, beadsapi.ListBeadsQuery{
+			Types: []string{"config"},
+		})
+	}()
+	go func() {
+		defer wg.Done()
+		adviceResult, adviceErr = ui.client.ListBeadsFiltered(ctx, beadsapi.ListBeadsQuery{
+			Types:    []string{"advice"},
+			Statuses: []string{"open", "in_progress"},
+		})
+	}()
+	go func() {
+		defer wg.Done()
+		agents, agentsErr = ui.client.ListAgentBeads(ctx)
+	}()
+	wg.Wait()
+
+	if configErr != nil {
+		ui.logger.Error("failed to list config beads", "error", configErr)
+	}
+	if adviceErr != nil {
+		ui.logger.Error("failed to list advice beads", "error", adviceErr)
+	}
+	if agentsErr != nil {
+		ui.logger.Error("failed to list agents", "error", agentsErr)
+	}
+
+	roles := make(map[string]*roleSummary)
+	ensureRole := func(name string) *roleSummary {
+		rs, ok := roles[name]
+		if !ok {
+			rs = &roleSummary{Name: name}
+			roles[name] = rs
+		}
+		return rs
+	}
+	ensureRole("global")
+
+	if configResult != nil {
+		for _, b := range configResult.Beads {
+			for _, label := range b.Labels {
+				if name, ok := strings.CutPrefix(label, "role:"); ok {
+					ensureRole(name).ConfigCount++
+				}
+				if label == "global" {
+					ensureRole("global").ConfigCount++
+				}
+			}
+		}
+	}
+
+	if adviceResult != nil {
+		for _, b := range adviceResult.Beads {
+			for _, label := range b.Labels {
+				if name, ok := strings.CutPrefix(label, "role:"); ok {
+					ensureRole(name).AdviceCount++
+				}
+				if label == "global" {
+					ensureRole("global").AdviceCount++
+				}
+			}
+		}
+	}
+
+	for _, ag := range agents {
+		if ag.Role != "" {
+			ensureRole(ag.Role).AgentCount++
+		}
+	}
+
+	result := make([]roleSummary, 0, len(roles))
+	for _, rs := range roles {
+		result = append(result, *rs)
+	}
+	sort.Slice(result, func(i, j int) bool {
+		if result[i].Name == "global" {
+			return true
+		}
+		if result[j].Name == "global" {
+			return false
+		}
+		return result[i].Name < result[j].Name
+	})
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	if err := ui.tmpl.t.ExecuteTemplate(w, "roles_list", rolesListData{Roles: result}); err != nil {
+		ui.logger.Error("template execution failed", "error", err)
+	}
+}
+
+func (ui *RolesUI) handleRolePreview(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	roleName := r.PathValue("role")
+
+	var labelFilter []string
+	if roleName == "global" {
+		labelFilter = []string{"global"}
+	} else {
+		labelFilter = []string{"role:" + roleName}
+	}
+
+	var (
+		configResult *beadsapi.ListBeadsResult
+		adviceResult *beadsapi.ListBeadsResult
+		agents       []beadsapi.AgentBead
+		configErr    error
+		adviceErr    error
+		agentsErr    error
+		wg           sync.WaitGroup
+	)
+
+	wg.Add(3)
+	go func() {
+		defer wg.Done()
+		configResult, configErr = ui.client.ListBeadsFiltered(ctx, beadsapi.ListBeadsQuery{
+			Types:  []string{"config"},
+			Labels: labelFilter,
+		})
+	}()
+	go func() {
+		defer wg.Done()
+		adviceResult, adviceErr = ui.client.ListBeadsFiltered(ctx, beadsapi.ListBeadsQuery{
+			Types:    []string{"advice"},
+			Statuses: []string{"open", "in_progress"},
+			Labels:   labelFilter,
+		})
+	}()
+	go func() {
+		defer wg.Done()
+		agents, agentsErr = ui.client.ListAgentBeads(ctx)
+	}()
+	wg.Wait()
+
+	if configErr != nil {
+		ui.logger.Error("failed to list config beads for role", "role", roleName, "error", configErr)
+		http.Error(w, "failed to fetch config beads", http.StatusInternalServerError)
+		return
+	}
+	if adviceErr != nil {
+		ui.logger.Error("failed to list advice beads for role", "role", roleName, "error", adviceErr)
+		http.Error(w, "failed to fetch advice beads", http.StatusInternalServerError)
+		return
+	}
+	if agentsErr != nil {
+		ui.logger.Error("failed to list agents", "error", agentsErr)
+	}
+
+	configs := make([]roleConfigBead, 0, len(configResult.Beads))
+	for _, b := range configResult.Beads {
+		valueStr := ""
+		if raw, ok := b.Fields["value"]; ok && raw != "" {
+			var parsed any
+			if json.Unmarshal([]byte(raw), &parsed) == nil {
+				pretty, _ := json.MarshalIndent(parsed, "", "  ")
+				valueStr = string(pretty)
+			} else {
+				valueStr = raw
+			}
+		}
+		configs = append(configs, roleConfigBead{
+			ID:     b.ID,
+			Title:  b.Title,
+			Labels: b.Labels,
+			Value:  valueStr,
+		})
+	}
+
+	advices := make([]roleAdviceBead, 0, len(adviceResult.Beads))
+	for _, b := range adviceResult.Beads {
+		advices = append(advices, roleAdviceBead{
+			ID:          b.ID,
+			Title:       b.Title,
+			Labels:      b.Labels,
+			Description: b.Description,
+		})
+	}
+
+	var activeAgents []string
+	for _, ag := range agents {
+		if ag.Role == roleName {
+			activeAgents = append(activeAgents, ag.AgentName)
+		}
+	}
+
+	data := rolePreviewData{
+		Name:         roleName,
+		ConfigBeads:  configs,
+		AdviceBeads:  advices,
+		ActiveAgents: activeAgents,
+	}
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	if err := ui.tmpl.t.ExecuteTemplate(w, "role_preview", data); err != nil {
+		ui.logger.Error("template execution failed", "error", err)
+	}
+}

--- a/gasboat/controller/cmd/roles-server/web_roles_test.go
+++ b/gasboat/controller/cmd/roles-server/web_roles_test.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"gasboat/controller/internal/beadsapi"
+)
+
+func TestRolesListPage(t *testing.T) {
+	daemon := mockDaemonWithMutations(t)
+	client, err := beadsapi.New(beadsapi.Config{HTTPAddr: daemon.URL})
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+	t.Cleanup(func() {
+		client.Close()
+		daemon.Close()
+	})
+
+	tmpl := newTemplateSet()
+	ui := NewRolesUI(client, setupLogger("error"), tmpl)
+
+	req := httptest.NewRequest("GET", "/roles", nil)
+	w := httptest.NewRecorder()
+	ui.handleListRoles(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, "Roles") {
+		t.Error("expected page to contain 'Roles' heading")
+	}
+	if !strings.Contains(body, "global") {
+		t.Error("expected page to list 'global' role")
+	}
+}
+
+func TestRolePreviewPage(t *testing.T) {
+	daemon := mockDaemonWithMutations(t)
+	client, err := beadsapi.New(beadsapi.Config{HTTPAddr: daemon.URL})
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+	t.Cleanup(func() {
+		client.Close()
+		daemon.Close()
+	})
+
+	tmpl := newTemplateSet()
+	ui := NewRolesUI(client, setupLogger("error"), tmpl)
+
+	req := httptest.NewRequest("GET", "/roles/crew", nil)
+	req.SetPathValue("role", "crew")
+	w := httptest.NewRecorder()
+	ui.handleRolePreview(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, "Role: crew") {
+		t.Error("expected page to show role name")
+	}
+	if !strings.Contains(body, "Config Beads") {
+		t.Error("expected page to contain Config Beads section")
+	}
+	if !strings.Contains(body, "Advice Beads") {
+		t.Error("expected page to contain Advice Beads section")
+	}
+}
+
+func TestRolePreviewGlobal(t *testing.T) {
+	daemon := mockDaemonWithMutations(t)
+	client, err := beadsapi.New(beadsapi.Config{HTTPAddr: daemon.URL})
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+	t.Cleanup(func() {
+		client.Close()
+		daemon.Close()
+	})
+
+	tmpl := newTemplateSet()
+	ui := NewRolesUI(client, setupLogger("error"), tmpl)
+
+	req := httptest.NewRequest("GET", "/roles/global", nil)
+	req.SetPathValue("role", "global")
+	w := httptest.NewRecorder()
+	ui.handleRolePreview(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, "Role: global") {
+		t.Error("expected page to show 'Role: global'")
+	}
+}

--- a/gasboat/controller/cmd/roles-server/web_test.go
+++ b/gasboat/controller/cmd/roles-server/web_test.go
@@ -1,0 +1,353 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"gasboat/controller/internal/beadsapi"
+)
+
+func setupTestWebUI(t *testing.T) (*WebUI, *http.ServeMux, *httptest.Server) {
+	t.Helper()
+	daemon := mockDaemonWithMutations(t)
+	client, err := beadsapi.New(beadsapi.Config{HTTPAddr: daemon.URL})
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+	t.Cleanup(func() {
+		client.Close()
+		daemon.Close()
+	})
+	tmpl := newTemplateSet()
+	ui := NewWebUI(client, setupLogger("error"), tmpl)
+	mux := http.NewServeMux()
+	ui.RegisterRoutes(mux)
+	return ui, mux, daemon
+}
+
+// mockDaemonWithMutations extends the mock daemon with POST/PATCH/DELETE handlers.
+func mockDaemonWithMutations(t *testing.T) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+
+	// Bead listing (reuse from existing mock).
+	mux.HandleFunc("GET /v1/beads", func(w http.ResponseWriter, r *http.Request) {
+		beadType := r.URL.Query().Get("type")
+		w.Header().Set("Content-Type", "application/json")
+
+		switch beadType {
+		case "config":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"beads": []map[string]any{
+					{
+						"id":     "cfg-1",
+						"title":  "claude-settings",
+						"type":   "config",
+						"kind":   "config",
+						"status": "open",
+						"labels": []string{"global"},
+						"fields": map[string]any{
+							"value": `{"model":"sonnet"}`,
+						},
+					},
+					{
+						"id":     "cfg-2",
+						"title":  "claude-instructions",
+						"type":   "config",
+						"kind":   "config",
+						"status": "open",
+						"labels": []string{"role:crew"},
+						"fields": map[string]any{
+							"value": `{"lifecycle":"persistent"}`,
+						},
+					},
+				},
+				"total": 2,
+			})
+		case "advice":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"beads": []map[string]any{
+					{
+						"id":          "adv-1",
+						"title":       "Use gb prime",
+						"type":        "advice",
+						"kind":        "data",
+						"status":      "open",
+						"labels":      []string{"global"},
+						"description": "Run gb prime after compaction",
+					},
+				},
+				"total": 1,
+			})
+		default:
+			_ = json.NewEncoder(w).Encode(map[string]any{"beads": []any{}, "total": 0})
+		}
+	})
+
+	// Get single bead.
+	mux.HandleFunc("GET /v1/beads/{id}", func(w http.ResponseWriter, r *http.Request) {
+		beadID := r.PathValue("id")
+		w.Header().Set("Content-Type", "application/json")
+
+		switch beadID {
+		case "cfg-1":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":     "cfg-1",
+				"title":  "claude-settings",
+				"type":   "config",
+				"kind":   "config",
+				"status": "open",
+				"labels": []string{"global"},
+				"fields": map[string]any{
+					"value": `{"model":"sonnet"}`,
+				},
+			})
+		case "adv-1":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":          "adv-1",
+				"title":       "Use gb prime",
+				"type":        "advice",
+				"kind":        "data",
+				"status":      "open",
+				"labels":      []string{"global"},
+				"description": "Run gb prime after compaction",
+			})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			_ = json.NewEncoder(w).Encode(map[string]string{"error": "not found"})
+		}
+	})
+
+	// Create bead.
+	mux.HandleFunc("POST /v1/beads", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]string{"id": "cfg-new"})
+	})
+
+	// Update bead (PATCH).
+	mux.HandleFunc("PATCH /v1/beads/{id}", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+	})
+
+	// Update fields.
+	mux.HandleFunc("PUT /v1/beads/{id}/fields", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+	})
+
+	// Delete bead.
+	mux.HandleFunc("DELETE /v1/beads/{id}", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	// Labels.
+	mux.HandleFunc("POST /v1/beads/{id}/labels", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+	})
+	mux.HandleFunc("DELETE /v1/beads/{id}/labels/{label}", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	return httptest.NewServer(mux)
+}
+
+
+func TestListConfigBeadsPage(t *testing.T) {
+	_, mux, _ := setupTestWebUI(t)
+
+	req := httptest.NewRequest("GET", "/config-beads", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, "Config Beads") {
+		t.Error("expected page to contain 'Config Beads' heading")
+	}
+	if !strings.Contains(body, "cfg-1") {
+		t.Error("expected page to contain bead ID cfg-1")
+	}
+	if !strings.Contains(body, "claude-settings") {
+		t.Error("expected page to contain category 'claude-settings'")
+	}
+}
+
+func TestNewConfigBeadForm(t *testing.T) {
+	_, mux, _ := setupTestWebUI(t)
+
+	req := httptest.NewRequest("GET", "/config-beads/new", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, "New Config Bead") {
+		t.Error("expected page to contain 'New Config Bead'")
+	}
+	if !strings.Contains(body, "claude-settings") {
+		t.Error("expected category dropdown to contain 'claude-settings'")
+	}
+}
+
+func TestCreateConfigBead(t *testing.T) {
+	_, mux, _ := setupTestWebUI(t)
+
+	form := url.Values{}
+	form.Set("title", "claude-settings")
+	form.Set("labels", "global, role:crew")
+	form.Set("value", `{"model":"opus"}`)
+
+	req := httptest.NewRequest("POST", "/config-beads/new", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("expected 303 redirect, got %d: %s", w.Code, w.Body.String())
+	}
+	if loc := w.Header().Get("Location"); loc != "/config-beads" {
+		t.Errorf("expected redirect to /config-beads, got %q", loc)
+	}
+}
+
+func TestCreateConfigBeadValidation(t *testing.T) {
+	_, mux, _ := setupTestWebUI(t)
+
+	tests := []struct {
+		name      string
+		title     string
+		value     string
+		wantError string
+	}{
+		{"empty title", "", `{}`, "title (category) is required"},
+		{"invalid JSON", "claude-settings", `{bad`, "value must be valid JSON"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			form := url.Values{}
+			form.Set("title", tt.title)
+			form.Set("value", tt.value)
+
+			req := httptest.NewRequest("POST", "/config-beads/new", strings.NewReader(form.Encode()))
+			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+			w := httptest.NewRecorder()
+			mux.ServeHTTP(w, req)
+
+			if w.Code != http.StatusUnprocessableEntity {
+				t.Fatalf("expected 422, got %d", w.Code)
+			}
+			body := w.Body.String()
+			if !strings.Contains(body, tt.wantError) {
+				t.Errorf("expected error %q in body, got: %s", tt.wantError, body)
+			}
+		})
+	}
+}
+
+func TestEditConfigBeadForm(t *testing.T) {
+	_, mux, _ := setupTestWebUI(t)
+
+	req := httptest.NewRequest("GET", "/config-beads/cfg-1/edit", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, "Edit Config Bead") {
+		t.Error("expected page to contain 'Edit Config Bead'")
+	}
+	if !strings.Contains(body, "claude-settings") {
+		t.Error("expected form to have category pre-selected")
+	}
+}
+
+func TestEditConfigBeadNotFound(t *testing.T) {
+	_, mux, _ := setupTestWebUI(t)
+
+	req := httptest.NewRequest("GET", "/config-beads/nonexistent/edit", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", w.Code)
+	}
+}
+
+func TestUpdateConfigBead(t *testing.T) {
+	_, mux, _ := setupTestWebUI(t)
+
+	form := url.Values{}
+	form.Set("title", "claude-settings")
+	form.Set("labels", "global")
+	form.Set("value", `{"model":"opus"}`)
+
+	req := httptest.NewRequest("POST", "/config-beads/cfg-1/edit", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("expected 303 redirect, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestDeleteConfirm(t *testing.T) {
+	_, mux, _ := setupTestWebUI(t)
+
+	req := httptest.NewRequest("GET", "/config-beads/cfg-1/delete", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, "Delete Config Bead") {
+		t.Error("expected page to contain 'Delete Config Bead'")
+	}
+	if !strings.Contains(body, "cfg-1") {
+		t.Error("expected page to show bead ID")
+	}
+}
+
+func TestDeleteConfigBead(t *testing.T) {
+	_, mux, _ := setupTestWebUI(t)
+
+	req := httptest.NewRequest("POST", "/config-beads/cfg-1/delete", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("expected 303 redirect, got %d: %s", w.Code, w.Body.String())
+	}
+	if loc := w.Header().Get("Location"); loc != "/config-beads" {
+		t.Errorf("expected redirect to /config-beads, got %q", loc)
+	}
+}
+
+func TestDeleteConfirmNotFound(t *testing.T) {
+	_, mux, _ := setupTestWebUI(t)
+
+	req := httptest.NewRequest("GET", "/config-beads/nonexistent/delete", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", w.Code)
+	}
+}
+

--- a/gasboat/docs/formula-role-project-transitions.md
+++ b/gasboat/docs/formula-role-project-transitions.md
@@ -4,7 +4,7 @@
 
 **Epic:** kd-8rRZvjyajQ
 **Date:** 2026-03-08
-**Status:** Draft
+**Status:** Complete (all 4 phases implemented)
 
 ---
 

--- a/gasboat/docs/multi-role-assignment.md
+++ b/gasboat/docs/multi-role-assignment.md
@@ -4,7 +4,7 @@
 
 **Epic:** kd-TNrihu5sTo
 **Date:** 2026-03-07
-**Status:** Draft
+**Status:** Complete (all phases implemented)
 
 ---
 

--- a/gasboat/helm/gasboat/templates/roles-server/deployment.yaml
+++ b/gasboat/helm/gasboat/templates/roles-server/deployment.yaml
@@ -1,0 +1,77 @@
+{{- if .Values.rolesServer.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "gasboat.fullname" . }}-roles-server
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "gasboat.labels" . | nindent 4 }}
+    app.kubernetes.io/component: roles-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "gasboat.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: roles-server
+  template:
+    metadata:
+      labels:
+        {{- include "gasboat.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: roles-server
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: roles-server
+          image: "{{ .Values.rolesServer.image.repository }}:{{ include "gasboat.imageTag" (dict "tag" .Values.rolesServer.image.tag "global" .Values.global "Chart" .Chart) }}"
+          imagePullPolicy: {{ include "gasboat.imagePullPolicy" (dict "pullPolicy" .Values.rolesServer.image.pullPolicy "global" .Values.global) }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.rolesServer.service.port | default 8092 }}
+              protocol: TCP
+          env:
+            - name: BEADS_HTTP_ADDR
+              value: "http://{{ include "gasboat.beads.host" . }}:{{ include "gasboat.beads.httpPort" . }}"
+            {{- if .Values.beads.tokenSecret }}
+            - name: BEADS_DAEMON_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "gasboat.beads.tokenSecretName" . }}
+                  key: token
+            {{- end }}
+            - name: LISTEN_ADDR
+              value: ":{{ .Values.rolesServer.service.port | default 8092 }}"
+            {{- if .Values.rolesServer.logLevel }}
+            - name: LOG_LEVEL
+              value: {{ .Values.rolesServer.logLevel | quote }}
+            {{- end }}
+            {{- if .Values.rolesServer.ingress.pathPrefix }}
+            - name: BASE_PATH
+              value: {{ .Values.rolesServer.ingress.pathPrefix | quote }}
+            {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 15
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: http
+            initialDelaySeconds: 3
+            periodSeconds: 10
+          resources:
+            {{- toYaml .Values.rolesServer.resources | nindent 12 }}
+      {{- include "gasboat.nodeSelector" (dict "local" .Values.rolesServer.nodeSelector "global" .Values.global.nodeSelector) | nindent 6 }}
+      {{- with .Values.rolesServer.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.rolesServer.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/gasboat/helm/gasboat/templates/roles-server/ingressroute.yaml
+++ b/gasboat/helm/gasboat/templates/roles-server/ingressroute.yaml
@@ -1,0 +1,85 @@
+{{- if and .Values.rolesServer.enabled .Values.rolesServer.ingress.enabled }}
+{{- $fullname := printf "%s-roles-server" (include "gasboat.fullname" .) -}}
+{{- $host := .Values.rolesServer.ingress.host -}}
+{{- $port := .Values.rolesServer.service.port | default 8092 -}}
+{{- $pathPrefix := .Values.rolesServer.ingress.pathPrefix | default "" -}}
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: {{ $fullname }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "gasboat.labels" . | nindent 4 }}
+    app.kubernetes.io/component: roles-server
+spec:
+  entryPoints:
+    - web
+    - websecure
+  routes:
+    - match: Host(`{{ $host }}`){{ if $pathPrefix }} && PathPrefix(`{{ $pathPrefix }}`){{ end }}
+      kind: Rule
+      priority: 100
+      services:
+        - name: {{ $fullname }}
+          port: {{ $port }}
+      middlewares:
+        {{- if $pathPrefix }}
+        - name: {{ $fullname }}-stripprefix
+        {{- end }}
+        {{- if .Values.rolesServer.ingress.ipWhitelist.enabled }}
+        - name: {{ $fullname }}-ipwhitelist
+        {{- end }}
+        {{- if .Values.rolesServer.ingress.basicAuth.enabled }}
+        - name: {{ $fullname }}-basicauth
+        {{- end }}
+  {{- if .Values.tls.enabled }}
+  tls:
+    secretName: {{ include "gasboat.fullname" . }}-wildcard-tls
+  {{- end }}
+{{- if $pathPrefix }}
+---
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: {{ $fullname }}-stripprefix
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "gasboat.labels" . | nindent 4 }}
+    app.kubernetes.io/component: roles-server
+spec:
+  stripPrefix:
+    prefixes:
+      - {{ $pathPrefix }}
+{{- end }}
+{{- if .Values.rolesServer.ingress.ipWhitelist.enabled }}
+---
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: {{ $fullname }}-ipwhitelist
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "gasboat.labels" . | nindent 4 }}
+    app.kubernetes.io/component: roles-server
+spec:
+  ipWhiteList:
+    sourceRange:
+      {{- toYaml .Values.rolesServer.ingress.ipWhitelist.sourceRange | nindent 6 }}
+    ipStrategy:
+      depth: {{ .Values.rolesServer.ingress.ipWhitelist.depth | default 1 }}
+{{- end }}
+{{- if .Values.rolesServer.ingress.basicAuth.enabled }}
+---
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: {{ $fullname }}-basicauth
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "gasboat.labels" . | nindent 4 }}
+    app.kubernetes.io/component: roles-server
+spec:
+  basicAuth:
+    secret: {{ include "gasboat.basicAuth.secret" (dict "local" .Values.rolesServer.ingress.basicAuth.secret "global" .Values.global.basicAuth.secret) }}
+{{- end }}
+{{- end }}

--- a/gasboat/helm/gasboat/templates/roles-server/service.yaml
+++ b/gasboat/helm/gasboat/templates/roles-server/service.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.rolesServer.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "gasboat.fullname" . }}-roles-server
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "gasboat.labels" . | nindent 4 }}
+    app.kubernetes.io/component: roles-server
+spec:
+  type: {{ .Values.rolesServer.service.type | default "ClusterIP" }}
+  ports:
+    - port: {{ .Values.rolesServer.service.port | default 8092 }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "gasboat.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: roles-server
+{{- end }}

--- a/gasboat/helm/gasboat/values.yaml
+++ b/gasboat/helm/gasboat/values.yaml
@@ -683,6 +683,52 @@ adviceViewer:
   affinity: {}
 
 # =============================================================================
+# Roles Server — web UI for managing agent roles and configuration
+# =============================================================================
+rolesServer:
+  enabled: false
+
+  image:
+    repository: ghcr.io/groblegark/gasboats/roles-server
+    tag: ""
+    pullPolicy: Always
+
+  # Log level: debug, info, warn, error
+  logLevel: ""
+
+  service:
+    type: ClusterIP
+    port: 8092
+
+  ingress:
+    enabled: false
+    host: ""
+    # Path prefix for the roles server (e.g. "/roles"). Traefik strips
+    # the prefix before forwarding; BASE_PATH env var is set so templates
+    # generate correct links.
+    pathPrefix: ""
+    ipWhitelist:
+      enabled: false
+      sourceRange: []
+      depth: 1
+    basicAuth:
+      enabled: false
+      secret: ""  # Per-service override; falls back to global.basicAuth.secret
+
+  resources:
+    requests:
+      cpu: 50m
+      memory: 64Mi
+    limits:
+      cpu: 200m
+      memory: 128Mi
+
+  # Pod scheduling
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+# =============================================================================
 # Beads3D — 3D visualization frontend for beads issues
 # Static SPA served by nginx, reverse-proxies /api/ to beads daemon.
 # =============================================================================

--- a/gasboat/images/roles-server/Dockerfile
+++ b/gasboat/images/roles-server/Dockerfile
@@ -1,0 +1,27 @@
+# roles-server: web UI for managing agent roles and configuration.
+# Multi-stage build: Go builder -> distroless runtime.
+#
+# Build:
+#   docker build -t gasboat/roles-server:latest -f images/roles-server/Dockerfile .
+
+FROM golang:1.25-bookworm AS builder
+
+ARG VERSION=dev
+ARG COMMIT=unknown
+
+WORKDIR /build
+COPY controller/ ./
+
+RUN CGO_ENABLED=0 go build \
+    -ldflags="-s -w -X main.version=${VERSION} -X main.commit=${COMMIT}" \
+    -o /roles-server ./cmd/roles-server/
+
+# -- Runtime -------------------------------------------------------------------
+FROM gcr.io/distroless/static-debian12:nonroot
+
+COPY --from=builder /roles-server /roles-server
+
+USER nonroot:nonroot
+EXPOSE 8092
+
+ENTRYPOINT ["/roles-server"]


### PR DESCRIPTION
## Summary
- Port roles-server from old gasboat repo to gasboats monorepo (rebased onto current main)
- Read/write HTTP API for viewing and managing agent roles, config beads, advice beads, and claude-instructions
- Web UI with navigation header, role list/preview, config CRUD, advice CRUD, and instructions editor
- Helm chart templates, Dockerfile, Makefile targets, and RWX CI build+push tasks
- Supersedes PR #5 (closed)

## Context
The original PRs #5 and #8 were created from the old single-repo gasboat before the monorepo migration. They couldn't be rebased normally because file paths changed (`controller/` → `gasboat/controller/`). This PR ports the unique roles-server code to the correct monorepo paths on a fresh branch from main.

## Test plan
- [x] `go build ./cmd/roles-server/` compiles
- [x] `go test ./cmd/roles-server/` passes
- [x] `go build ./...` (full controller) passes
- [x] `helm lint helm/gasboat/` passes
- [ ] Manual: deploy with `rolesServer.enabled=true` and verify web UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)