### PR TITLE
feat(gasboat/bridge): add @gasboat kill mention for in-thread agent shutdown

### DIFF
--- a/gasboat/controller/internal/bridge/bot_mentions.go
+++ b/gasboat/controller/internal/bridge/bot_mentions.go
@@ -49,6 +49,9 @@ func (b *Bot) handleAppMention(ctx context.Context, ev *slackevents.AppMentionEv
 		case "kill":
 			b.handleMentionKill(ctx, ev, strings.Contains(cmdArgs, "--force"))
 			return
+		case "clear":
+			b.handleMentionClear(ctx, ev)
+			return
 		}
 	}
 
@@ -721,7 +724,7 @@ func parseMentionCommand(text string) (string, string) {
 	}
 	keyword := strings.ToLower(words[0])
 	switch keyword {
-	case "kill":
+	case "kill", "clear":
 		remaining := strings.TrimSpace(strings.Join(words[1:], " "))
 		return keyword, remaining
 	}
@@ -770,6 +773,44 @@ func (b *Bot) handleMentionKill(ctx context.Context, ev *slackevents.AppMentionE
 				slack.MsgOptionTS(threadTS))
 		}
 	}()
+}
+
+// handleMentionClear resets the thread→agent mapping when "@gasboat clear" is
+// posted in a thread. The agent is NOT killed — it continues running but is
+// unbound from the thread. A subsequent @mention in the same thread will spawn
+// a new agent. This is useful when a thread agent is stuck or the user wants
+// a fresh agent in the same thread.
+func (b *Bot) handleMentionClear(ctx context.Context, ev *slackevents.AppMentionEvent) {
+	channel := ev.Channel
+	threadTS := ev.ThreadTimeStamp
+	userID := ev.User
+
+	agent := b.getAgentByThread(channel, threadTS)
+	if agent == "" {
+		if b.api != nil {
+			_, _ = b.api.PostEphemeral(channel, userID,
+				slack.MsgOptionText(":x: No agent is bound to this thread.", false))
+		}
+		return
+	}
+	agent = extractAgentName(agent)
+
+	// Remove thread→agent mapping.
+	if b.state != nil {
+		_ = b.state.RemoveThreadAgent(channel, threadTS)
+		_ = b.state.RemoveListenThread(channel, threadTS)
+	}
+
+	b.logger.Info("cleared thread agent mapping via mention",
+		"agent", agent, "channel", channel, "thread_ts", threadTS, "user", userID)
+
+	if b.api != nil {
+		_, _, _ = b.api.PostMessage(channel,
+			slack.MsgOptionText(
+				fmt.Sprintf(":broom: Cleared thread binding for *%s*. Mention me again to spawn a new agent here.", agent),
+				false),
+			slack.MsgOptionTS(threadTS))
+	}
 }
 
 // stripBotMention removes all <@BOTID> occurrences from text and trims whitespace.

--- a/gasboat/controller/internal/bridge/bot_mentions_test.go
+++ b/gasboat/controller/internal/bridge/bot_mentions_test.go
@@ -881,6 +881,137 @@ func TestHandleMentionKill_NoAgentInThread(t *testing.T) {
 	}
 }
 
