### PR TITLE
feat(gasboat/scheduler): add guard rails for scheduled agents

### DIFF
--- a/gasboat/controller/internal/scheduler/guardrails_test.go
+++ b/gasboat/controller/internal/scheduler/guardrails_test.go
@@ -1,0 +1,677 @@
+package scheduler
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"gasboat/controller/internal/beadsapi"
+)
+
+// --- helpers ---
+
+func TestParseIntField(t *testing.T) {
+	tests := []struct {
+		input  string
+		defVal int
+		want   int
+	}{
+		{"", 5, 5},
+		{"0", 5, 0},
+		{"3", 5, 3},
+		{"10", 0, 10},
+		{"-1", 5, 5},
+		{"abc", 5, 5},
+		{"100", 0, 100},
+	}
+	for _, tt := range tests {
+		got := parseIntField(tt.input, tt.defVal)
+		if got != tt.want {
+			t.Errorf("parseIntField(%q, %d) = %d, want %d", tt.input, tt.defVal, got, tt.want)
+		}
+	}
+}
+
+func TestParseDurationField(t *testing.T) {
+	tests := []struct {
+		input  string
+		defVal time.Duration
+		want   time.Duration
+	}{
+		{"", 30 * time.Minute, 30 * time.Minute},
+		{"10m", 30 * time.Minute, 10 * time.Minute},
+		{"1h", 30 * time.Minute, 1 * time.Hour},
+		{"45s", 30 * time.Minute, 45 * time.Second},
+		{"2h30m", 30 * time.Minute, 2*time.Hour + 30*time.Minute},
+		// Plain integer → minutes.
+		{"15", 30 * time.Minute, 15 * time.Minute},
+		{"1", 30 * time.Minute, 1 * time.Minute},
+		// Invalid.
+		{"abc", 30 * time.Minute, 30 * time.Minute},
+		{"-5m", 30 * time.Minute, 30 * time.Minute},
+		{"0", 30 * time.Minute, 30 * time.Minute},   // plain int 0 → invalid
+		{"0s", 30 * time.Minute, 30 * time.Minute},   // zero duration → default
+		{"-1", 30 * time.Minute, 30 * time.Minute},   // negative plain int
+	}
+	for _, tt := range tests {
+		got := parseDurationField(tt.input, tt.defVal)
+		if got != tt.want {
+			t.Errorf("parseDurationField(%q, %v) = %v, want %v", tt.input, tt.defVal, got, tt.want)
+		}
+	}
+}
+
+// --- mock daemon ---
+
+// mockBeads is a simple in-memory mock of the beads daemon API.
+type mockBeads struct {
+	mu     sync.Mutex
+	beads  map[string]*beadsapi.BeadDetail
+	closed map[string]bool
+	// Track calls for assertions.
+	updateCalls []updateCall
+	closeCalls  []string
+	createCalls int
+}
+
+type updateCall struct {
+	id     string
+	fields map[string]string
+}
+
+func newMockBeads() *mockBeads {
+	return &mockBeads{
+		beads:  make(map[string]*beadsapi.BeadDetail),
+		closed: make(map[string]bool),
+	}
+}
+
+func (m *mockBeads) handler() http.Handler {
+	mux := http.NewServeMux()
+
+	// GET /v1/beads?type=schedule&status=open,in_progress → list
+	mux.HandleFunc("/v1/beads", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost {
+			// CreateBead
+			m.mu.Lock()
+			m.createCalls++
+			id := fmt.Sprintf("mock-bead-%d", m.createCalls)
+			m.beads[id] = &beadsapi.BeadDetail{ID: id, Status: "open", Fields: map[string]string{}}
+			m.mu.Unlock()
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]string{"id": id})
+			return
+		}
+		// ListBeadsFiltered
+		m.mu.Lock()
+		var result []any
+		for _, b := range m.beads {
+			if b.Type != "schedule" {
+				continue
+			}
+			result = append(result, map[string]any{
+				"id":     b.ID,
+				"title":  b.Title,
+				"type":   b.Type,
+				"status": b.Status,
+				"fields": b.Fields,
+			})
+		}
+		m.mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"beads": result, "total": len(result)})
+	})
+
+	// /v1/beads/{id} and sub-resources
+	mux.HandleFunc("/v1/beads/", func(w http.ResponseWriter, r *http.Request) {
+		path := r.URL.Path[len("/v1/beads/"):]
+
+		// Sub-resources: /v1/beads/{id}/close, /labels, /deps
+		for _, suffix := range []string{"/close", "/labels", "/deps"} {
+			if idx := len(path) - len(suffix); idx > 0 && path[idx:] == suffix {
+				beadID := path[:idx]
+				switch suffix {
+				case "/close":
+					m.mu.Lock()
+					m.closeCalls = append(m.closeCalls, beadID)
+					if b, ok := m.beads[beadID]; ok {
+						b.Status = "closed"
+					}
+					m.mu.Unlock()
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(map[string]bool{"ok": true})
+				return
+			}
+		}
+
+		// Bare bead path: /v1/beads/{id}
+		beadID := path
+		if r.Method == http.MethodPatch {
+			// UpdateBeadFields: PATCH /v1/beads/{id} with {"fields": {...}}
+			var body map[string]json.RawMessage
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			var fields map[string]any
+			if raw, ok := body["fields"]; ok {
+				_ = json.Unmarshal(raw, &fields)
+			}
+			// Convert to string map for tracking.
+			strFields := make(map[string]string)
+			for k, v := range fields {
+				switch val := v.(type) {
+				case string:
+					strFields[k] = val
+				case bool:
+					strFields[k] = fmt.Sprintf("%v", val)
+				default:
+					strFields[k] = fmt.Sprintf("%v", val)
+				}
+			}
+			m.mu.Lock()
+			m.updateCalls = append(m.updateCalls, updateCall{id: beadID, fields: strFields})
+			if b, ok := m.beads[beadID]; ok {
+				for k, v := range strFields {
+					b.Fields[k] = v
+				}
+			}
+			m.mu.Unlock()
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]bool{"ok": true})
+			return
+		}
+
+		// GET /v1/beads/{id}
+		m.mu.Lock()
+		b, ok := m.beads[beadID]
+		m.mu.Unlock()
+		if !ok {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":     b.ID,
+			"title":  b.Title,
+			"type":   b.Type,
+			"status": b.Status,
+			"fields": b.Fields,
+		})
+	})
+
+	return mux
+}
+
+func newTestScheduler(srv *httptest.Server) *Scheduler {
+	client, _ := beadsapi.New(beadsapi.Config{HTTPAddr: srv.URL})
+	return New(client, slog.Default())
+}
+
+// --- guard rail tests ---
+
+func TestIsLastAgentRunning_NoAgent(t *testing.T) {
+	mock := newMockBeads()
+	srv := httptest.NewServer(mock.handler())
+	defer srv.Close()
+
+	s := newTestScheduler(srv)
+	// No last agent → not running.
+	got := s.isLastAgentRunning(context.Background(), Schedule{})
+	if got {
+		t.Error("expected false for schedule with no last agent")
+	}
+}
+
+func TestIsLastAgentRunning_AgentClosed(t *testing.T) {
+	mock := newMockBeads()
+	mock.beads["agent-1"] = &beadsapi.BeadDetail{
+		ID: "agent-1", Type: "agent", Status: "closed",
+		Fields: map[string]string{},
+	}
+	srv := httptest.NewServer(mock.handler())
+	defer srv.Close()
+
+	s := newTestScheduler(srv)
+	got := s.isLastAgentRunning(context.Background(), Schedule{LastAgentID: "agent-1"})
+	if got {
+		t.Error("expected false for closed agent")
+	}
+}
+
+func TestIsLastAgentRunning_AgentOpen(t *testing.T) {
+	mock := newMockBeads()
+	mock.beads["agent-1"] = &beadsapi.BeadDetail{
+		ID: "agent-1", Type: "agent", Status: "open",
+		Fields: map[string]string{},
+	}
+	srv := httptest.NewServer(mock.handler())
+	defer srv.Close()
+
+	s := newTestScheduler(srv)
+	got := s.isLastAgentRunning(context.Background(), Schedule{LastAgentID: "agent-1"})
+	if !got {
+		t.Error("expected true for open agent")
+	}
+}
+
+func TestIsLastAgentRunning_AgentNotFound(t *testing.T) {
+	mock := newMockBeads()
+	srv := httptest.NewServer(mock.handler())
+	defer srv.Close()
+
+	s := newTestScheduler(srv)
+	// Unknown agent → can't determine status → allow spawn.
+	got := s.isLastAgentRunning(context.Background(), Schedule{LastAgentID: "nonexistent"})
+	if got {
+		t.Error("expected false when agent not found (permissive)")
+	}
+}
+
+func TestRecordFailure_IncrementsCount(t *testing.T) {
+	mock := newMockBeads()
+	mock.beads["sched-1"] = &beadsapi.BeadDetail{
+		ID: "sched-1", Type: "schedule", Status: "open",
+		Fields: map[string]string{"consecutive_failures": "0"},
+	}
+	srv := httptest.NewServer(mock.handler())
+	defer srv.Close()
+
+	s := newTestScheduler(srv)
+	sched := &Schedule{
+		ID:                  "sched-1",
+		Enabled:             true,
+		MaxRetries:          3,
+		ConsecutiveFailures: 0,
+	}
+
+	s.recordFailure(context.Background(), sched)
+
+	if sched.ConsecutiveFailures != 1 {
+		t.Errorf("expected 1 consecutive failure, got %d", sched.ConsecutiveFailures)
+	}
+	if !sched.Enabled {
+		t.Error("should not be disabled after 1 failure")
+	}
+}
+
+func TestRecordFailure_AutoDisablesAtMaxRetries(t *testing.T) {
+	mock := newMockBeads()
+	mock.beads["sched-1"] = &beadsapi.BeadDetail{
+		ID: "sched-1", Type: "schedule", Status: "open",
+		Fields: map[string]string{"consecutive_failures": "2"},
+	}
+	srv := httptest.NewServer(mock.handler())
+	defer srv.Close()
+
+	s := newTestScheduler(srv)
+	sched := &Schedule{
+		ID:                  "sched-1",
+		Enabled:             true,
+		MaxRetries:          3,
+		ConsecutiveFailures: 2, // Already at 2, one more → auto-disable.
+	}
+
+	s.recordFailure(context.Background(), sched)
+
+	if sched.ConsecutiveFailures != 3 {
+		t.Errorf("expected 3 consecutive failures, got %d", sched.ConsecutiveFailures)
+	}
+	if sched.Enabled {
+		t.Error("expected schedule to be auto-disabled at max retries")
+	}
+
+	// Check that enabled=false was written to the bead.
+	mock.mu.Lock()
+	defer mock.mu.Unlock()
+	found := false
+	for _, call := range mock.updateCalls {
+		if call.id == "sched-1" && call.fields["enabled"] == "false" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected UpdateBeadFields to set enabled=false")
+	}
+}
+
+func TestTrackLastAgentStatus_SuccessResetsFailures(t *testing.T) {
+	mock := newMockBeads()
+	mock.beads["sched-1"] = &beadsapi.BeadDetail{
+		ID: "sched-1", Type: "schedule", Status: "open",
+		Fields: map[string]string{
+			"consecutive_failures": "2",
+			"last_agent_id":        "agent-done",
+		},
+	}
+	mock.beads["agent-done"] = &beadsapi.BeadDetail{
+		ID: "agent-done", Type: "agent", Status: "closed",
+		Fields: map[string]string{"agent_state": "done"},
+	}
+	srv := httptest.NewServer(mock.handler())
+	defer srv.Close()
+
+	s := newTestScheduler(srv)
+	sched := &Schedule{
+		ID:                  "sched-1",
+		LastAgentID:         "agent-done",
+		ConsecutiveFailures: 2,
+	}
+
+	s.trackLastAgentStatus(context.Background(), sched)
+
+	if sched.ConsecutiveFailures != 0 {
+		t.Errorf("expected failures reset to 0, got %d", sched.ConsecutiveFailures)
+	}
+}
+
+func TestTrackLastAgentStatus_FailureIncrements(t *testing.T) {
+	mock := newMockBeads()
+	mock.beads["sched-1"] = &beadsapi.BeadDetail{
+		ID: "sched-1", Type: "schedule", Status: "open",
+		Fields: map[string]string{
+			"consecutive_failures": "1",
+			"last_agent_id":        "agent-fail",
+		},
+	}
+	mock.beads["agent-fail"] = &beadsapi.BeadDetail{
+		ID: "agent-fail", Type: "agent", Status: "closed",
+		Fields: map[string]string{"agent_state": "failed"},
+	}
+	srv := httptest.NewServer(mock.handler())
+	defer srv.Close()
+
+	s := newTestScheduler(srv)
+	sched := &Schedule{
+		ID:                  "sched-1",
+		LastAgentID:         "agent-fail",
+		ConsecutiveFailures: 1,
+		MaxRetries:          5,
+		Enabled:             true,
+	}
+
+	s.trackLastAgentStatus(context.Background(), sched)
+
+	if sched.ConsecutiveFailures != 2 {
+		t.Errorf("expected 2 consecutive failures, got %d", sched.ConsecutiveFailures)
+	}
+}
+
+func TestTrackLastAgentStatus_AutoDisablesAtMaxRetries(t *testing.T) {
+	mock := newMockBeads()
+	mock.beads["sched-1"] = &beadsapi.BeadDetail{
+		ID: "sched-1", Type: "schedule", Status: "open",
+		Fields: map[string]string{
+			"consecutive_failures": "2",
+			"last_agent_id":        "agent-fail",
+		},
+	}
+	mock.beads["agent-fail"] = &beadsapi.BeadDetail{
+		ID: "agent-fail", Type: "agent", Status: "closed",
+		Fields: map[string]string{"agent_state": "failed"},
+	}
+	srv := httptest.NewServer(mock.handler())
+	defer srv.Close()
+
+	s := newTestScheduler(srv)
+	sched := &Schedule{
+		ID:                  "sched-1",
+		LastAgentID:         "agent-fail",
+		ConsecutiveFailures: 2,
+		MaxRetries:          3,
+		Enabled:             true,
+	}
+
+	s.trackLastAgentStatus(context.Background(), sched)
+
+	if sched.ConsecutiveFailures != 3 {
+		t.Errorf("expected 3 failures, got %d", sched.ConsecutiveFailures)
+	}
+	if sched.Enabled {
+		t.Error("expected schedule to be auto-disabled")
+	}
+}
+
+func TestTrackLastAgentStatus_SkipsAlreadyCheckedAgent(t *testing.T) {
+	mock := newMockBeads()
+	mock.beads["sched-1"] = &beadsapi.BeadDetail{
+		ID: "sched-1", Type: "schedule", Status: "open",
+		Fields: map[string]string{
+			"last_agent_id":        "agent-1",
+			"last_checked_agent":   "agent-1", // Already checked.
+			"consecutive_failures": "1",
+		},
+	}
+	mock.beads["agent-1"] = &beadsapi.BeadDetail{
+		ID: "agent-1", Type: "agent", Status: "closed",
+		Fields: map[string]string{"agent_state": "failed"},
+	}
+	srv := httptest.NewServer(mock.handler())
+	defer srv.Close()
+
+	s := newTestScheduler(srv)
+	sched := &Schedule{
+		ID:                  "sched-1",
+		LastAgentID:         "agent-1",
+		ConsecutiveFailures: 1,
+		MaxRetries:          5,
+	}
+
+	s.trackLastAgentStatus(context.Background(), sched)
+
+	// Should not have changed because this agent was already checked.
+	if sched.ConsecutiveFailures != 1 {
+		t.Errorf("expected failures unchanged at 1, got %d", sched.ConsecutiveFailures)
+	}
+}
+
+func TestTrackLastAgentStatus_SkipsNonClosedAgent(t *testing.T) {
+	mock := newMockBeads()
+	mock.beads["sched-1"] = &beadsapi.BeadDetail{
+		ID: "sched-1", Type: "schedule", Status: "open",
+		Fields: map[string]string{"last_agent_id": "agent-running"},
+	}
+	mock.beads["agent-running"] = &beadsapi.BeadDetail{
+		ID: "agent-running", Type: "agent", Status: "in_progress",
+		Fields: map[string]string{"agent_state": "working"},
+	}
+	srv := httptest.NewServer(mock.handler())
+	defer srv.Close()
+
+	s := newTestScheduler(srv)
+	sched := &Schedule{
+		ID:                  "sched-1",
+		LastAgentID:         "agent-running",
+		ConsecutiveFailures: 0,
+	}
+
+	s.trackLastAgentStatus(context.Background(), sched)
+
+	// Should not have changed — agent still running.
+	if sched.ConsecutiveFailures != 0 {
+		t.Errorf("expected failures unchanged at 0, got %d", sched.ConsecutiveFailures)
+	}
+}
+
+func TestEnforceTimeouts_KillsTimedOutAgent(t *testing.T) {
+	mock := newMockBeads()
+	mock.beads["agent-slow"] = &beadsapi.BeadDetail{
+		ID: "agent-slow", Type: "agent", Status: "open",
+		Fields: map[string]string{"agent_state": "working"},
+	}
+	mock.beads["sched-1"] = &beadsapi.BeadDetail{
+		ID: "sched-1", Type: "schedule", Status: "open",
+		Fields: map[string]string{"consecutive_failures": "0"},
+	}
+	srv := httptest.NewServer(mock.handler())
+	defer srv.Close()
+
+	s := newTestScheduler(srv)
+	now := time.Now()
+	schedules := []Schedule{
+		{
+			ID:                  "sched-1",
+			LastAgentID:         "agent-slow",
+			LastRun:             now.Add(-45 * time.Minute),
+			Timeout:             30 * time.Minute,
+			MaxRetries:          3,
+			ConsecutiveFailures: 0,
+			Enabled:             true,
+		},
+	}
+
+	s.enforceTimeouts(context.Background(), schedules, now)
+
+	mock.mu.Lock()
+	defer mock.mu.Unlock()
+
+	// Should have closed the agent.
+	if len(mock.closeCalls) == 0 {
+		t.Fatal("expected agent to be closed")
+	}
+	if mock.closeCalls[0] != "agent-slow" {
+		t.Errorf("expected agent-slow to be closed, got %q", mock.closeCalls[0])
+	}
+
+	// Should have set agent_state=failed.
+	found := false
+	for _, call := range mock.updateCalls {
+		if call.id == "agent-slow" && call.fields["agent_state"] == "failed" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected agent_state=failed to be set on timed out agent")
+	}
+
+	// Should have recorded the failure on the schedule.
+	if schedules[0].ConsecutiveFailures != 1 {
+		t.Errorf("expected 1 failure after timeout, got %d", schedules[0].ConsecutiveFailures)
+	}
+}
+
+func TestEnforceTimeouts_SkipsAgentWithinTimeout(t *testing.T) {
+	mock := newMockBeads()
+	mock.beads["agent-ok"] = &beadsapi.BeadDetail{
+		ID: "agent-ok", Type: "agent", Status: "open",
+		Fields: map[string]string{"agent_state": "working"},
+	}
+	srv := httptest.NewServer(mock.handler())
+	defer srv.Close()
+
+	s := newTestScheduler(srv)
+	now := time.Now()
+	schedules := []Schedule{
+		{
+			ID:          "sched-1",
+			LastAgentID: "agent-ok",
+			LastRun:     now.Add(-10 * time.Minute),
+			Timeout:     30 * time.Minute,
+		},
+	}
+
+	s.enforceTimeouts(context.Background(), schedules, now)
+
+	mock.mu.Lock()
+	defer mock.mu.Unlock()
+	if len(mock.closeCalls) > 0 {
+		t.Error("agent within timeout should not be closed")
+	}
+}
+
+func TestEnforceTimeouts_SkipsAlreadyClosedAgent(t *testing.T) {
+	mock := newMockBeads()
+	mock.beads["agent-done"] = &beadsapi.BeadDetail{
+		ID: "agent-done", Type: "agent", Status: "closed",
+		Fields: map[string]string{"agent_state": "done"},
+	}
+	srv := httptest.NewServer(mock.handler())
+	defer srv.Close()
+
+	s := newTestScheduler(srv)
+	now := time.Now()
+	schedules := []Schedule{
+		{
+			ID:          "sched-1",
+			LastAgentID: "agent-done",
+			LastRun:     now.Add(-45 * time.Minute),
+			Timeout:     30 * time.Minute,
+		},
+	}
+
+	s.enforceTimeouts(context.Background(), schedules, now)
+
+	mock.mu.Lock()
+	defer mock.mu.Unlock()
+	if len(mock.closeCalls) > 0 {
+		t.Error("already-closed agent should not be closed again")
+	}
+}
+
+func TestReconcile_SkipsDisabledSchedule(t *testing.T) {
+	mock := newMockBeads()
+	mock.beads["sched-1"] = &beadsapi.BeadDetail{
+		ID: "sched-1", Type: "schedule", Status: "open",
+		Title: "Disabled Schedule",
+		Fields: map[string]string{
+			"cron":    "* * * * *",
+			"enabled": "false",
+			"prompt":  "do something",
+		},
+	}
+	srv := httptest.NewServer(mock.handler())
+	defer srv.Close()
+
+	s := newTestScheduler(srv)
+	err := s.Reconcile(context.Background())
+	if err != nil {
+		t.Fatalf("Reconcile error: %v", err)
+	}
+
+	// Should not have spawned any agents.
+	mock.mu.Lock()
+	defer mock.mu.Unlock()
+	if mock.createCalls > 0 {
+		t.Error("disabled schedule should not spawn agents")
+	}
+}
+
+func TestReconcile_SkipsConcurrencyLimitReached(t *testing.T) {
+	mock := newMockBeads()
+	mock.beads["agent-running"] = &beadsapi.BeadDetail{
+		ID: "agent-running", Type: "agent", Status: "open",
+		Fields: map[string]string{"agent_state": "working"},
+	}
+	mock.beads["sched-1"] = &beadsapi.BeadDetail{
+		ID: "sched-1", Type: "schedule", Status: "open",
+		Title: "Busy Schedule",
+		Fields: map[string]string{
+			"cron":           "* * * * *",
+			"enabled":        "true",
+			"prompt":         "do something",
+			"last_agent_id":  "agent-running",
+			"max_concurrent": "1",
+		},
+	}
+	srv := httptest.NewServer(mock.handler())
+	defer srv.Close()
+
+	s := newTestScheduler(srv)
+	err := s.Reconcile(context.Background())
+	if err != nil {
+		t.Fatalf("Reconcile error: %v", err)
+	}
+
+	// The only create calls should be 0 because the last agent is still running.
+	mock.mu.Lock()
+	defer mock.mu.Unlock()
+	if mock.createCalls > 0 {
+		t.Error("should not spawn agent when concurrency limit reached")
+	}
+}

