### PR TITLE
fix(agent): install uv and fix bun symlinks for monorepo dev

### DIFF
--- a/.rwx/docker.yml
+++ b/.rwx/docker.yml
@@ -837,16 +837,14 @@ tasks:
         chmod +x $OUT/usr/local/bin/terragrunt
       ) &
       (
-        # uv
-        curl -LsSf https://astral.sh/uv/install.sh | env INSTALLER_NO_MODIFY_PATH=1 sh
-        mv /root/.local/bin/uv $OUT/usr/local/bin/uv 2>/dev/null || true
-        mv /root/.local/bin/uvx $OUT/usr/local/bin/uvx 2>/dev/null || true
+        # uv — install directly to output dir (UV_UNMANAGED_INSTALL for CI)
+        curl -LsSf https://astral.sh/uv/install.sh | env UV_UNMANAGED_INSTALL="$OUT/usr/local/bin" sh
       ) &
       (
-        # Bun
+        # Bun — install to output dir, use final-image symlink targets
         curl -fsSL https://bun.sh/install | BUN_INSTALL=$OUT/usr/local/bun bash
-        ln -sf $OUT/usr/local/bun/bin/bun $OUT/usr/local/bin/bun
-        ln -sf $OUT/usr/local/bun/bin/bunx $OUT/usr/local/bin/bunx
+        ln -sf /usr/local/bun/bin/bun $OUT/usr/local/bin/bun
+        ln -sf /usr/local/bun/bin/bunx $OUT/usr/local/bin/bunx
       ) &
       (
         # yq

--- a/gasboat/.rwx/agent-clis.lock
+++ b/gasboat/.rwx/agent-clis.lock
@@ -1,6 +1,6 @@
 # Cache key for agent-install-clis task.
 # Touch this file to force a rebuild of CLI tools only.
-cache-epoch=2
+cache-epoch=3
 docker-cli=27.5.1
 terraform=1.11.3
 terragrunt=0.77.11


### PR DESCRIPTION
## Summary

The monorepo project requires `uv` (Python package manager) and `bun` (JS runtime) for development.
Both are nominally installed in the gasboat agent image, but two bugs prevent them from working:

- **`uv` missing entirely**: The install script uses `INSTALLER_NO_MODIFY_PATH=1` and then
  hardcodes `mv /root/.local/bin/uv` — but `$HOME` isn't always `/root` in the RWX CI context.
  The `|| true` swallows the error silently. Fix: use `UV_UNMANAGED_INSTALL` env var to install
  directly to the output directory.

- **`bun` broken symlinks**: Symlinks point to build-time paths (`/tmp/clis-layer/usr/local/bun/bin/bun`)
  instead of final image paths (`/usr/local/bun/bin/bun`). Bun happens to work currently because
  crane-append preserves the temp paths, but this is fragile. Fix: use absolute final-image paths.

Also bumps `agent-clis.lock` cache-epoch to force a rebuild.

## Impact

Without `uv`, agents working on the monorepo cannot:
- Run `task services-setup` (calls `make setup install` → `uv sync`)
- Run `task test-quick` (calls `uv run pytest`)
- Run any Python linting/typing (`uv run ruff`, `uv run pyright`)
- Install Python dependencies for any service

## Test plan

- [ ] CI docker build passes (agent-install-clis task)
- [ ] New agent image has `uv` in PATH
- [ ] New agent image has `uvx` in PATH
- [ ] Bun symlinks point to `/usr/local/bun/bin/bun` (not `/tmp/clis-layer/...`)
- [ ] Agent can run `uv sync` in a monorepo Python service directory