+// --- parseMentionCommand clear tests ---
+
+func TestParseMentionCommand_Clear(t *testing.T) {
+	cmd, remaining := parseMentionCommand("clear")
+	if cmd != "clear" {
+		t.Errorf("expected cmd=clear, got %q", cmd)
+	}
+	if remaining != "" {
+		t.Errorf("expected empty remaining, got %q", remaining)
+	}
+}
+
+func TestParseMentionCommand_ClearCaseInsensitive(t *testing.T) {
+	cmd, _ := parseMentionCommand("CLEAR")
+	if cmd != "clear" {
+		t.Errorf("expected cmd=clear, got %q", cmd)
+	}
+}
+
+// --- handleMentionClear tests ---
+
+func TestHandleMentionClear_ClearsThreadMapping(t *testing.T) {
+	daemon := newMockDaemon()
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+
+	bot := newTestBot(daemon, slackSrv)
+
+	tmpDir := t.TempDir()
+	sm, err := NewStateManager(filepath.Join(tmpDir, "state.json"))
+	if err != nil {
+		t.Fatalf("failed to create state manager: %v", err)
+	}
+	bot.state = sm
+
+	// Bind agent to thread with listen mode.
+	_ = sm.SetThreadAgent("C123", "1111.2222", "thread-1111-2222")
+	_ = sm.SetListenThread("C123", "1111.2222")
+
+	ev := &slackevents.AppMentionEvent{
+		Channel:         "C123",
+		ThreadTimeStamp: "1111.2222",
+		User:            "U456",
+	}
+
+	bot.handleMentionClear(context.Background(), ev)
+
+	// Thread mapping should be cleared.
+	if _, ok := sm.GetThreadAgent("C123", "1111.2222"); ok {
+		t.Error("expected thread agent mapping to be removed after clear")
+	}
+
+	// Listen mode should also be cleared.
+	if sm.IsListenThread("C123", "1111.2222") {
+		t.Error("expected listen thread to be removed after clear")
+	}
+}
+
+func TestHandleMentionClear_NoAgentInThread(t *testing.T) {
+	daemon := newMockDaemon()
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+
+	bot := newTestBot(daemon, slackSrv)
+
+	tmpDir := t.TempDir()
+	sm, err := NewStateManager(filepath.Join(tmpDir, "state.json"))
+	if err != nil {
+		t.Fatalf("failed to create state manager: %v", err)
+	}
+	bot.state = sm
+
+	ev := &slackevents.AppMentionEvent{
+		Channel:         "C123",
+		ThreadTimeStamp: "1111.2222",
+		User:            "U456",
+	}
+
+	// Should not panic when no agent is bound.
+	bot.handleMentionClear(context.Background(), ev)
+}
+
+func TestHandleMentionClear_AgentNotKilled(t *testing.T) {
+	daemon := newMockDaemon()
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+
+	bot := newTestBot(daemon, slackSrv)
+
+	tmpDir := t.TempDir()
+	sm, err := NewStateManager(filepath.Join(tmpDir, "state.json"))
+	if err != nil {
+		t.Fatalf("failed to create state manager: %v", err)
+	}
+	bot.state = sm
+
+	// Bind agent to thread.
+	_ = sm.SetThreadAgent("C123", "1111.2222", "thread-1111-2222")
+
+	// Seed agent bead.
+	daemon.mu.Lock()
+	daemon.beads["thread-1111-2222"] = &beadsapi.BeadDetail{
+		ID:     "bd-thread-agent",
+		Title:  "thread-1111-2222",
+		Type:   "agent",
+		Fields: map[string]string{"agent": "thread-1111-2222"},
+	}
+	daemon.mu.Unlock()
+
+	ev := &slackevents.AppMentionEvent{
+		Channel:         "C123",
+		ThreadTimeStamp: "1111.2222",
+		User:            "U456",
+	}
+
+	bot.handleMentionClear(context.Background(), ev)
+
+	// Thread mapping should be cleared.
+	if _, ok := sm.GetThreadAgent("C123", "1111.2222"); ok {
+		t.Error("expected thread agent mapping to be removed after clear")
+	}
+
+	// Agent bead should NOT be closed — clear only unbinds, doesn't kill.
+	daemon.mu.Lock()
+	closedCount := len(daemon.closed)
+	daemon.mu.Unlock()
+	if closedCount != 0 {
+		t.Errorf("expected 0 close calls (clear should not kill), got %d", closedCount)
+	}
+}
+
 func TestSanitizeTS(t *testing.T) {
 	tests := []struct {
 		input string


### PR DESCRIPTION
## Summary
- Adds `parseMentionCommand()` to detect command keywords (kill) at the start of mention text
- Adds `handleMentionKill()` for name-free thread agent shutdown: `@gasboat kill` in a thread kills the bound agent
- Supports `@gasboat kill --force` for immediate (non-graceful) shutdown
- Early routing in `handleAppMention()` intercepts commands before normal mention flow

## Test plan
- [x] `parseMentionCommand` unit tests (5 cases: kill, kill+args, case-insensitive, non-command, empty)
- [x] `handleMentionKill` integration tests (kills thread agent + clears mapping, no-agent-in-thread safety)
- [x] Full bridge test suite passes (22s)
- [ ] Manual: mention `@gasboat kill` in a thread with a running agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)