### PR TITLE
fix(gasboat/agent-image): add missing gcc-13 and cc symlink

### DIFF
--- a/gasboat/.rwx/agent-syspackages.lock
+++ b/gasboat/.rwx/agent-syspackages.lock
@@ -3,5 +3,5 @@
 #
 # Versions controlled here:
 #   python=3.12, apt packages (git, curl, gcc, cmake, ffmpeg, etc.)
-cache-epoch=2
+cache-epoch=3
 python=3.12

--- a/gasboat/.rwx/docker.yml
+++ b/gasboat/.rwx/docker.yml
@@ -517,7 +517,7 @@ tasks:
           python3-pip python3-venv python3.12-venv \
           libpython3.12-stdlib libpython3.12-minimal \
           make gcc g++ unzip binutils shellcheck \
-          gcc-14 g++-14 cpp-14 libgcc-14-dev \
+          gcc-13 g++-13 cpp-13 gcc-14 g++-14 cpp-14 libgcc-14-dev \
           libc6-dev linux-libc-dev binutils-x86-64-linux-gnu \
           pkg-config libssl-dev \
           libcurl4t64 libcurl3t64-gnutls \
@@ -593,6 +593,7 @@ tasks:
       done || true
       mkdir -p $OUT/usr/libexec/sudo && cp /usr/libexec/sudo/*.so* $OUT/usr/libexec/sudo/ 2>/dev/null || true
       ln -sf python3 $OUT/usr/bin/python
+      ln -sf gcc $OUT/usr/bin/cc
 
       sudo tar -cf syspackages.tar -C $OUT .
     outputs:

--- a/gasboat/images/agent/Dockerfile
+++ b/gasboat/images/agent/Dockerfile
@@ -122,6 +122,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     postgresql-client shellcheck \
     ffmpeg cmake libsdl2-dev && \
     ln -sf /usr/bin/python3 /usr/bin/python && \
+    ln -sf gcc /usr/bin/cc && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # ── Go + gopls ───────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Add `gcc-13 g++-13 cpp-13` to the RWX CI dpkg copy loop — the actual compiler binaries that `gcc`/`g++` symlinks point to were missing
- Add `cc → gcc` symlink in both Dockerfile and RWX CI — Rust/cargo invokes the linker as `cc`
- Bump syspackages cache epoch to force layer rebuild

**Root cause:** `apt-get install gcc` on Ubuntu 24.04 installs `gcc-13` as the actual binary and creates a `gcc → gcc-13` symlink. The RWX dpkg extraction loop only listed `gcc-14`, so the symlink target was never copied. Agents couldn't compile C dependencies (e.g. `cargo test` fails with "linker `cc` not found").

## Test plan

- [ ] RWX CI rebuild produces an image where `gcc --version` and `cc --version` both work
- [ ] `cargo test` can compile in an agent pod built from this image
- [ ] Dockerfile local build (`make image-agent`) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)