### PR TITLE
fix(controller): don't default CLAUDE_TEAMMATE_MODE to tmux

### DIFF
--- a/gasboat/controller/internal/config/config.go
+++ b/gasboat/controller/internal/config/config.go
@@ -295,7 +295,7 @@ func Parse() *Config {
 		AgentStorageClass:  os.Getenv("AGENT_STORAGE_CLASS"),
 		ClaudeModel:             os.Getenv("CLAUDE_MODEL"),
 		ClaudeTeamsEnabled:      envBoolOr("CLAUDE_TEAMS_ENABLED", false),
-		ClaudeTeammateMode:      envOr("CLAUDE_TEAMMATE_MODE", "tmux"),
+		ClaudeTeammateMode:      envOr("CLAUDE_TEAMMATE_MODE", ""),
 		ClaudeTeamsMaxTeammates:  envIntOr("CLAUDE_TEAMS_MAX_TEAMMATES", 0),
 		ClaudeTeamsCPURequest:    os.Getenv("CLAUDE_TEAMS_CPU_REQUEST"),
 		ClaudeTeamsCPULimit:      os.Getenv("CLAUDE_TEAMS_CPU_LIMIT"),


### PR DESCRIPTION
## Summary
- Remove the default value of `"tmux"` for `CLAUDE_TEAMMATE_MODE`, defaulting to empty string instead
- This prevents the controller from forcing tmux teammate mode when the env var is unset

## Test plan
- [ ] Verify agents start without teammate mode when `CLAUDE_TEAMMATE_MODE` is unset
- [ ] Verify setting `CLAUDE_TEAMMATE_MODE=tmux` explicitly still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)