### PR TITLE
feat(gasboat/controller): add claude_config field to project beads

### DIFF
--- a/gasboat/controller/cmd/gb/config_resolve.go
+++ b/gasboat/controller/cmd/gb/config_resolve.go
@@ -48,7 +48,7 @@ func buildRoleIndex(subscriptions []string) map[string]int {
 	return idx
 }
 
-func ResolveConfigBeads(ctx context.Context, lister configBeadLister, category string, subscriptions []string) (map[string]any, int) {
+func ResolveConfigBeads(ctx context.Context, lister configBeadLister, category string, subscriptions []string, extraLayers ...resolvedConfig) (map[string]any, int) {
 	cat := LookupCategory(category)
 	if cat == nil {
 		return nil, 0
@@ -105,11 +105,14 @@ func ResolveConfigBeads(ctx context.Context, lister configBeadLister, category s
 		})
 	}
 
+	// Append any extra layers (e.g. project bead inline claude_config).
+	matched = append(matched, extraLayers...)
+
 	if len(matched) == 0 {
 		return nil, 0
 	}
 
-	// Sort by specificity: global (0:) < project (1:) < role (2:) < agent (3:).
+	// Sort by specificity: global (0:) < project (1:) < role (2:) < project-inline (2~:) < agent (3:).
 	sort.Slice(matched, func(i, j int) bool {
 		return matched[i].specificity < matched[j].specificity
 	})

--- a/gasboat/controller/cmd/gb/config_resolve_test.go
+++ b/gasboat/controller/cmd/gb/config_resolve_test.go
@@ -292,3 +292,89 @@ func TestResolveConfigBeads_SpecificityOrder(t *testing.T) {
 	}
 }
 
+func TestResolveConfigBeads_ProjectInlineOverridesRole(t *testing.T) {
+	// Project bead inline config (extra layer at "2~:" specificity) should
+	// override role config beads but be overridden by agent config beads.
+	lister := &mockConfigBeadLister{
+		beads: []*beadsapi.BeadDetail{
+			{
+				Title:       "claude-settings",
+				Labels:      []string{"global"},
+				Description: `{"model":"sonnet","base":"yes"}`,
+			},
+			{
+				Title:       "claude-settings",
+				Labels:      []string{"role:crew"},
+				Description: `{"model":"haiku","role_key":"yes"}`,
+			},
+		},
+	}
+
+	// Inject project inline config as an extra layer.
+	extras := []resolvedConfig{{
+		value:       []byte(`{"model":"opus","project_inline":"yes"}`),
+		specificity: projectInlineSpecificity,
+	}}
+
+	subs := []string{"global", "role:crew"}
+	merged, count := ResolveConfigBeads(context.Background(), lister, "claude-settings", subs, extras...)
+
+	if count != 3 {
+		t.Fatalf("expected 3 layers (global + role + inline), got %d", count)
+	}
+	// Project inline should override role for "model".
+	if merged["model"] != "opus" {
+		t.Errorf("expected model=opus (project inline wins over role), got %v", merged["model"])
+	}
+	// Role key should survive.
+	if merged["role_key"] != "yes" {
+		t.Error("expected role_key=yes from role layer")
+	}
+	// Project inline key should be present.
+	if merged["project_inline"] != "yes" {
+		t.Error("expected project_inline=yes from inline layer")
+	}
+	// Global base should survive.
+	if merged["base"] != "yes" {
+		t.Error("expected base=yes from global layer")
+	}
+}
+
+func TestResolveConfigBeads_AgentOverridesProjectInline(t *testing.T) {
+	// Agent-level config beads (3:) should override project inline (2~:).
+	lister := &mockConfigBeadLister{
+		beads: []*beadsapi.BeadDetail{
+			{
+				Title:       "claude-settings",
+				Labels:      []string{"global"},
+				Description: `{"model":"sonnet"}`,
+			},
+			{
+				Title:       "claude-settings",
+				Labels:      []string{"agent:kd-test-agent"},
+				Description: `{"model":"opus"}`,
+			},
+		},
+	}
+
+	extras := []resolvedConfig{{
+		value:       []byte(`{"model":"haiku","inline_key":"yes"}`),
+		specificity: projectInlineSpecificity,
+	}}
+
+	subs := []string{"global", "agent:kd-test-agent"}
+	merged, count := ResolveConfigBeads(context.Background(), lister, "claude-settings", subs, extras...)
+
+	if count != 3 {
+		t.Fatalf("expected 3 layers, got %d", count)
+	}
+	// Agent should win for "model".
+	if merged["model"] != "opus" {
+		t.Errorf("expected model=opus (agent wins over project inline), got %v", merged["model"])
+	}
+	// Project inline key should survive.
+	if merged["inline_key"] != "yes" {
+		t.Error("expected inline_key=yes from project inline layer")
+	}
+}
+

