### PR TITLE
fix(ci): add PR trigger to RWX ci.yml and upgrade golangci-lint

### DIFF
--- a/.rwx/ci.yml
+++ b/.rwx/ci.yml
@@ -5,7 +5,9 @@ on:
     push:
       branches: [main]
       tags: ['20*']
-    statuses:
+    pull_request:
+      init:
+        commit-sha: ${{ event.git.sha }}
   cli:
     init:
       commit-sha: ${{ event.git.sha }}
@@ -34,7 +36,7 @@ tasks:
     filter:
       - .rwx/ci.yml
     run: |
-      go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.8
+      curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.11.2
 
   # ── Rust toolchain (for coop + quench) ───────────────────────────────
   - key: rust


### PR DESCRIPTION
## Summary

- Add `pull_request` trigger to `.rwx/ci.yml` — previously only had `push` (main/tags) and a dangling `statuses:` key, causing all PRs to show "This run failed to start" errors
- Upgrade golangci-lint from v1.64.8 (built with Go 1.24) to v2.11.2 — fixes incompatibility with Go 1.25 declared in go.mod
- Matches GitHub Actions CI which already uses golangci-lint v2.11

## Test plan

- [ ] Verify RWX CI status checks run on this PR (no longer "failed to start")
- [ ] Verify golangci-lint v2.11.2 can lint Go 1.25 code
- [ ] Confirm existing GitHub Actions CI still passes

Closes kd-OfbJHNheNG

🤖 Generated with [Claude Code](https://claude.com/claude-code)