### PR TITLE
feat(bridge): in-thread kill/restart commands

### DIFF
--- a/gasboat/controller/internal/bridge/bot_commands.go
+++ b/gasboat/controller/internal/bridge/bot_commands.go
@@ -26,6 +26,8 @@ func (b *Bot) handleSlashCommand(ctx context.Context, cmd slack.SlashCommand) {
 		b.handleStartCommand(ctx, cmd)
 	case "/kill":
 		b.handleKillCommand(ctx, cmd)
+	case "/kill-thread":
+		b.handleKillThreadCommand(ctx, cmd)
 	case "/unreleased":
 		b.handleUnreleasedCommand(ctx, cmd)
 	case "/clear-threads":
@@ -661,6 +663,98 @@ func (b *Bot) handleKillCommand(ctx context.Context, cmd slack.SlashCommand) {
 
 	_, _ = b.api.PostEphemeral(cmd.ChannelID, cmd.UserID,
 		slack.MsgOptionText(fmt.Sprintf(":hourglass_flowing_sand: Killing agent *%s*…", agentName), false))
+}
+
+// handleKillThreadCommand kills a thread-bound agent by name or lists thread agents
+// in the current channel. Since slash commands don't carry thread context, this
+// requires the agent name as an argument.
+// Usage: /kill-thread <agent> [--force] [--restart]
+func (b *Bot) handleKillThreadCommand(_ context.Context, cmd slack.SlashCommand) {
+	args := strings.Fields(strings.TrimSpace(cmd.Text))
+	if len(args) == 0 {
+		// No agent specified — list thread agents in this channel.
+		b.listChannelThreadAgents(cmd)
+		return
+	}
+
+	force := false
+	restart := false
+	positional := args[:0]
+	for _, a := range args {
+		switch a {
+		case "--force":
+			force = true
+		case "--restart":
+			restart = true
+		default:
+			positional = append(positional, a)
+		}
+	}
+	if len(positional) == 0 {
+		_, _ = b.api.PostEphemeral(cmd.ChannelID, cmd.UserID,
+			slack.MsgOptionText(":x: Usage: `/kill-thread <agent> [--force] [--restart]`", false))
+		return
+	}
+
+	agentName := positional[0]
+
+	_, _ = b.api.PostEphemeral(cmd.ChannelID, cmd.UserID,
+		slack.MsgOptionText(fmt.Sprintf(":hourglass_flowing_sand: Killing thread agent *%s*…", agentName), false))
+
+	go func() {
+		// Look up the agent bead to capture thread metadata before killing.
+		bead, err := b.daemon.FindAgentBead(context.Background(), extractAgentName(agentName))
+		if err != nil {
+			_, _ = b.api.PostEphemeral(cmd.ChannelID, cmd.UserID,
+				slack.MsgOptionText(fmt.Sprintf(":x: Agent %q not found: %s", agentName, err), false))
+			return
+		}
+		threadChannel := bead.Fields["slack_thread_channel"]
+		threadTS := bead.Fields["slack_thread_ts"]
+
+		if err := b.killAgent(context.Background(), agentName, force); err != nil {
+			b.logger.Error("kill-thread command: failed", "agent", agentName, "error", err)
+			_, _ = b.api.PostEphemeral(cmd.ChannelID, cmd.UserID,
+				slack.MsgOptionText(fmt.Sprintf(":x: Failed to kill thread agent %q: %s", agentName, err.Error()), false))
+			return
+		}
+
+		b.logger.Info("killed thread agent via slash command", "agent", agentName, "user", cmd.UserID, "restart", restart)
+
+		if restart && threadChannel != "" && threadTS != "" {
+			b.respawnThreadAgent(context.Background(), threadChannel, threadTS, agentName,
+				"Restarted via /kill-thread --restart")
+			_, _ = b.api.PostEphemeral(cmd.ChannelID, cmd.UserID,
+				slack.MsgOptionText(fmt.Sprintf(":arrows_counterclockwise: Thread agent *%s* restarted with session resume.", agentName), false))
+		} else {
+			_, _ = b.api.PostEphemeral(cmd.ChannelID, cmd.UserID,
+				slack.MsgOptionText(fmt.Sprintf(":skull: Thread agent *%s* terminated.", agentName), false))
+		}
+	}()
+}
+
+// listChannelThreadAgents shows thread agents bound to threads in the given channel.
+func (b *Bot) listChannelThreadAgents(cmd slack.SlashCommand) {
+	if b.state == nil {
+		_, _ = b.api.PostEphemeral(cmd.ChannelID, cmd.UserID,
+			slack.MsgOptionText(":x: State manager not available", false))
+		return
+	}
+
+	agents := b.state.GetThreadAgentsByChannel(cmd.ChannelID)
+	if len(agents) == 0 {
+		_, _ = b.api.PostEphemeral(cmd.ChannelID, cmd.UserID,
+			slack.MsgOptionText(":information_source: No thread agents in this channel.\nUsage: `/kill-thread <agent> [--force] [--restart]`", false))
+		return
+	}
+
+	var sb strings.Builder
+	sb.WriteString(":thread: *Thread agents in this channel:*\n")
+	for _, a := range agents {
+		sb.WriteString(fmt.Sprintf("• `%s` — `/kill-thread %s`\n", a, a))
+	}
+	_, _ = b.api.PostEphemeral(cmd.ChannelID, cmd.UserID,
+		slack.MsgOptionText(sb.String(), false))
 }
 
 // handleClearThreadsCommand removes all thread→agent mappings from state.

--- a/gasboat/controller/internal/bridge/bot_mentions.go
+++ b/gasboat/controller/internal/bridge/bot_mentions.go
@@ -130,6 +130,14 @@ func (b *Bot) handleAppMention(ctx context.Context, ev *slackevents.AppMentionEv
 	// and stored refs use consistent keys.
 	agent = extractAgentName(agent)
 
+	// Check for thread control commands: @gasboat kill, @gasboat restart, @gasboat stop.
+	// These only work in threads where an agent is bound.
+	if ev.ThreadTimeStamp != "" && agent != "" {
+		if handled := b.handleMentionThreadCommand(ctx, ev, agent, text); handled {
+			return
+		}
+	}
+
 	// Resolve sender display name.
 	username := ev.User
 	if user, err := b.api.GetUserInfo(ev.User); err == nil {
@@ -718,4 +726,91 @@ func (b *Bot) nudgeAgentForMention(ctx context.Context, agent, text, beadID stri
 	b.logger.Info("nudged agent for mention",
 		"agent", agentName, "bead", beadID)
 	return nil
+}
+
+// handleMentionThreadCommand checks if a thread @mention is a control command
+// (kill, stop, restart) and executes it. Returns true if the command was handled.
+// This provides in-thread agent lifecycle control via @gasboat kill/restart.
+func (b *Bot) handleMentionThreadCommand(_ context.Context, ev *slackevents.AppMentionEvent, agent, text string) bool {
+	cmd, force := parseThreadCommand(text)
+	if cmd == "" {
+		return false
+	}
+
+	channelID := ev.Channel
+	threadTS := ev.ThreadTimeStamp
+	userID := ev.User
+
+	switch cmd {
+	case "kill", "stop":
+		if b.api != nil {
+			_, _, _ = b.api.PostMessage(channelID,
+				slack.MsgOptionText(fmt.Sprintf(":hourglass_flowing_sand: Killing thread agent *%s*…", agent), false),
+				slack.MsgOptionTS(threadTS),
+			)
+		}
+		go func() {
+			if err := b.killAgent(context.Background(), agent, force); err != nil {
+				b.logger.Error("mention kill: failed", "agent", agent, "error", err)
+				if b.api != nil {
+					_, _ = b.api.PostEphemeral(channelID, userID,
+						slack.MsgOptionText(fmt.Sprintf(":x: Failed to kill agent %q: %s", agent, err.Error()), false))
+				}
+				return
+			}
+			b.logger.Info("killed thread agent via mention", "agent", agent, "user", userID)
+			if b.api != nil {
+				_, _, _ = b.api.PostMessage(channelID,
+					slack.MsgOptionText(fmt.Sprintf(":skull: Thread agent *%s* terminated.", agent), false),
+					slack.MsgOptionTS(threadTS),
+				)
+			}
+		}()
+		return true
+
+	case "restart":
+		if b.api != nil {
+			_, _, _ = b.api.PostMessage(channelID,
+				slack.MsgOptionText(fmt.Sprintf(":arrows_counterclockwise: Restarting thread agent *%s*…", agent), false),
+				slack.MsgOptionTS(threadTS),
+			)
+		}
+		go func() {
+			b.respawnThreadAgent(context.Background(), channelID, threadTS, agent,
+				"Restarted via @mention command")
+		}()
+		return true
+	}
+
+	return false
+}
+
+// parseThreadCommand extracts a thread control command from mention text.
+// Returns the command name and whether --force was specified.
+// Only matches exact command keywords (with optional flags) to avoid false
+// positives on messages like "kill the deployment process".
+func parseThreadCommand(text string) (cmd string, force bool) {
+	text = strings.TrimSpace(strings.ToLower(text))
+	words := strings.Fields(text)
+	if len(words) == 0 {
+		return "", false
+	}
+
+	switch words[0] {
+	case "kill", "stop", "restart":
+		cmd = words[0]
+	default:
+		return "", false
+	}
+
+	// Only recognize as a command if no extra words beyond flags.
+	for _, w := range words[1:] {
+		if w == "--force" {
+			force = true
+		} else {
+			// Extra words like "kill the deployment" — not a command.
+			return "", false
+		}
+	}
+	return cmd, force
 }

--- a/gasboat/controller/internal/bridge/bot_mentions_test.go
+++ b/gasboat/controller/internal/bridge/bot_mentions_test.go
@@ -775,3 +775,113 @@ func TestProjectFromAgentIdentity(t *testing.T) {
 		}
 	}
 }
+
+func TestParseThreadCommand(t *testing.T) {
+	tests := []struct {
+		text      string
+		wantCmd   string
+		wantForce bool
+	}{
+		{"kill", "kill", false},
+		{"stop", "stop", false},
+		{"restart", "restart", false},
+		{"kill --force", "kill", true},
+		{"stop --force", "stop", true},
+		{"  Kill  ", "kill", false},
+		{"RESTART", "restart", false},
+		// Not commands — contain extra words.
+		{"kill the deployment", "", false},
+		{"restart the agent now", "", false},
+		{"check the logs", "", false},
+		{"", "", false},
+		{"--force", "", false},
+	}
+
+	for _, tt := range tests {
+		cmd, force := parseThreadCommand(tt.text)
+		if cmd != tt.wantCmd || force != tt.wantForce {
+			t.Errorf("parseThreadCommand(%q) = (%q, %v), want (%q, %v)",
+				tt.text, cmd, force, tt.wantCmd, tt.wantForce)
+		}
+	}
+}
+
+func TestGetThreadAgentsByChannel(t *testing.T) {
+	dir := t.TempDir()
+	state, err := NewStateManager(filepath.Join(dir, "state.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Add thread agents in two different channels.
+	_ = state.SetThreadAgent("C-general", "1111.2222", "thread-1111-2222")
+	_ = state.SetThreadAgent("C-general", "3333.4444", "thread-3333-4444")
+	_ = state.SetThreadAgent("C-other", "5555.6666", "thread-5555-6666")
+
+	agents := state.GetThreadAgentsByChannel("C-general")
+	if len(agents) != 2 {
+		t.Fatalf("expected 2 agents in C-general, got %d", len(agents))
+	}
+
+	agents = state.GetThreadAgentsByChannel("C-other")
+	if len(agents) != 1 {
+		t.Fatalf("expected 1 agent in C-other, got %d", len(agents))
+	}
+	if agents[0] != "thread-5555-6666" {
+		t.Errorf("expected thread-5555-6666, got %s", agents[0])
+	}
+
+	agents = state.GetThreadAgentsByChannel("C-nonexistent")
+	if len(agents) != 0 {
+		t.Errorf("expected 0 agents in nonexistent channel, got %d", len(agents))
+	}
+}
+
+func TestHandleMentionThreadCommand_CommandDispatch(t *testing.T) {
+	daemon := newMockDaemon()
+	dir := t.TempDir()
+	state, err := NewStateManager(filepath.Join(dir, "state.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	b := &Bot{
+		daemon:     daemon,
+		state:      state,
+		logger:     slog.Default(),
+		botUserID:  "U-BOT",
+		agentCards: map[string]MessageRef{},
+	}
+
+	ev := &slackevents.AppMentionEvent{
+		Channel:         "C-test",
+		ThreadTimeStamp: "1111.2222",
+		User:            "U-USER",
+		TimeStamp:       "9999.0001",
+	}
+
+	tests := []struct {
+		text    string
+		handled bool
+	}{
+		{"kill", true},
+		{"stop", true},
+		{"restart", true},
+		{"kill --force", true},
+		{"stop --force", true},
+		{"check the logs", false},
+		{"kill the deployment", false},
+		{"restart the server now", false},
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		handled := b.handleMentionThreadCommand(context.Background(), ev, "thread-agent-1", tt.text)
+		if handled != tt.handled {
+			t.Errorf("handleMentionThreadCommand(%q) = %v, want %v", tt.text, handled, tt.handled)
+		}
+		// Give goroutines time to finish to avoid panics (kill/restart goroutines
+		// will fail on the mock daemon but that's expected).
+		time.Sleep(10 * time.Millisecond)
+	}
+}

--- a/gasboat/controller/internal/bridge/state.go
+++ b/gasboat/controller/internal/bridge/state.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 )
 
@@ -237,6 +238,20 @@ func (sm *StateManager) ClearAllThreadAgents() (int, error) {
 	n := len(sm.data.ThreadAgents)
 	sm.data.ThreadAgents = make(map[string]string)
 	return n, sm.saveLocked()
+}
+
+// GetThreadAgentsByChannel returns agent names for all threads in a given channel.
+func (sm *StateManager) GetThreadAgentsByChannel(channel string) []string {
+	sm.mu.RLock()
+	defer sm.mu.RUnlock()
+	prefix := channel + ":"
+	var agents []string
+	for k, v := range sm.data.ThreadAgents {
+		if strings.HasPrefix(k, prefix) {
+			agents = append(agents, v)
+		}
+	}
+	return agents
 }
 
 // --- Listen Threads ---


### PR DESCRIPTION
## Summary
- Add `@gasboat kill` / `@gasboat stop` / `@gasboat restart` in-thread commands for managing thread-bound agents directly from the Slack thread
- Add `/kill-thread <agent> [--force] [--restart]` slash command for channel-level thread agent management
- Add `GetThreadAgentsByChannel` to list thread agents per channel (used by `/kill-thread` with no args)

## How it works
Slack slash commands don't carry thread context, so **@mention** is the primary in-thread UX. The `handleAppMention` handler intercepts `kill`, `stop`, and `restart` keywords before the normal mention flow (bead creation + nudge). Only exact keyword matches are treated as commands — `@gasboat kill the deployment` is forwarded to the agent as a normal mention.

The `/kill-thread` slash command is an admin fallback that works from any channel. When invoked without arguments, it lists all thread agents in the current channel.

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/bridge/` passes (3 new test functions)
- [ ] Manual: `@gasboat kill` in a thread with a bound agent → agent killed, confirmation posted
- [ ] Manual: `@gasboat restart` in thread → agent killed and respawned with session resume
- [ ] Manual: `/kill-thread` with no args → lists thread agents
- [ ] Manual: `/kill-thread thread-xxx --restart` → kill + respawn

🤖 Generated with [Claude Code](https://claude.com/claude-code)