--- a/gasboat/controller/cmd/gb/setup.go
+++ b/gasboat/controller/cmd/gb/setup.go
@@ -294,8 +294,13 @@ func runSetupClaudeRemove(workspace string) error {
 func runSetupClaude(ctx context.Context, workspace, role string) error {
 	subs := buildSubscriptions(role)
 
+	// ── Project-level inline config overrides ────────────────────────────
+	// If the project bead has a claude_config field, inject those values
+	// as extra layers between role (2:) and agent (3:) specificity.
+	projectExtras := fetchProjectClaudeConfig(ctx)
+
 	// ── User-level settings (claude-settings) ───────────────────────────
-	settings, _ := ResolveConfigBeads(ctx, daemon, "claude-settings", subs)
+	settings, _ := ResolveConfigBeads(ctx, daemon, "claude-settings", subs, projectExtras["claude-settings"]...)
 	if settings != nil {
 		if err := writeUserSettings(settings); err != nil {
 			fmt.Fprintf(os.Stderr, "[setup] warning: failed to write user settings: %v\n", err)
@@ -307,7 +312,7 @@ func runSetupClaude(ctx context.Context, workspace, role string) error {
 	}
 
 	// ── Project-level MCP config (claude-mcp) ───────────────────────────
-	mcpConfig, _ := ResolveConfigBeads(ctx, daemon, "claude-mcp", subs)
+	mcpConfig, _ := ResolveConfigBeads(ctx, daemon, "claude-mcp", subs, projectExtras["claude-mcp"]...)
 	if mcpConfig == nil {
 		mcpConfig = defaultMCPConfig()
 	}
@@ -318,7 +323,7 @@ func runSetupClaude(ctx context.Context, workspace, role string) error {
 	}
 
 	// ── Workspace-level hooks (claude-hooks) ────────────────────────────
-	hooks, _ := ResolveConfigBeads(ctx, daemon, "claude-hooks", subs)
+	hooks, _ := ResolveConfigBeads(ctx, daemon, "claude-hooks", subs, projectExtras["claude-hooks"]...)
 	if hooks == nil {
 		return fmt.Errorf("no claude-hooks config found")
 	}
@@ -345,7 +350,7 @@ func runSetupClaude(ctx context.Context, workspace, role string) error {
 	fmt.Fprintf(os.Stderr, "[setup] wrote %s\n", outPath)
 
 	// ── Agent instructions (claude-instructions) ────────────────────────
-	instructions, _ := ResolveConfigBeads(ctx, daemon, "claude-instructions", subs)
+	instructions, _ := ResolveConfigBeads(ctx, daemon, "claude-instructions", subs, projectExtras["claude-instructions"]...)
 	if instructions != nil {
 		writeInstructionFiles(workspace, instructions)
 	}
@@ -354,4 +359,41 @@ func runSetupClaude(ctx context.Context, workspace, role string) error {
 	symlinkClaudeExtensions(workspace)
 
 	return nil
+}
+
+// projectInlineSpecificity is the sort key for project bead inline config.
+// Sorts after role-level (2:) and before agent-level (3:), since '~' > ':'.
+const projectInlineSpecificity = "2~:project-inline"
+
+// fetchProjectClaudeConfig returns per-category extra layers from the
+// current project bead's claude_config field. Returns an empty map (safe
+// to index) when no project is set or the field is absent.
+func fetchProjectClaudeConfig(ctx context.Context) map[string][]resolvedConfig {
+	result := make(map[string][]resolvedConfig)
+
+	project := os.Getenv("BOAT_PROJECT")
+	if project == "" {
+		return result
+	}
+
+	projects, err := daemon.ListProjectBeads(ctx)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[setup] warning: failed to list projects for claude_config: %v\n", err)
+		return result
+	}
+
+	info, ok := projects[project]
+	if !ok || info.ClaudeConfig == nil {
+		return result
+	}
+
+	for category, raw := range info.ClaudeConfig {
+		result[category] = []resolvedConfig{{
+			value:       raw,
+			specificity: projectInlineSpecificity,
+		}}
+	}
+
+	fmt.Fprintf(os.Stderr, "[setup] loaded %d claude_config categories from project bead %q\n", len(result), project)
+	return result
 }

--- a/gasboat/controller/internal/beadsapi/projects.go
+++ b/gasboat/controller/internal/beadsapi/projects.go
@@ -61,6 +61,13 @@ type ProjectInfo struct {
 	EnvVars        []EnvEntry          // Per-project plain env vars
 	Repos          []RepoEntry         // Multi-repo definitions
 	PrewarmedPool  *PrewarmedPoolConfig // Per-project prewarmed agent pool config (nil = disabled)
+
+	// ClaudeConfig holds per-category Claude config overrides stored inline
+	// on the project bead (field: "claude_config"). Each key is a config
+	// category name (e.g. "claude-settings", "claude-hooks") and the value
+	// is the raw JSON config for that category. Used by gb setup claude to
+	// inject project-level overrides between role and agent specificity.
+	ClaudeConfig map[string]json.RawMessage
 }
 
 // PrewarmedPoolConfig holds per-project prewarmed agent pool settings.
@@ -141,6 +148,13 @@ func (c *Client) ListProjectBeads(ctx context.Context) (map[string]ProjectInfo, 
 					poolCfg.Mode = "crew"
 				}
 				info.PrewarmedPool = &poolCfg
+			}
+		}
+		// Parse inline Claude config overrides from JSON field.
+		if raw := fields["claude_config"]; raw != "" {
+			var cfg map[string]json.RawMessage
+			if json.Unmarshal([]byte(raw), &cfg) == nil {
+				info.ClaudeConfig = cfg
 			}
 		}
 		// Parse env_json field.


### PR DESCRIPTION
## Summary
- Adds `ClaudeConfig` field to `ProjectInfo` struct, parsed from `claude_config` JSON field on project beads
- Extends `ResolveConfigBeads()` with variadic `extraLayers` parameter for injecting additional config layers
- In `runSetupClaude()`, fetches current project's `claude_config` and injects per-category overrides at `2~:` specificity (between role and agent)
- Backward compatible — existing config beads and callers without extras work unchanged

Usage: `kd update <project-id> -f 'claude_config={"claude-settings":{"model":"opus"},"claude-mcp":{...}}'`

## Test plan
- [x] New test: project inline overrides role config (specificity `2~:` > `2:`)
- [x] New test: agent config overrides project inline (specificity `3:` > `2~:`)
- [x] All existing config resolution tests pass (12/12)
- [x] Full controller test suite passes
- [ ] Manual: set `claude_config` on a project bead and verify `gb setup claude` picks it up

🤖 Generated with [Claude Code](https://claude.com/claude-code)