### PR TITLE
fix(gasboat/bridge): @mention decision owners in Slack notifications

### DIFF
--- a/gasboat/controller/internal/bridge/bot_commands.go
+++ b/gasboat/controller/internal/bridge/bot_commands.go
@@ -303,6 +303,14 @@ func (b *Bot) spawnAndRespond(ctx context.Context, cmd slack.SlashCommand, agent
 
 	b.logger.Info("spawned agent via Slack", "agent", agentName, "project", project, "task", taskID, "role", role, "prompt", customPrompt, "bead", beadID, "user", cmd.UserID)
 
+	// Best-effort: store the Slack user ID of the spawner on the agent bead
+	// so decision notifications can @mention the right person.
+	if cmd.UserID != "" {
+		_ = b.daemon.UpdateBeadFields(ctx, beadID, map[string]string{
+			"slack_user_id": cmd.UserID,
+		})
+	}
+
 	text := fmt.Sprintf(":rocket: Spawning agent *%s*", agentName)
 	if project != "" {
 		text += fmt.Sprintf(" in project *%s*", project)

--- a/gasboat/controller/internal/bridge/bot_decisions.go
+++ b/gasboat/controller/internal/bridge/bot_decisions.go
@@ -33,6 +33,21 @@ func decisionQuestion(fields map[string]string) string {
 	return fields["question"]
 }
 
+// resolveDecisionMentionUser looks up the Slack user ID to @mention in a
+// decision notification. It checks the agent bead's slack_user_id field,
+// which is set when agents are spawned via Slack.
+func (b *Bot) resolveDecisionMentionUser(ctx context.Context, agent string) string {
+	if agent == "" {
+		return ""
+	}
+	agentName := extractAgentName(agent)
+	detail, err := b.daemon.FindAgentBead(ctx, agentName)
+	if err != nil {
+		return ""
+	}
+	return detail.Fields["slack_user_id"]
+}
+
 // NotifyDecision posts a Block Kit message to Slack for a new decision.
 // Layout matches the beads implementation: each option is a Section block
 // with numbered label, description, and right-aligned accessory button.
@@ -59,11 +74,18 @@ func (b *Bot) NotifyDecision(ctx context.Context, bead BeadEvent) error {
 		}
 	}
 
+	// Resolve who to @mention in the decision notification.
+	mentionUserID := b.resolveDecisionMentionUser(ctx, bead.Assignee)
+
 	// Build Block Kit blocks — header section with priority-colored indicator.
+	headerText := fmt.Sprintf("%s *Decision Needed*", decisionPriorityEmoji(bead.Priority))
+	if mentionUserID != "" {
+		headerText += fmt.Sprintf(" <@%s>", mentionUserID)
+	}
+	headerText += "\n" + question
 	blocks := []slack.Block{
 		slack.NewSectionBlock(
-			slack.NewTextBlockObject("mrkdwn",
-				fmt.Sprintf("%s *Decision Needed*\n%s", decisionPriorityEmoji(bead.Priority), question), false, false),
+			slack.NewTextBlockObject("mrkdwn", headerText, false, false),
 			nil, nil,
 		),
 	}
@@ -206,8 +228,12 @@ func (b *Bot) NotifyDecision(ctx context.Context, bead BeadEvent) error {
 		slack.NewActionBlock("", dismissBtn))
 
 	// Build message options.
+	fallbackText := fmt.Sprintf("Decision needed: %s", question)
+	if mentionUserID != "" {
+		fallbackText = fmt.Sprintf("Decision needed (<@%s>): %s", mentionUserID, question)
+	}
 	msgOpts := []slack.MsgOption{
-		slack.MsgOptionText(fmt.Sprintf("Decision needed: %s", question), false),
+		slack.MsgOptionText(fallbackText, false),
 		slack.MsgOptionBlocks(blocks...),
 	}
 
@@ -334,7 +360,14 @@ func (b *Bot) NotifyEscalation(ctx context.Context, bead BeadEvent) error {
 	agent := extractAgentName(bead.Assignee)
 	agentDisplay := b.agentDisplayName(agent)
 
-	text := fmt.Sprintf(":rotating_light: *ESCALATED: %s*\n%s", beadTitle(bead.ID, bead.Title), question)
+	// Resolve who to @mention.
+	mentionUserID := b.resolveDecisionMentionUser(ctx, bead.Assignee)
+
+	text := fmt.Sprintf(":rotating_light: *ESCALATED: %s*", beadTitle(bead.ID, bead.Title))
+	if mentionUserID != "" {
+		text += fmt.Sprintf(" <@%s>", mentionUserID)
+	}
+	text += "\n" + question
 
 	blocks := []slack.Block{
 		slack.NewSectionBlock(
@@ -355,8 +388,12 @@ func (b *Bot) NotifyEscalation(ctx context.Context, bead BeadEvent) error {
 
 	targetChannel := b.resolveChannel(agent)
 
+	escalationFallback := fmt.Sprintf("ESCALATED: %s — %s", beadTitle(bead.ID, bead.Title), question)
+	if mentionUserID != "" {
+		escalationFallback = fmt.Sprintf("ESCALATED (<@%s>): %s — %s", mentionUserID, beadTitle(bead.ID, bead.Title), question)
+	}
 	msgOpts := []slack.MsgOption{
-		slack.MsgOptionText(fmt.Sprintf("ESCALATED: %s — %s", beadTitle(bead.ID, bead.Title), question), false),
+		slack.MsgOptionText(escalationFallback, false),
 		slack.MsgOptionBlocks(blocks...),
 	}
 

--- a/gasboat/controller/internal/bridge/bot_decisions_notify_test.go
+++ b/gasboat/controller/internal/bridge/bot_decisions_notify_test.go
@@ -469,6 +469,189 @@ func TestNotifyDecision_ContextTruncation(t *testing.T) {
 	}
 }
 
+// --- @mention tests ---
+
+func TestNotifyDecision_MentionsSlackUser(t *testing.T) {
+	daemon := newMockDaemon()
+	// Seed agent bead with slack_user_id (set by spawn).
+	daemon.beads["mention-agent"] = &beadsapi.BeadDetail{
+		ID:    "bd-mention-agent",
+		Type:  "agent",
+		Title: "mention-agent",
+		Fields: map[string]string{
+			"agent":         "mention-agent",
+			"slack_user_id": "U12345HUMAN",
+		},
+	}
+
+	var mu sync.Mutex
+	var postedText, postedBlocks string
+	slackSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/chat.postMessage" {
+			_ = r.ParseForm()
+			mu.Lock()
+			postedText = r.FormValue("text")
+			postedBlocks = r.FormValue("blocks")
+			mu.Unlock()
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"ok": true, "channel": "C123", "ts": "1111.2222"})
+	}))
+	defer slackSrv.Close()
+
+	bot := newTestBot(daemon, slackSrv)
+	bot.channel = "C123"
+
+	opts, _ := json.Marshal([]string{"approve", "reject"})
+	err := bot.NotifyDecision(context.Background(), BeadEvent{
+		ID:       "dec-mention",
+		Type:     "decision",
+		Title:    "Deploy approval",
+		Priority: 1,
+		Assignee: "mention-agent",
+		Fields: map[string]string{
+			"prompt":  "Should we deploy to prod?",
+			"options": string(opts),
+		},
+	})
+	if err != nil {
+		t.Fatalf("NotifyDecision: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	// Fallback text should contain the @mention.
+	if !strings.Contains(postedText, "<@U12345HUMAN>") {
+		t.Errorf("expected fallback text to contain <@U12345HUMAN>, got %q", postedText)
+	}
+	// Block Kit blocks should contain the @mention in the header.
+	// Slack API JSON-escapes angle brackets as \u003c/\u003e.
+	if !strings.Contains(postedBlocks, "@U12345HUMAN") {
+		t.Errorf("expected blocks to contain @U12345HUMAN mention, got %q", postedBlocks)
+	}
+}
+
+func TestNotifyDecision_NoMentionWhenNoSlackUser(t *testing.T) {
+	daemon := newMockDaemon()
+	// Agent bead exists but has no slack_user_id.
+	daemon.beads["no-user-agent"] = &beadsapi.BeadDetail{
+		ID:    "bd-no-user-agent",
+		Type:  "agent",
+		Title: "no-user-agent",
+		Fields: map[string]string{
+			"agent": "no-user-agent",
+		},
+	}
+
+	var mu sync.Mutex
+	var postedText string
+	slackSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/chat.postMessage" {
+			_ = r.ParseForm()
+			mu.Lock()
+			postedText = r.FormValue("text")
+			mu.Unlock()
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"ok": true, "channel": "C123", "ts": "1111.2222"})
+	}))
+	defer slackSrv.Close()
+
+	bot := newTestBot(daemon, slackSrv)
+	bot.channel = "C123"
+
+	opts, _ := json.Marshal([]string{"yes", "no"})
+	err := bot.NotifyDecision(context.Background(), BeadEvent{
+		ID:       "dec-no-mention",
+		Type:     "decision",
+		Priority: 2,
+		Assignee: "no-user-agent",
+		Fields: map[string]string{
+			"prompt":  "Proceed?",
+			"options": string(opts),
+		},
+	})
+	if err != nil {
+		t.Fatalf("NotifyDecision: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	// Should not contain any @mention.
+	if strings.Contains(postedText, "<@") {
+		t.Errorf("expected no @mention in text, got %q", postedText)
+	}
+}
+
+func TestNotifyEscalation_MentionsSlackUser(t *testing.T) {
+	daemon := newMockDaemon()
+	daemon.beads["esc-mention-agent"] = &beadsapi.BeadDetail{
+		ID:    "bd-esc-mention",
+		Type:  "agent",
+		Title: "esc-mention-agent",
+		Fields: map[string]string{
+			"agent":         "esc-mention-agent",
+			"slack_user_id": "U99HUMAN",
+		},
+	}
+
+	var mu sync.Mutex
+	var postedText string
+	slackSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/chat.postMessage" {
+			_ = r.ParseForm()
+			mu.Lock()
+			postedText = r.FormValue("text")
+			mu.Unlock()
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"ok": true, "channel": "C123", "ts": "1111.3333"})
+	}))
+	defer slackSrv.Close()
+
+	bot := newTestBot(daemon, slackSrv)
+	bot.channel = "C123"
+
+	err := bot.NotifyEscalation(context.Background(), BeadEvent{
+		ID:       "dec-esc-mention",
+		Type:     "decision",
+		Title:    "Urgent item",
+		Priority: 0,
+		Assignee: "esc-mention-agent",
+		Labels:   []string{"escalated"},
+		Fields:   map[string]string{"prompt": "Handle now?"},
+	})
+	if err != nil {
+		t.Fatalf("NotifyEscalation: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if !strings.Contains(postedText, "<@U99HUMAN>") {
+		t.Errorf("expected escalation text to contain <@U99HUMAN>, got %q", postedText)
+	}
+}
+
+func TestResolveDecisionMentionUser_ReturnsEmptyForUnknownAgent(t *testing.T) {
+	daemon := newMockDaemon()
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+
+	bot := newTestBot(daemon, slackSrv)
+
+	// No agent bead exists.
+	userID := bot.resolveDecisionMentionUser(context.Background(), "unknown-agent")
+	if userID != "" {
+		t.Errorf("expected empty user ID for unknown agent, got %q", userID)
+	}
+
+	// Empty agent name.
+	userID = bot.resolveDecisionMentionUser(context.Background(), "")
+	if userID != "" {
+		t.Errorf("expected empty user ID for empty agent, got %q", userID)
+	}
+}
+
 // --- NotifyEscalation tests ---
 
 func TestNotifyEscalation_PostsMessage(t *testing.T) {

--- a/gasboat/controller/internal/bridge/bot_mentions.go
+++ b/gasboat/controller/internal/bridge/bot_mentions.go
@@ -433,6 +433,14 @@ func (b *Bot) handleThreadSpawn(ctx context.Context, ev *slackevents.AppMentionE
 			"bead", beadID, "agent", assignedAgent,
 			"channel", channel, "thread_ts", threadTS, "listen", listen)
 
+		// Best-effort: store the Slack user ID of the spawner on the agent bead
+		// so decision notifications can @mention the right person.
+		if ev.User != "" {
+			_ = b.daemon.UpdateBeadFields(ctx, beadID, map[string]string{
+				"slack_user_id": ev.User,
+			})
+		}
+
 		if b.state != nil {
 			_ = b.state.SetThreadAgent(channel, threadTS, assignedAgent)
 			if listen {
@@ -476,6 +484,7 @@ func (b *Bot) handleThreadSpawn(ctx context.Context, ev *slackevents.AppMentionE
 		"slack_thread_channel": channel,
 		"slack_thread_ts":      threadTS,
 		"spawn_source":         "slack-thread",
+		"slack_user_id":        ev.User,
 	}
 	fieldsJSON, err := json.Marshal(fields)
 	if err != nil {

--- a/gasboat/controller/internal/bridge/bot_start_test.go
+++ b/gasboat/controller/internal/bridge/bot_start_test.go
@@ -76,6 +76,9 @@ func TestHandleStartCommand_SpawnsAgentWithProject(t *testing.T) {
 		if b.Fields["role"] != "crew" {
 			t.Errorf("expected default role=crew, got %s", b.Fields["role"])
 		}
+		if b.Fields["slack_user_id"] != "U456" {
+			t.Errorf("expected slack_user_id=U456, got %s", b.Fields["slack_user_id"])
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- Store the spawner's Slack user ID (`slack_user_id` field) on agent beads when agents are spawned via `/start`, `/spawn`, or thread @mention
- Decision notifications (`NotifyDecision`) now include `<@USERID>` in the Block Kit header and fallback text, so the right person gets pinged
- Escalation notifications (`NotifyEscalation`) also include `<@USERID>` mentions
- Graceful degradation: if no `slack_user_id` is found (e.g., agent spawned via CLI), notifications work as before without a mention

Fixes kd-NCJiaQm7Vf

## Test plan
- [x] `TestNotifyDecision_MentionsSlackUser` — verifies @mention appears in both fallback text and blocks
- [x] `TestNotifyDecision_NoMentionWhenNoSlackUser` — verifies no mention when agent has no `slack_user_id`
- [x] `TestNotifyEscalation_MentionsSlackUser` — verifies escalation includes @mention
- [x] `TestResolveDecisionMentionUser_ReturnsEmptyForUnknownAgent` — verifies empty return for unknown/empty agent
- [x] `TestHandleStartCommand_SpawnsAgentWithProject` — verifies `slack_user_id` is set on spawn
- [x] All existing tests pass (`go test ./...`)
- [x] `go build` succeeds for both controller and slack-bridge
- [x] `helm lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)