### PR TITLE
feat(agent): add poetry to agent image

### DIFF
--- a/.rwx/docker.yml
+++ b/.rwx/docker.yml
@@ -841,6 +841,11 @@ tasks:
         curl -LsSf https://astral.sh/uv/install.sh | env UV_UNMANAGED_INSTALL="$OUT/usr/local/bin" sh
       ) &
       (
+        # Poetry — install to output dir
+        curl -sSL https://install.python-poetry.org | POETRY_HOME="$OUT/usr/local" python3 -
+        chmod +x $OUT/usr/local/bin/poetry
+      ) &
+      (
         # Bun — install to output dir, use final-image symlink targets
         curl -fsSL https://bun.sh/install | BUN_INSTALL=$OUT/usr/local/bun bash
         ln -sf /usr/local/bun/bin/bun $OUT/usr/local/bin/bun

--- a/gasboat/.rwx/agent-clis.lock
+++ b/gasboat/.rwx/agent-clis.lock
@@ -1,6 +1,6 @@
 # Cache key for agent-install-clis task.
 # Touch this file to force a rebuild of CLI tools only.
-cache-epoch=3
+cache-epoch=4
 docker-cli=27.5.1
 terraform=1.11.3
 terragrunt=0.77.11

--- a/gasboat/images/agent/Dockerfile
+++ b/gasboat/images/agent/Dockerfile
@@ -179,6 +179,10 @@ RUN curl -LsSf https://astral.sh/uv/install.sh | env INSTALLER_NO_MODIFY_PATH=1 
     mv /root/.local/bin/uv /usr/local/bin/uv && \
     mv /root/.local/bin/uvx /usr/local/bin/uvx
 
+# ── Poetry (Python dependency manager) ───────────────────────
+RUN curl -sSL https://install.python-poetry.org | POETRY_HOME=/usr/local python3 - && \
+    chmod +x /usr/local/bin/poetry
+
 # ── Bun ────────────────────────────────────────────────────────
 ENV BUN_INSTALL=/usr/local/bun
 RUN curl -fsSL https://bun.sh/install | BUN_INSTALL=${BUN_INSTALL} bash && \


### PR DESCRIPTION
## Summary
- Adds Poetry (Python dependency manager) to the agent image
- Updated both `images/agent/Dockerfile` and `.rwx/docker.yml` (RWX CI)
- Poetry installs to `/usr/local` via `POETRY_HOME`, runs as a parallel install block in CI
- Bumped `agent-clis.lock` cache epoch to force rebuild

## Test plan
- [ ] RWX CI builds agent image successfully
- [ ] `poetry --version` works inside the built agent container
- [ ] Existing tools (uv, bun, etc.) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)