### PR TITLE
fix(gasboat/advice): exclude closed advice beads from gb prime

### DIFF
--- a/gasboat/controller/cmd/advice-viewer/server.go
+++ b/gasboat/controller/cmd/advice-viewer/server.go
@@ -154,7 +154,7 @@ func (s *Server) handleAgent(w http.ResponseWriter, r *http.Request) {
 
 // handleAdviceList shows all advice beads.
 func (s *Server) handleAdviceList(w http.ResponseWriter, r *http.Request) {
-	allAdvice, err := advice.ListAllAdvice(r.Context(), s.daemon)
+	allAdvice, err := advice.ListOpenAdvice(r.Context(), s.daemon)
 	if err != nil {
 		s.logger.Error("listing advice", "error", err)
 		http.Error(w, "Failed to list advice", http.StatusInternalServerError)

--- a/gasboat/controller/internal/advice/advice.go
+++ b/gasboat/controller/internal/advice/advice.go
@@ -18,7 +18,7 @@ type MatchedAdvice struct {
 // ListAdviceForAgent fetches open advice beads and filters them by the agent's
 // subscriptions. Returns matched advice and the computed subscription list.
 func ListAdviceForAgent(ctx context.Context, daemon *beadsapi.Client, agentID string) ([]MatchedAdvice, []string, error) {
-	allAdvice, err := ListAllAdvice(ctx, daemon)
+	allAdvice, err := ListOpenAdvice(ctx, daemon)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -44,8 +44,9 @@ func ListAdviceForAgent(ctx context.Context, daemon *beadsapi.Client, agentID st
 	return matched, subs, nil
 }
 
-// ListAllAdvice fetches all open advice beads from the daemon.
-func ListAllAdvice(ctx context.Context, daemon *beadsapi.Client) ([]*beadsapi.BeadDetail, error) {
+// ListOpenAdvice fetches all open advice beads from the daemon.
+// Closed advice beads are excluded so they don't appear in gb prime.
+func ListOpenAdvice(ctx context.Context, daemon *beadsapi.Client) ([]*beadsapi.BeadDetail, error) {
 	result, err := daemon.ListBeadsFiltered(ctx, beadsapi.ListBeadsQuery{
 		Types:    []string{"advice"},
 		Statuses: []string{"open"},
@@ -54,5 +55,19 @@ func ListAllAdvice(ctx context.Context, daemon *beadsapi.Client) ([]*beadsapi.Be
 	if err != nil {
 		return nil, err
 	}
-	return result.Beads, nil
+	// Belt-and-suspenders: filter out any non-open beads client-side
+	// in case the server doesn't honor the status filter.
+	open := make([]*beadsapi.BeadDetail, 0, len(result.Beads))
+	for _, b := range result.Beads {
+		if b.Status == "closed" {
+			continue
+		}
+		open = append(open, b)
+	}
+	return open, nil
+}
+
+// ListAllAdvice is a deprecated alias for ListOpenAdvice.
+func ListAllAdvice(ctx context.Context, daemon *beadsapi.Client) ([]*beadsapi.BeadDetail, error) {
+	return ListOpenAdvice(ctx, daemon)
 }

--- a/gasboat/controller/internal/advice/advice_test.go
+++ b/gasboat/controller/internal/advice/advice_test.go
@@ -1,0 +1,90 @@
+package advice
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"gasboat/controller/internal/beadsapi"
+)
+
+func TestListOpenAdvice_ExcludesClosed(t *testing.T) {
+	// Simulate a server that returns both open and closed advice beads
+	// (e.g., if the server-side status filter has a bug).
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := map[string]any{
+			"beads": []map[string]any{
+				{"id": "kd-open1", "title": "Open advice", "status": "open", "type": "advice", "kind": "data", "labels": []string{"global"}},
+				{"id": "kd-closed1", "title": "Closed advice", "status": "closed", "type": "advice", "kind": "data", "labels": []string{"global"}},
+				{"id": "kd-open2", "title": "Another open", "status": "open", "type": "advice", "kind": "data", "labels": []string{"global"}},
+			},
+			"total": 3,
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	client, err := beadsapi.New(beadsapi.Config{
+		HTTPAddr: srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("creating client: %v", err)
+	}
+	defer client.Close()
+
+	beads, err := ListOpenAdvice(context.Background(), client)
+	if err != nil {
+		t.Fatalf("ListOpenAdvice: %v", err)
+	}
+
+	// Should only return the 2 open beads, filtering out the closed one.
+	if len(beads) != 2 {
+		t.Errorf("expected 2 open beads, got %d", len(beads))
+	}
+	for _, b := range beads {
+		if b.Status == "closed" {
+			t.Errorf("closed bead %s should not be returned by ListOpenAdvice", b.ID)
+		}
+	}
+}
+
+func TestListOpenAdvice_AllOpen(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify the request includes status=open filter.
+		status := r.URL.Query().Get("status")
+		if status != "open" {
+			t.Errorf("expected status=open query param, got %q", status)
+		}
+
+		resp := map[string]any{
+			"beads": []map[string]any{
+				{"id": "kd-1", "title": "Advice 1", "status": "open", "type": "advice", "kind": "data", "labels": []string{"global"}},
+				{"id": "kd-2", "title": "Advice 2", "status": "open", "type": "advice", "kind": "data", "labels": []string{"role:crew"}},
+			},
+			"total": 2,
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	client, err := beadsapi.New(beadsapi.Config{
+		HTTPAddr: srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("creating client: %v", err)
+	}
+	defer client.Close()
+
+	beads, err := ListOpenAdvice(context.Background(), client)
+	if err != nil {
+		t.Fatalf("ListOpenAdvice: %v", err)
+	}
+
+	if len(beads) != 2 {
+		t.Errorf("expected 2 beads, got %d", len(beads))
+	}
+}

--- a/gasboat/controller/internal/advice/diff.go
+++ b/gasboat/controller/internal/advice/diff.go
@@ -19,7 +19,7 @@ type AdviceDiff struct {
 // role. The caller provides the agent's current matched advice and the target
 // role. Returns the diff (added/removed items).
 func DiffAdviceForRole(ctx context.Context, daemon *beadsapi.Client, agentID, targetRole string, currentMatched []MatchedAdvice) (*AdviceDiff, error) {
-	allAdvice, err := ListAllAdvice(ctx, daemon)
+	allAdvice, err := ListOpenAdvice(ctx, daemon)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary
- Rename `ListAllAdvice` → `ListOpenAdvice` to clarify that only open advice beads are returned
- Add client-side filtering as a belt-and-suspenders safeguard against server-side status filter bugs (filters out any `closed` beads that slip through)
- Add test coverage for `ListOpenAdvice` verifying closed beads are excluded
- Retain `ListAllAdvice` as a deprecated alias for backward compatibility

## Test plan
- [x] `TestListOpenAdvice_ExcludesClosed` — verifies closed beads are filtered client-side even if server returns them
- [x] `TestListOpenAdvice_AllOpen` — verifies `status=open` query param is sent and all open beads are returned
- [x] All existing tests pass (`go test ./gasboat/controller/...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)