### PR TITLE
feat(bridge): --project flag and project-aware agent card routing

### DIFF
--- a/gasboat/controller/internal/bridge/bot.go
+++ b/gasboat/controller/internal/bridge/bot.go
@@ -70,6 +70,12 @@ type Bot struct {
 	agentPodName  map[string]string    // agent identity → pod hostname (coopmux session ID)
 	agentImageTag map[string]string   // agent identity → deployed image tag
 	agentRole     map[string]string   // agent identity → role (e.g., "crew", "lead", "ops")
+	agentProject  map[string]string   // agent identity → project name (for channel routing)
+
+	// TTL-cached project→primary channel mapping (refreshed every projectChannelCacheTTL).
+	projectChannelCache   map[string]string // project name → primary Slack channel ID
+	projectChannelCacheAt time.Time         // when cache was last refreshed
+
 	threadSpawnMsgs  map[string]MessageRef // agent identity → spawn confirmation message ref (for in-place update)
 	beadMsgs         map[string]MessageRef // "agent:beadID" → Slack message ref for inline bead status updates
 
@@ -142,6 +148,7 @@ func NewBot(cfg BotConfig) *Bot {
 		agentPodName:     make(map[string]string),
 		agentImageTag:    make(map[string]string),
 		agentRole:        make(map[string]string),
+		agentProject:     make(map[string]string),
 		threadSpawnMsgs:  make(map[string]MessageRef),
 		beadMsgs:         make(map[string]MessageRef),
 		lastThreadNudge: make(map[string]time.Time),

--- a/gasboat/controller/internal/bridge/bot_agent_kill.go
+++ b/gasboat/controller/internal/bridge/bot_agent_kill.go
@@ -59,6 +59,7 @@ func (b *Bot) killAgent(ctx context.Context, agentName string, force bool) error
 		delete(b.agentPodName, agentName)
 		delete(b.agentImageTag, agentName)
 		delete(b.agentRole, agentName)
+		delete(b.agentProject, agentName)
 	}
 	b.mu.Unlock()
 
@@ -174,6 +175,7 @@ func (b *Bot) handleClearAgent(ctx context.Context, agentIdentity string, callba
 		delete(b.agentPodName, agentIdentity)
 		delete(b.agentImageTag, agentIdentity)
 		delete(b.agentRole, agentIdentity)
+		delete(b.agentProject, agentIdentity)
 	}
 	b.mu.Unlock()
 

--- a/gasboat/controller/internal/bridge/bot_agents.go
+++ b/gasboat/controller/internal/bridge/bot_agents.go
@@ -76,6 +76,7 @@ func (b *Bot) pruneStaleAgentCards(ctx context.Context) {
 			delete(b.agentPodName, agent)
 			delete(b.agentImageTag, agent)
 			delete(b.agentRole, agent)
+			delete(b.agentProject, agent)
 		}
 		b.mu.Unlock()
 
@@ -212,6 +213,9 @@ func (b *Bot) NotifyAgentSpawn(ctx context.Context, bead BeadEvent) {
 	b.agentSeen[agent] = time.Now()
 	if role := bead.Fields["role"]; role != "" {
 		b.agentRole[agent] = role
+	}
+	if project := bead.Fields["project"]; project != "" {
+		b.agentProject[agent] = project
 	}
 	b.mu.Unlock()
 
@@ -624,6 +628,8 @@ func (b *Bot) fetchAndCachePodName(ctx context.Context, agent string) {
 	imageTag := extractImageTag(notes["image_tag"])
 	role := detail.Fields["role"]
 
+	project := detail.Fields["project"]
+
 	b.mu.Lock()
 	if podName != "" {
 		b.agentPodName[agent] = podName
@@ -633,6 +639,9 @@ func (b *Bot) fetchAndCachePodName(ctx context.Context, agent string) {
 	}
 	if role != "" {
 		b.agentRole[agent] = role
+	}
+	if project != "" {
+		b.agentProject[agent] = project
 	}
 	b.mu.Unlock()
 }
@@ -660,15 +669,73 @@ func extractAgentProject(identity string) string {
 }
 
 // resolveChannel returns the target Slack channel for an agent.
-// Uses the router if configured, otherwise falls back to the default channel.
+// Priority:
+//  1. Router override/pattern match (if router configured)
+//  2. Agent's project primary channel (first channel in project bead's slack_channel)
+//  3. Router default / bot default channel
 func (b *Bot) resolveChannel(agent string) string {
+	var routerResult RouteResult
 	if b.router != nil && agent != "" {
-		result := b.router.Resolve(agent)
-		if result.ChannelID != "" {
-			return result.ChannelID
+		routerResult = b.router.Resolve(agent)
+		if routerResult.ChannelID != "" && !routerResult.IsDefault {
+			return routerResult.ChannelID
 		}
 	}
+
+	// Look up agent's project and use the project's primary Slack channel.
+	if agent != "" {
+		b.mu.Lock()
+		project := b.agentProject[agent]
+		b.mu.Unlock()
+		if project != "" {
+			if ch := b.projectPrimaryChannel(project); ch != "" {
+				return ch
+			}
+		}
+	}
+
+	// Fall back to router default (if matched), otherwise bot default channel.
+	if routerResult.ChannelID != "" {
+		return routerResult.ChannelID
+	}
 	return b.channel
+}
+
+// projectChannelCacheTTL is the duration for which project→channel mappings
+// are cached to avoid repeated HTTP calls on the hot resolveChannel path.
+const projectChannelCacheTTL = 30 * time.Second
+
+// projectPrimaryChannel returns the first (primary) Slack channel for a project.
+// Uses a TTL-based cache to avoid calling ListProjectBeads on every notification.
+// Returns "" if the project is not found or has no channels configured.
+func (b *Bot) projectPrimaryChannel(project string) string {
+	b.mu.Lock()
+	if b.projectChannelCache != nil && time.Since(b.projectChannelCacheAt) < projectChannelCacheTTL {
+		ch := b.projectChannelCache[project]
+		b.mu.Unlock()
+		return ch
+	}
+	b.mu.Unlock()
+
+	projects, err := b.daemon.ListProjectBeads(context.Background())
+	if err != nil {
+		b.logger.Debug("resolveChannel: failed to list projects", "error", err)
+		return ""
+	}
+
+	cache := make(map[string]string, len(projects))
+	for name, info := range projects {
+		if len(info.SlackChannels) > 0 {
+			cache[name] = info.SlackChannels[0]
+		}
+	}
+
+	b.mu.Lock()
+	b.projectChannelCache = cache
+	b.projectChannelCacheAt = time.Now()
+	b.mu.Unlock()
+
+	return cache[project]
 }
 
 // Agent kill, clear, respawn, and coop shutdown functions are in bot_agent_kill.go.

--- a/gasboat/controller/internal/bridge/bot_commands.go
+++ b/gasboat/controller/internal/bridge/bot_commands.go
@@ -42,31 +42,20 @@ func (b *Bot) handleSlashCommand(ctx context.Context, cmd slack.SlashCommand) {
 }
 
 // handleSpawnCommand processes the /spawn slash command.
-// Usage: /spawn [task|ticket] [--role <role>]
+// Usage: /spawn [task|ticket] [--role <role>] [--project <project>]
 //
 // The new /spawn does NOT require an agent name — it auto-generates one.
 // Project is inferred from the channel's default project (via project beads'
-// slack_channel field). If no channel mapping exists, the user must use /start
-// which accepts an explicit agent name and project.
+// slack_channel field), unless --project is specified to override.
 func (b *Bot) handleSpawnCommand(ctx context.Context, cmd slack.SlashCommand) {
 	args := splitQuotedArgs(strings.TrimSpace(cmd.Text))
+	positional, role, projectFlag := extractSpawnFlags(args)
 
-	// Extract --role flag from args, leaving positional args intact.
-	role := ""
-	positional := args[:0]
-	for i := 0; i < len(args); i++ {
-		if args[i] == "--role" && i+1 < len(args) {
-			role = args[i+1]
-			i++ // skip value
-		} else if v, ok := strings.CutPrefix(args[i], "--role="); ok {
-			role = v
-		} else {
-			positional = append(positional, args[i])
-		}
+	// Resolve project: explicit --project flag overrides channel inference.
+	project := projectFlag
+	if project == "" {
+		project = b.projectFromChannel(ctx, cmd.ChannelID)
 	}
-
-	// Resolve project from channel.
-	project := b.projectFromChannel(ctx, cmd.ChannelID)
 
 	taskID := ""
 
@@ -203,9 +192,9 @@ func (b *Bot) handleTaskFirstSpawn(ctx context.Context, cmd slack.SlashCommand, 
 }
 
 // handleStartCommand processes the /start slash command.
-// Usage: /start <agent> [project|ticket|"PROMPT TEXT"] [task] [--role <role>]
+// Usage: /start <agent> [project|ticket|"PROMPT TEXT"] [task] [--role <role>] [--project <project>]
 //
-//	/start "task description" [project] [--role <role>]
+//	/start "task description" [project] [--role <role>] [--project <project>]
 //
 // This is the original /spawn behavior, preserved for power users who want to
 // specify an explicit agent name.
@@ -213,23 +202,11 @@ func (b *Bot) handleStartCommand(ctx context.Context, cmd slack.SlashCommand) {
 	args := splitQuotedArgs(strings.TrimSpace(cmd.Text))
 	if len(args) == 0 {
 		_, _ = b.api.PostEphemeral(cmd.ChannelID, cmd.UserID,
-			slack.MsgOptionText(":x: Usage: `/start <agent> [project|ticket|\"PROMPT TEXT\"] [task] [--role <role>]`\nor: `/start \"task description\" [project] [--role <role>]`", false))
+			slack.MsgOptionText(":x: Usage: `/start <agent> [project|ticket|\"PROMPT TEXT\"] [task] [--role <role>] [--project <project>]`\nor: `/start \"task description\" [project] [--role <role>]`", false))
 		return
 	}
 
-	// Extract --role flag from args, leaving positional args intact.
-	role := ""
-	positional := args[:0]
-	for i := 0; i < len(args); i++ {
-		if args[i] == "--role" && i+1 < len(args) {
-			role = args[i+1]
-			i++ // skip value
-		} else if v, ok := strings.CutPrefix(args[i], "--role="); ok {
-			role = v
-		} else {
-			positional = append(positional, args[i])
-		}
-	}
+	positional, role, projectFlag := extractSpawnFlags(args)
 
 	// Task-first mode: if the first positional arg contains spaces, it was a
 	// quoted task description rather than an agent name.
@@ -278,6 +255,11 @@ func (b *Bot) handleStartCommand(ctx context.Context, cmd slack.SlashCommand) {
 
 	if len(positional) >= 3 && taskID == "" {
 		taskID = positional[2]
+	}
+
+	// Explicit --project flag overrides any inferred project.
+	if projectFlag != "" {
+		project = projectFlag
 	}
 
 	// Validate project exists.
@@ -388,6 +370,29 @@ func randomSuffix(n int) string {
 		b[i] = chars[rand.IntN(len(chars))]
 	}
 	return string(b)
+}
+
+// extractSpawnFlags extracts --role and --project flags from a split arg list,
+// returning the remaining positional args and the extracted flag values.
+// Supports both "--flag value" and "--flag=value" syntax.
+func extractSpawnFlags(args []string) (positional []string, role, project string) {
+	positional = args[:0]
+	for i := 0; i < len(args); i++ {
+		if args[i] == "--role" && i+1 < len(args) {
+			role = args[i+1]
+			i++ // skip value
+		} else if v, ok := strings.CutPrefix(args[i], "--role="); ok {
+			role = v
+		} else if args[i] == "--project" && i+1 < len(args) {
+			project = args[i+1]
+			i++ // skip value
+		} else if v, ok := strings.CutPrefix(args[i], "--project="); ok {
+			project = v
+		} else {
+			positional = append(positional, args[i])
+		}
+	}
+	return
 }
 
 // splitQuotedArgs splits a command string into arguments, respecting double-quoted

--- a/gasboat/controller/internal/bridge/bot_spawn_test.go
+++ b/gasboat/controller/internal/bridge/bot_spawn_test.go
@@ -524,6 +524,54 @@ func TestGenerateSpawnName(t *testing.T) {
 	}
 }
 
+func TestExtractSpawnFlags(t *testing.T) {
+	cases := []struct {
+		name        string
+		args        []string
+		wantPos     []string
+		wantRole    string
+		wantProject string
+	}{
+		{"no flags", []string{"kd-abc"}, []string{"kd-abc"}, "", ""},
+		{"role flag", []string{"--role", "captain"}, nil, "captain", ""},
+		{"role=", []string{"--role=captain"}, nil, "captain", ""},
+		{"project flag", []string{"--project", "gasboat"}, nil, "", "gasboat"},
+		{"project=", []string{"--project=gasboat"}, nil, "", "gasboat"},
+		{"both flags", []string{"--project", "gasboat", "--role", "captain"}, nil, "captain", "gasboat"},
+		{"flags with positional", []string{"kd-abc", "--project", "gasboat", "--role", "ops"}, []string{"kd-abc"}, "ops", "gasboat"},
+		{"empty", nil, nil, "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Make a copy of args since extractSpawnFlags reuses the backing array.
+			argsCopy := make([]string, len(tc.args))
+			copy(argsCopy, tc.args)
+			pos, role, project := extractSpawnFlags(argsCopy)
+			if len(pos) == 0 {
+				pos = nil
+			}
+			if len(tc.wantPos) == 0 {
+				tc.wantPos = nil
+			}
+			if len(pos) != len(tc.wantPos) {
+				t.Errorf("positional: got %v (len %d), want %v (len %d)", pos, len(pos), tc.wantPos, len(tc.wantPos))
+			} else {
+				for i := range pos {
+					if pos[i] != tc.wantPos[i] {
+						t.Errorf("positional[%d]: got %q, want %q", i, pos[i], tc.wantPos[i])
+					}
+				}
+			}
+			if role != tc.wantRole {
+				t.Errorf("role: got %q, want %q", role, tc.wantRole)
+			}
+			if project != tc.wantProject {
+				t.Errorf("project: got %q, want %q", project, tc.wantProject)
+			}
+		})
+	}
+}
+
 // --- Slash command routing test ---
 
 func TestHandleSlashCommand_RoutesStartAndSpawn(t *testing.T) {
@@ -634,4 +682,281 @@ func TestHandleSpawnCommand_SmartQuotes_PassesPrompt(t *testing.T) {
 		}
 	}
 	t.Errorf("expected agent bead to have prompt field 'fix the helm chart'")
+}
+
+// --- /spawn --project flag tests ---
+
+func TestHandleSpawnCommand_ProjectFlag_OverridesChannel(t *testing.T) {
+	daemon := newMockDaemon()
+	daemon.seedProjectWithChannel("monorepo", "C-MONO")
+	daemon.seedProject("gasboat")
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+
+	bot := newTestBot(daemon, slackSrv)
+
+	// Channel maps to monorepo, but --project says gasboat.
+	bot.handleSpawnCommand(context.Background(), slack.SlashCommand{
+		Command:   "/spawn",
+		Text:      "--project gasboat",
+		ChannelID: "C-MONO",
+		UserID:    "U456",
+	})
+
+	agentBeads := filterAgentBeads(daemon.beads)
+	if len(agentBeads) != 1 {
+		t.Fatalf("expected 1 agent bead created, got %d", len(agentBeads))
+	}
+	for _, b := range agentBeads {
+		if b.Fields["project"] != "gasboat" {
+			t.Errorf("expected project=gasboat (from --project flag), got %s", b.Fields["project"])
+		}
+		// Name should use gasboat prefix.
+		if !strings.HasPrefix(b.Title, "gasboat-") {
+			t.Errorf("expected name with prefix 'gasboat-', got %q", b.Title)
+		}
+	}
+}
+
+func TestHandleSpawnCommand_ProjectFlagEquals_OverridesChannel(t *testing.T) {
+	daemon := newMockDaemon()
+	daemon.seedProjectWithChannel("monorepo", "C-MONO")
+	daemon.seedProject("gasboat")
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+
+	bot := newTestBot(daemon, slackSrv)
+
+	// --project=gasboat syntax
+	bot.handleSpawnCommand(context.Background(), slack.SlashCommand{
+		Command:   "/spawn",
+		Text:      "--project=gasboat",
+		ChannelID: "C-MONO",
+		UserID:    "U456",
+	})
+
+	agentBeads := filterAgentBeads(daemon.beads)
+	if len(agentBeads) != 1 {
+		t.Fatalf("expected 1 agent bead created, got %d", len(agentBeads))
+	}
+	for _, b := range agentBeads {
+		if b.Fields["project"] != "gasboat" {
+			t.Errorf("expected project=gasboat (from --project=), got %s", b.Fields["project"])
+		}
+	}
+}
+
+func TestHandleSpawnCommand_ProjectFlag_WithTask(t *testing.T) {
+	daemon := newMockDaemon()
+	daemon.seedProject("gasboat")
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+
+	bot := newTestBot(daemon, slackSrv)
+
+	// /spawn --project gasboat "fix the auth flow"
+	bot.handleSpawnCommand(context.Background(), slack.SlashCommand{
+		Command:   "/spawn",
+		Text:      `--project gasboat "fix the auth flow"`,
+		ChannelID: "C-RANDOM",
+		UserID:    "U456",
+	})
+
+	taskBeads := filterBeadsByType(daemon.beads, "task")
+	if len(taskBeads) != 1 {
+		t.Fatalf("expected 1 task bead created, got %d", len(taskBeads))
+	}
+	for _, b := range taskBeads {
+		if !containsLabel(b.Labels, "project:gasboat") {
+			t.Errorf("expected task to have label project:gasboat, got %v", b.Labels)
+		}
+	}
+
+	agentBeads := filterAgentBeads(daemon.beads)
+	if len(agentBeads) != 1 {
+		t.Fatalf("expected 1 agent bead created, got %d", len(agentBeads))
+	}
+	for _, b := range agentBeads {
+		if b.Fields["project"] != "gasboat" {
+			t.Errorf("expected project=gasboat, got %s", b.Fields["project"])
+		}
+	}
+}
+
+func TestHandleSpawnCommand_ProjectFlag_WithRole(t *testing.T) {
+	daemon := newMockDaemon()
+	daemon.seedProject("gasboat")
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+
+	bot := newTestBot(daemon, slackSrv)
+
+	// /spawn --project gasboat --role captain
+	bot.handleSpawnCommand(context.Background(), slack.SlashCommand{
+		Command:   "/spawn",
+		Text:      "--project gasboat --role captain",
+		ChannelID: "C-RANDOM",
+		UserID:    "U456",
+	})
+
+	agentBeads := filterAgentBeads(daemon.beads)
+	if len(agentBeads) != 1 {
+		t.Fatalf("expected 1 agent bead created, got %d", len(agentBeads))
+	}
+	for _, b := range agentBeads {
+		if b.Fields["project"] != "gasboat" {
+			t.Errorf("expected project=gasboat, got %s", b.Fields["project"])
+		}
+		if b.Fields["role"] != "captain" {
+			t.Errorf("expected role=captain, got %s", b.Fields["role"])
+		}
+	}
+}
+
+func TestHandleSpawnCommand_ProjectFlag_NoChannel(t *testing.T) {
+	daemon := newMockDaemon()
+	daemon.seedProject("gasboat")
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+
+	bot := newTestBot(daemon, slackSrv)
+
+	// /spawn --project gasboat from an unmapped channel
+	bot.handleSpawnCommand(context.Background(), slack.SlashCommand{
+		Command:   "/spawn",
+		Text:      "--project gasboat",
+		ChannelID: "C-UNMAPPED",
+		UserID:    "U456",
+	})
+
+	agentBeads := filterAgentBeads(daemon.beads)
+	if len(agentBeads) != 1 {
+		t.Fatalf("expected 1 agent bead created, got %d", len(agentBeads))
+	}
+	for _, b := range agentBeads {
+		if b.Fields["project"] != "gasboat" {
+			t.Errorf("expected project=gasboat (from --project in unmapped channel), got %s", b.Fields["project"])
+		}
+	}
+}
+
+// --- resolveChannel project-aware tests ---
+
+func TestResolveChannel_AgentProject_UsesProjectPrimaryChannel(t *testing.T) {
+	daemon := newMockDaemon()
+	daemon.seedProjectWithChannel("gasboat", "C-GASBOAT")
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+
+	bot := newTestBot(daemon, slackSrv)
+	bot.channel = "C-DEFAULT"
+
+	// Cache the project for the agent.
+	bot.agentProject["my-agent"] = "gasboat"
+
+	result := bot.resolveChannel("my-agent")
+	if result != "C-GASBOAT" {
+		t.Errorf("expected C-GASBOAT (project primary channel), got %q", result)
+	}
+}
+
+func TestResolveChannel_AgentProject_NoChannelConfig_FallsBack(t *testing.T) {
+	daemon := newMockDaemon()
+	daemon.seedProject("gasboat") // No channel configured
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+
+	bot := newTestBot(daemon, slackSrv)
+	bot.channel = "C-DEFAULT"
+
+	bot.agentProject["my-agent"] = "gasboat"
+
+	result := bot.resolveChannel("my-agent")
+	if result != "C-DEFAULT" {
+		t.Errorf("expected C-DEFAULT (no project channel), got %q", result)
+	}
+}
+
+func TestResolveChannel_AgentProject_UnknownProject_FallsBack(t *testing.T) {
+	daemon := newMockDaemon()
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+
+	bot := newTestBot(daemon, slackSrv)
+	bot.channel = "C-DEFAULT"
+
+	bot.agentProject["my-agent"] = "nonexistent"
+
+	result := bot.resolveChannel("my-agent")
+	if result != "C-DEFAULT" {
+		t.Errorf("expected C-DEFAULT (unknown project), got %q", result)
+	}
+}
+
+func TestResolveChannel_RouterOverride_TakesPrecedenceOverProject(t *testing.T) {
+	daemon := newMockDaemon()
+	daemon.seedProjectWithChannel("gasboat", "C-GASBOAT")
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+
+	bot := newTestBot(daemon, slackSrv)
+	bot.channel = "C-DEFAULT"
+	bot.router = NewRouter(RouterConfig{
+		DefaultChannel: "C-ROUTER-DEFAULT",
+		Overrides: map[string]string{
+			"my-agent": "C-OVERRIDE",
+		},
+	})
+
+	bot.agentProject["my-agent"] = "gasboat"
+
+	result := bot.resolveChannel("my-agent")
+	if result != "C-OVERRIDE" {
+		t.Errorf("expected C-OVERRIDE (router override > project), got %q", result)
+	}
+}
+
+func TestResolveChannel_RouterPatternMatch_TakesPrecedenceOverProject(t *testing.T) {
+	daemon := newMockDaemon()
+	daemon.seedProjectWithChannel("gasboat", "C-GASBOAT")
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+
+	bot := newTestBot(daemon, slackSrv)
+	bot.channel = "C-DEFAULT"
+	bot.router = NewRouter(RouterConfig{
+		DefaultChannel: "C-ROUTER-DEFAULT",
+		Channels: map[string]string{
+			"gasboat/crew/*": "C-CREW",
+		},
+	})
+
+	bot.agentProject["my-agent"] = "gasboat"
+
+	// Pattern match "gasboat/crew/*" should take precedence over project channel
+	result := bot.resolveChannel("gasboat/crew/my-agent")
+	if result != "C-CREW" {
+		t.Errorf("expected C-CREW (router pattern > project), got %q", result)
+	}
+}
+
+func TestResolveChannel_ProjectChannel_OverridesRouterDefault(t *testing.T) {
+	daemon := newMockDaemon()
+	daemon.seedProjectWithChannel("gasboat", "C-GASBOAT")
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+
+	bot := newTestBot(daemon, slackSrv)
+	bot.channel = "C-DEFAULT"
+	bot.router = NewRouter(RouterConfig{
+		DefaultChannel: "C-ROUTER-DEFAULT",
+	})
+
+	bot.agentProject["my-agent"] = "gasboat"
+
+	// No router pattern matches, project channel should override router default
+	result := bot.resolveChannel("my-agent")
+	if result != "C-GASBOAT" {
+		t.Errorf("expected C-GASBOAT (project channel > router default), got %q", result)
+	}
 }

--- a/gasboat/controller/internal/bridge/bot_start_test.go
+++ b/gasboat/controller/internal/bridge/bot_start_test.go
@@ -31,6 +31,7 @@ func newTestBot(daemon BeadClient, slackSrv *httptest.Server) *Bot {
 		agentPodName:    make(map[string]string),
 		agentImageTag:   make(map[string]string),
 		agentRole:       make(map[string]string),
+		agentProject:    make(map[string]string),
 		threadSpawnMsgs: make(map[string]MessageRef),
 	}
 }


### PR DESCRIPTION
## Summary
- Add `--project` flag to `/spawn` and `/start` commands so agents can be spawned for any project from any Slack channel (e.g. `/spawn myagent --project pihealth`)
- Route agent status cards to the project's primary Slack channel (first entry in the project bead's `slack_channel` field) instead of always posting to the default gasboat channel
- Add 30-second TTL cache for project→channel lookups to keep the hot path fast

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/bridge/` passes (13 new tests)
- [ ] Manual: `/spawn test-agent --project gasboat` from a non-gasboat channel → card appears in gasboat's primary channel
- [ ] Manual: `/spawn test-agent` from a project-mapped channel → existing behavior preserved
- [ ] Manual: `/start myagent --project pihealth --role ops taskdesc` → correct project assigned

🤖 Generated with [Claude Code](https://claude.com/claude-code)