--- a/gasboat/controller/internal/scheduler/scheduler.go
+++ b/gasboat/controller/internal/scheduler/scheduler.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"strconv"
 	"sync"
 	"time"
 
@@ -42,12 +43,28 @@ type Schedule struct {
 	Timezone    string
 	LastRun     time.Time
 	LastAgentID string
+
+	// Guard rails.
+	MaxConcurrent       int           // max concurrent agents (default 2)
+	Timeout             time.Duration // max agent run duration (default 30m)
+	RetryOnFailure      bool          // retry on next cycle if agent fails
+	MaxRetries          int           // max consecutive failures before auto-disable (default 3)
+	ConsecutiveFailures int           // current consecutive failure count
 }
+
+// Guard rail defaults.
+const (
+	defaultMaxConcurrent = 2
+	defaultTimeout       = 30 * time.Minute
+	defaultMaxRetries    = 3
+)
 
 // Reconcile performs a single evaluation pass. For each enabled schedule bead:
 //  1. Parse the cron expression
 //  2. Calculate the most recent fire time before now
-//  3. If that fire time is after last_run, spawn an agent and update last_run
+//  3. Check guard rails (concurrency, failure tracking)
+//  4. If fire time is after last_run and guard rails pass, spawn an agent
+//  5. Enforce timeouts on running scheduled agents
 func (s *Scheduler) Reconcile(ctx context.Context) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -63,7 +80,12 @@ func (s *Scheduler) Reconcile(ctx context.Context) error {
 
 	now := time.Now()
 
-	for _, sched := range schedules {
+	for i := range schedules {
+		sched := &schedules[i]
+
+		// Track last agent status for failure counting before checking enabled.
+		s.trackLastAgentStatus(ctx, sched)
+
 		if !sched.Enabled {
 			continue
 		}
@@ -101,14 +123,24 @@ func (s *Scheduler) Reconcile(ctx context.Context) error {
 			continue
 		}
 
+		// Check concurrency limit.
+		if s.isLastAgentRunning(ctx, *sched) {
+			s.logger.Warn("schedule at concurrency limit, skipping",
+				"id", sched.ID, "title", sched.Title,
+				"max_concurrent", sched.MaxConcurrent,
+				"last_agent", sched.LastAgentID)
+			continue
+		}
+
 		s.logger.Info("schedule triggered",
 			"id", sched.ID, "title", sched.Title,
 			"cron", sched.Cron, "last_fire", lastFire.Format(time.RFC3339))
 
-		agentID, err := s.spawnScheduledAgent(ctx, sched)
+		agentID, err := s.spawnScheduledAgent(ctx, *sched)
 		if err != nil {
 			s.logger.Error("failed to spawn scheduled agent",
 				"schedule", sched.ID, "error", err)
+			s.recordFailure(ctx, sched)
 			continue
 		}
 
@@ -122,7 +154,146 @@ func (s *Scheduler) Reconcile(ctx context.Context) error {
 		}
 	}
 
+	// Enforce timeouts on all running scheduled agents.
+	s.enforceTimeouts(ctx, schedules, now)
+
 	return nil
+}
+
+// trackLastAgentStatus checks the status of the last spawned agent and updates
+// the schedule's consecutive failure count. If the agent completed successfully,
+// the failure count is reset. If it failed, the count is incremented and the
+// schedule may be auto-disabled. Uses last_checked_agent on the schedule bead
+// to avoid re-processing the same agent's result on every reconcile cycle.
+func (s *Scheduler) trackLastAgentStatus(ctx context.Context, sched *Schedule) {
+	if sched.LastAgentID == "" {
+		return
+	}
+
+	detail, err := s.daemon.GetBead(ctx, sched.LastAgentID)
+	if err != nil {
+		return
+	}
+
+	// Only process closed agents (terminal state).
+	if detail.Status != "closed" {
+		return
+	}
+
+	// Skip if we already processed this agent's result.
+	lastChecked, _ := s.daemon.GetBead(ctx, sched.ID)
+	if lastChecked != nil && lastChecked.Fields["last_checked_agent"] == sched.LastAgentID {
+		return
+	}
+
+	agentState := detail.Fields["agent_state"]
+
+	// Mark this agent as checked to avoid re-processing.
+	updateFields := map[string]string{
+		"last_checked_agent": sched.LastAgentID,
+	}
+
+	if agentState == "failed" {
+		sched.ConsecutiveFailures++
+		updateFields["consecutive_failures"] = fmt.Sprintf("%d", sched.ConsecutiveFailures)
+		if sched.ConsecutiveFailures >= sched.MaxRetries {
+			sched.Enabled = false
+			updateFields["enabled"] = "false"
+			s.logger.Warn("schedule auto-disabled after max consecutive failures",
+				"id", sched.ID, "title", sched.Title,
+				"consecutive_failures", sched.ConsecutiveFailures,
+				"max_retries", sched.MaxRetries)
+		}
+	} else if agentState == "done" {
+		if sched.ConsecutiveFailures > 0 {
+			sched.ConsecutiveFailures = 0
+			updateFields["consecutive_failures"] = "0"
+		}
+	}
+
+	_ = s.daemon.UpdateBeadFields(ctx, sched.ID, updateFields)
+}
+
+// recordFailure increments the consecutive failure count and auto-disables
+// the schedule if max_retries is reached. Used for spawn failures and
+// timeout kills (agent completion failures are tracked in trackLastAgentStatus).
+func (s *Scheduler) recordFailure(ctx context.Context, sched *Schedule) {
+	sched.ConsecutiveFailures++
+	fields := map[string]string{
+		"consecutive_failures": fmt.Sprintf("%d", sched.ConsecutiveFailures),
+	}
+
+	if sched.ConsecutiveFailures >= sched.MaxRetries {
+		sched.Enabled = false
+		fields["enabled"] = "false"
+		s.logger.Warn("schedule auto-disabled after max consecutive failures",
+			"id", sched.ID, "title", sched.Title,
+			"consecutive_failures", sched.ConsecutiveFailures,
+			"max_retries", sched.MaxRetries)
+	}
+
+	if err := s.daemon.UpdateBeadFields(ctx, sched.ID, fields); err != nil {
+		s.logger.Warn("failed to update consecutive_failures",
+			"schedule", sched.ID, "error", err)
+	}
+}
+
+// isLastAgentRunning checks if the last spawned agent for this schedule is
+// still active (not closed). Returns true if the schedule is at its
+// concurrency limit.
+func (s *Scheduler) isLastAgentRunning(ctx context.Context, sched Schedule) bool {
+	if sched.LastAgentID == "" {
+		return false
+	}
+
+	detail, err := s.daemon.GetBead(ctx, sched.LastAgentID)
+	if err != nil {
+		// Can't determine status — allow the spawn.
+		return false
+	}
+
+	// If the last agent's bead is still open/in_progress, it's running.
+	return detail.Status != "closed"
+}
+
+// enforceTimeouts checks all schedules for running agents that have exceeded
+// their timeout duration. Timed-out agents are closed with agent_state=failed.
+func (s *Scheduler) enforceTimeouts(ctx context.Context, schedules []Schedule, now time.Time) {
+	for i := range schedules {
+		sched := &schedules[i]
+		if sched.LastAgentID == "" || sched.LastRun.IsZero() || sched.Timeout <= 0 {
+			continue
+		}
+
+		// Check if the agent has exceeded the timeout.
+		elapsed := now.Sub(sched.LastRun)
+		if elapsed <= sched.Timeout {
+			continue
+		}
+
+		// Verify the agent is still running before killing it.
+		detail, err := s.daemon.GetBead(ctx, sched.LastAgentID)
+		if err != nil || detail.Status == "closed" {
+			continue
+		}
+
+		s.logger.Warn("schedule agent timed out, killing",
+			"schedule", sched.ID, "title", sched.Title,
+			"agent", sched.LastAgentID,
+			"elapsed", elapsed.String(), "timeout", sched.Timeout.String())
+
+		// Mark agent as failed and close.
+		_ = s.daemon.UpdateBeadFields(ctx, sched.LastAgentID, map[string]string{
+			"agent_state":  "failed",
+			"close_reason": fmt.Sprintf("timeout after %s (limit: %s)", elapsed.Truncate(time.Second), sched.Timeout),
+		})
+		_ = s.daemon.CloseBead(ctx, sched.LastAgentID, map[string]string{
+			"agent_state": "failed",
+		})
+
+		// Record the timeout as a failure.
+		s.recordFailure(ctx, sched)
+	}
 }
 
 // RunLoop runs the scheduler periodically until the context is cancelled.
@@ -177,16 +348,21 @@ func (s *Scheduler) listSchedules(ctx context.Context) ([]Schedule, error) {
 			}
 		}
 		schedules = append(schedules, Schedule{
-			ID:          b.ID,
-			Title:       b.Title,
-			Cron:        b.Fields["cron"],
-			Project:     b.Fields["project"],
-			Role:        b.Fields["role"],
-			Prompt:      b.Fields["prompt"],
-			Enabled:     enabled,
-			Timezone:    b.Fields["timezone"],
-			LastRun:     lastRun,
-			LastAgentID: b.Fields["last_agent_id"],
+			ID:                  b.ID,
+			Title:               b.Title,
+			Cron:                b.Fields["cron"],
+			Project:             b.Fields["project"],
+			Role:                b.Fields["role"],
+			Prompt:              b.Fields["prompt"],
+			Enabled:             enabled,
+			Timezone:            b.Fields["timezone"],
+			LastRun:             lastRun,
+			LastAgentID:         b.Fields["last_agent_id"],
+			MaxConcurrent:       parseIntField(b.Fields["max_concurrent"], defaultMaxConcurrent),
+			Timeout:             parseDurationField(b.Fields["timeout"], defaultTimeout),
+			RetryOnFailure:      b.Fields["retry_on_failure"] == "true",
+			MaxRetries:          parseIntField(b.Fields["max_retries"], defaultMaxRetries),
+			ConsecutiveFailures: parseIntField(b.Fields["consecutive_failures"], 0),
 		})
 	}
 	return schedules, nil
