### PR TITLE
feat(gasboat): set default Claude effort level to high

### DIFF
--- a/gasboat/controller/cmd/gb/setup_config.go
+++ b/gasboat/controller/cmd/gb/setup_config.go
@@ -38,7 +38,10 @@ func defaultUserSettings() map[string]any {
 			},
 			"deny": []any{},
 		},
-		"alwaysThinkingEnabled":          true,
+		"env": map[string]any{
+			"CLAUDE_CODE_EFFORT_LEVEL": "high",
+		},
+		"alwaysThinkingEnabled":             true,
 		"skipDangerousModePermissionPrompt": true,
 	}
 }


### PR DESCRIPTION
## Summary
- Adds `CLAUDE_CODE_EFFORT_LEVEL=high` to `defaultUserSettings()` in `setup_config.go` so new agent pods default to high reasoning effort instead of Claude Code's default of medium
- Also updated the live `claude-settings` global config bead to include the same env var, so existing/future agents resolved via config beads also get `high`

## Test plan
- [x] `TestDefaultUserSettings` passes
- [ ] Verify new agent pods start with `CLAUDE_CODE_EFFORT_LEVEL=high` in their settings.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)