### PR TITLE
fix(agent-image): install Chrome for Testing and fix browser system deps

### DIFF
--- a/gasboat/.rwx/agent-playwright.lock
+++ b/gasboat/.rwx/agent-playwright.lock
@@ -1,4 +1,5 @@
 # Cache key for agent-install-playwright task.
-# Touch this file to force a rebuild of Playwright + Chromium only.
-cache-epoch=2
+# Touch this file to force a rebuild of Playwright + Chromium + Chrome only.
+cache-epoch=3
 playwright=1.58.2
+# epoch 3: add Chrome for Testing browser, fix system deps, ldd sweep

--- a/gasboat/.rwx/docker.yml
+++ b/gasboat/.rwx/docker.yml
@@ -627,7 +627,7 @@ tasks:
         - key: node-tar
           path: node-layer.tar
 
-  # ── Playwright + Chromium + system deps (cached separately) ────────
+  # ── Playwright + Chromium + Chrome + system deps (cached separately) ──
   - key: agent-install-playwright
     use: [agent-install-node]
     timeout: 10m
@@ -693,9 +693,19 @@ tasks:
           mkdir -p "$OUT$(dirname "$lib")" && cp -a "$lib" "$OUT${lib}" 2>/dev/null || true
         done || true
       done
-      # Install Chromium browser
-      PLAYWRIGHT_BROWSERS_PATH=$OUT/ms-playwright npx playwright install chromium
+      # Install Chromium + Chrome for Testing browsers.
+      # @playwright/mcp defaults to --browser=chrome, so Chrome must be present.
+      PLAYWRIGHT_BROWSERS_PATH=$OUT/ms-playwright npx playwright install chromium chrome
       chmod -R 777 $OUT/ms-playwright
+      # Final ldd sweep: resolve ALL shared libs needed by installed browser binaries.
+      # This catches transitive deps that the dpkg/glob copies above may have missed.
+      find $OUT/ms-playwright -name chrome -type f -executable 2>/dev/null | while read -r bin; do
+        ldd "$bin" 2>/dev/null | grep "=> /" | awk '{print $3}' | while read -r lib; do
+          [ -e "$lib" ] || continue
+          [ -e "$OUT$lib" ] && continue  # already copied
+          mkdir -p "$OUT$(dirname "$lib")" && cp -a "$lib" "$OUT${lib}" 2>/dev/null || true
+        done || true
+      done
 
       tar -cf playwright-layer.tar -C $OUT .
     outputs:
@@ -881,15 +891,17 @@ tasks:
       LAYER=/tmp/layer
       mkdir -p $LAYER
 
-      # Unpack all cached install layers in parallel.
-      # NOTE: all extractions use sudo because layers share directories
-      # (e.g. /usr/lib/x86_64-linux-gnu/) — if syspackages creates a
-      # root-owned dir first, non-sudo extractions silently fail to write
-      # into it, dropping files like libnspr4.so and libnss3.so.
-      echo "=== Unpacking cached layers (parallel) ==="
-      sudo tar -xf ${{ tasks.agent-install-syspackages.artifacts.syspackages-tar }} -C $LAYER &
+      # Unpack cached install layers.
+      # IMPORTANT: syspackages and playwright both write to /usr/lib/x86_64-linux-gnu/.
+      # Parallel tar extraction to the same directory tree causes a race condition where
+      # one tar's directory entries can interfere with the other, silently dropping shared
+      # library files (libnspr4.so, libnss3.so, etc.). Extract these two sequentially,
+      # then the rest (which write to disjoint paths) in parallel.
+      echo "=== Unpacking layers with shared lib dirs (sequential) ==="
+      sudo tar -xf ${{ tasks.agent-install-syspackages.artifacts.syspackages-tar }} -C $LAYER
+      sudo tar -xf ${{ tasks.agent-install-playwright.artifacts.playwright-tar }} -C $LAYER
+      echo "=== Unpacking remaining layers (parallel) ==="
       sudo tar -xf ${{ tasks.agent-install-node.artifacts.node-tar }} -C $LAYER &
-      sudo tar -xf ${{ tasks.agent-install-playwright.artifacts.playwright-tar }} -C $LAYER &
       sudo tar -xf ${{ tasks.agent-install-go.artifacts.go-tar }} -C $LAYER &
       sudo tar -xf ${{ tasks.agent-install-rust.artifacts.rust-tar }} -C $LAYER &
       sudo tar -xf ${{ tasks.agent-install-clis.artifacts.clis-tar }} -C $LAYER &