@@ -243,4 +419,36 @@ func (s *Scheduler) spawnScheduledAgent(ctx context.Context, sched Schedule) (st
 		"project", project, "role", role)
 
 	return beadID, nil
+}
+
+// parseIntField parses a string as an integer, returning defVal if empty or invalid.
+func parseIntField(s string, defVal int) int {
+	if s == "" {
+		return defVal
+	}
+	v, err := strconv.Atoi(s)
+	if err != nil || v < 0 {
+		return defVal
+	}
+	return v
+}
+
+// parseDurationField parses a string as a duration, returning defVal if empty or invalid.
+// Supports Go duration strings (e.g., "30m", "1h", "45s") and plain integers as minutes.
+func parseDurationField(s string, defVal time.Duration) time.Duration {
+	if s == "" {
+		return defVal
+	}
+	d, err := time.ParseDuration(s)
+	if err != nil {
+		// Try as plain minutes.
+		if mins, err := strconv.Atoi(s); err == nil && mins > 0 {
+			return time.Duration(mins) * time.Minute
+		}
+		return defVal
+	}
+	if d <= 0 {
+		return defVal
+	}
+	return d
 }


### PR DESCRIPTION
## Summary
- Add concurrency limits, timeout enforcement, and retry policy for scheduled agents
- Track consecutive failures and auto-disable schedules after max retries (default 3)
- Kill agents that exceed their schedule timeout (default 30m) and record as failure
- Skip spawning when last agent is still running (concurrency check)
- 18 new tests covering all guard rail behaviors (helpers, failure tracking, timeout enforcement, reconcile integration)

## Test plan
- [x] `go test ./internal/scheduler/` — all 22 tests pass (4 existing + 18 new)
- [x] `go test ./...` — full controller test suite passes
- [x] `go build ./...` — compiles clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)