### PR TITLE
fix(gasboat/agent): replace 30m standby TTL with 24h safety net

### DIFF
--- a/gasboat/images/agent/entrypoint.sh
+++ b/gasboat/images/agent/entrypoint.sh
@@ -513,12 +513,12 @@ standby_wait_for_assignment() {
 
     echo "[entrypoint] Standby mode: Claude is idle, waiting for assignment (bead: ${BOAT_AGENT_BEAD_ID})"
     local poll_interval="${BOAT_STANDBY_POLL:-5}"
-    local max_wait="${BOAT_STANDBY_TTL:-1800}"
+    local max_wait="${BOAT_STANDBY_MAX_TTL:-86400}"
     local elapsed=0
 
     while true; do
         if [ "${elapsed}" -ge "${max_wait}" ]; then
-            echo "[entrypoint] Standby TTL (${max_wait}s) exceeded, shutting down"
+            echo "[entrypoint] Standby safety-net TTL (${max_wait}s) exceeded, shutting down"
             rm -f /tmp/standby_active
             touch /tmp/standby_expired
             curl -sf -X POST http://localhost:8080/api/v1/shutdown 2>/dev/null || true


### PR DESCRIPTION
## Summary
- Replaces `BOAT_STANDBY_TTL` (default 1800s/30m) with `BOAT_STANDBY_MAX_TTL` (default 86400s/24h)
- Eliminates ~48 unnecessary pod create/delete cycles per day per prewarmed agent
- Pool manager already handles lifecycle via reconciliation; TTL is now purely a zombie-pod safety net

## Test plan
- [ ] Deploy prewarmed agent pool and verify pods stay alive beyond 30 minutes
- [ ] Verify pool manager downsizing still terminates prewarmed agents correctly
- [ ] Verify safety-net TTL triggers after 24h (or set `BOAT_STANDBY_MAX_TTL=60` to test quickly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)