--- a/gasboat/controller/cmd/gb/setup_config.go
+++ b/gasboat/controller/cmd/gb/setup_config.go
@@ -115,6 +115,9 @@ func expandEnvVars(s string) string {
 
 // defaultMCPConfig returns a fallback MCP config with Playwright if the
 // playwright-mcp binary is on PATH. Returns nil if not found.
+// Uses --browser=chromium to ensure the bundled Chromium browser is used,
+// which is always available in the agent image (unlike Chrome for Testing
+// which @playwright/mcp defaults to).
 func defaultMCPConfig() map[string]any {
 	if !pathExists("playwright-mcp") {
 		return nil
@@ -123,7 +126,7 @@ func defaultMCPConfig() map[string]any {
 		"mcpServers": map[string]any{
 			"playwright": map[string]any{
 				"command": "playwright-mcp",
-				"args":    []any{"--headless", "--no-sandbox"},
+				"args":    []any{"--browser", "chromium", "--headless", "--no-sandbox"},
 			},
 		},
 	}

--- a/gasboat/controller/cmd/gb/setup_test.go
+++ b/gasboat/controller/cmd/gb/setup_test.go
@@ -285,7 +285,7 @@ func TestWriteMCPConfig_DoesNotOverrideExistingServer(t *testing.T) {
 		"mcpServers": map[string]any{
 			"playwright": map[string]any{
 				"command": "playwright-mcp",
-				"args":    []any{"--headless", "--no-sandbox"},
+				"args":    []any{"--browser", "chromium", "--headless", "--no-sandbox"},
 			},
 		},
 	}

--- a/gasboat/images/agent/Dockerfile
+++ b/gasboat/images/agent/Dockerfile
@@ -259,15 +259,17 @@ RUN curl -fsSL "https://github.com/ggml-org/whisper.cpp/archive/refs/tags/v${WHI
     cp /tmp/whisper-build/bin/whisper-cli /usr/local/bin/whisper-cli && \
     rm -rf /tmp/whisper.cpp-${WHISPER_CPP_VERSION} /tmp/whisper-build
 
-# ── Playwright + Chromium + MCP server (headless browser automation) ──
+# ── Playwright + Chromium + Chrome + MCP server (headless browser automation) ──
 # NOTE: apt lists were cleaned after the system packages step above,
 # so we must re-run apt-get update before --with-deps can install
-# Chromium's system library dependencies (libglib, libnss3, etc.).
+# browser system library dependencies (libglib, libnss3, etc.).
+# Both chromium and chrome are installed because @playwright/mcp
+# defaults to --browser=chrome (Chrome for Testing).
 ARG PLAYWRIGHT_VERSION=1.58.2
 ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
 RUN apt-get update && \
     npm install -g playwright@${PLAYWRIGHT_VERSION} @playwright/mcp && \
-    npx playwright install --with-deps chromium && \
+    npx playwright install --with-deps chromium chrome && \
     apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* && \
     npm cache clean --force && \
     chmod -R 777 ${PLAYWRIGHT_BROWSERS_PATH}


### PR DESCRIPTION
## Summary

- **Install Chrome for Testing** alongside Chromium in the agent image — `@playwright/mcp` defaults to `--browser=chrome` but only Chromium was installed, causing browser launch failures
- **Fix parallel tar extraction race** in RWX CI push-agent assembly — syspackages and playwright layers both write to `/usr/lib/x86_64-linux-gnu/` and parallel extraction silently dropped shared library files (libnspr4.so, libnss3.so, libatk-1.0.so, etc.)
- **Add ldd sweep** on installed browser binaries in the playwright RWX task to catch transitive deps that dpkg/glob copies may have missed
- **Default MCP config** now specifies `--browser chromium` as a safety net so the bundled browser is always used

## Root cause

Agents using Playwright MCP to browse websites hit: `Error: Missing system dependencies required to run browser chrome. Install them with: sudo npx playwright install-deps chrome`

Two contributing factors:
1. `@playwright/mcp` defaults to Chrome for Testing, which was never installed (only Chromium was)
2. Even Chromium's system deps were missing — the RWX CI parallel tar extraction race between syspackages and playwright layers dropped shared library files

## Files changed

| File | Change |
|---|---|
| `gasboat/images/agent/Dockerfile` | `npx playwright install --with-deps chromium chrome` (was `chromium` only) |
| `gasboat/.rwx/docker.yml` | Add `chrome` to browser install, add ldd sweep, serialize conflicting layer extraction |
| `gasboat/.rwx/agent-playwright.lock` | Bump cache epoch to 3 |
| `gasboat/controller/cmd/gb/setup_config.go` | Add `--browser chromium` to default MCP args |
| `gasboat/controller/cmd/gb/setup_test.go` | Update test for new args |

## Test plan

- [x] `go test ./...` — all tests pass
- [x] `go build ./cmd/gb/` and `go build ./cmd/slack-bridge/` — both compile
- [x] `helm lint gasboat/helm/gasboat/` — clean
- [ ] Next release builds agent image with Chrome for Testing + system deps
- [ ] Verify `ldd /ms-playwright/*/chrome` shows no missing libs on a new pod

🤖 Generated with [Claude Code](https://claude.com/claude-code)