### PR TITLE
fix(gasboat/bridge): clean up listen flags on kill and add nil guards

### DIFF
--- a/gasboat/controller/internal/bridge/bot_agent_kill.go
+++ b/gasboat/controller/internal/bridge/bot_agent_kill.go
@@ -282,19 +282,25 @@ func (b *Bot) handleKillThreadAgent(ctx context.Context, agentName string, callb
 	userID := callback.User.ID
 
 	// Acknowledge immediately — kill can take 30s+.
-	_, _ = b.api.PostEphemeral(channelID, userID,
-		slack.MsgOptionText(fmt.Sprintf(":hourglass_flowing_sand: Killing thread agent *%s*…", agentName), false))
+	if b.api != nil {
+		_, _ = b.api.PostEphemeral(channelID, userID,
+			slack.MsgOptionText(fmt.Sprintf(":hourglass_flowing_sand: Killing thread agent *%s*…", agentName), false))
+	}
 
 	go func() {
 		if err := b.killAgent(context.Background(), agentName, false); err != nil {
 			b.logger.Error("kill-thread-agent button: failed", "agent", agentName, "error", err)
-			_, _ = b.api.PostEphemeral(channelID, userID,
-				slack.MsgOptionText(fmt.Sprintf(":x: Failed to kill thread agent %q: %s", agentName, err.Error()), false))
+			if b.api != nil {
+				_, _ = b.api.PostEphemeral(channelID, userID,
+					slack.MsgOptionText(fmt.Sprintf(":x: Failed to kill thread agent %q: %s", agentName, err.Error()), false))
+			}
 			return
 		}
 		b.logger.Info("killed thread agent via button", "agent", agentName, "user", userID)
-		_, _ = b.api.PostEphemeral(channelID, userID,
-			slack.MsgOptionText(fmt.Sprintf(":skull: Thread agent *%s* terminated.", agentName), false))
+		if b.api != nil {
+			_, _ = b.api.PostEphemeral(channelID, userID,
+				slack.MsgOptionText(fmt.Sprintf(":skull: Thread agent *%s* terminated.", agentName), false))
+		}
 	}()
 }
 
@@ -308,13 +314,17 @@ func (b *Bot) handleRestartThreadAgent(ctx context.Context, agentName string, ca
 	userID := callback.User.ID
 
 	if threadTS == "" {
-		_, _ = b.api.PostEphemeral(channelID, userID,
-			slack.MsgOptionText(":x: Restart is only available in threads.", false))
+		if b.api != nil {
+			_, _ = b.api.PostEphemeral(channelID, userID,
+				slack.MsgOptionText(":x: Restart is only available in threads.", false))
+		}
 		return
 	}
 
-	_, _ = b.api.PostEphemeral(channelID, userID,
-		slack.MsgOptionText(fmt.Sprintf(":arrows_counterclockwise: Restarting thread agent *%s*…", agentName), false))
+	if b.api != nil {
+		_, _ = b.api.PostEphemeral(channelID, userID,
+			slack.MsgOptionText(fmt.Sprintf(":arrows_counterclockwise: Restarting thread agent *%s*…", agentName), false))
+	}
 
 	go func() {
 		bgCtx := context.Background()
@@ -323,8 +333,10 @@ func (b *Bot) handleRestartThreadAgent(ctx context.Context, agentName string, ca
 		bead, err := b.daemon.FindAgentBead(bgCtx, agentName)
 		if err != nil {
 			b.logger.Error("restart-thread-agent: agent bead not found", "agent", agentName, "error", err)
-			_, _ = b.api.PostEphemeral(channelID, userID,
-				slack.MsgOptionText(fmt.Sprintf(":x: Agent %q not found: %s", agentName, err), false))
+			if b.api != nil {
+				_, _ = b.api.PostEphemeral(channelID, userID,
+					slack.MsgOptionText(fmt.Sprintf(":x: Agent %q not found: %s", agentName, err), false))
+			}
 			return
 		}
 		project := bead.Fields["project"]
@@ -332,8 +344,10 @@ func (b *Bot) handleRestartThreadAgent(ctx context.Context, agentName string, ca
 		// Kill the agent (graceful shutdown + close bead + clean up state).
 		if err := b.killAgent(bgCtx, agentName, false); err != nil {
 			b.logger.Error("restart-thread-agent: kill failed", "agent", agentName, "error", err)
-			_, _ = b.api.PostEphemeral(channelID, userID,
-				slack.MsgOptionText(fmt.Sprintf(":x: Failed to kill agent %q: %s", agentName, err), false))
+			if b.api != nil {
+				_, _ = b.api.PostEphemeral(channelID, userID,
+					slack.MsgOptionText(fmt.Sprintf(":x: Failed to kill agent %q: %s", agentName, err), false))
+			}
 			return
 		}
 
@@ -368,8 +382,10 @@ func (b *Bot) handleRestartThreadAgent(ctx context.Context, agentName string, ca
 		})
 		if err != nil {
 			b.logger.Error("restart-thread-agent: failed to create new bead", "agent", agentName, "error", err)
-			_, _ = b.api.PostEphemeral(channelID, userID,
-				slack.MsgOptionText(fmt.Sprintf(":x: Killed agent but failed to re-spawn: %s", err), false))
+			if b.api != nil {
+				_, _ = b.api.PostEphemeral(channelID, userID,
+					slack.MsgOptionText(fmt.Sprintf(":x: Killed agent but failed to re-spawn: %s", err), false))
+			}
 			return
 		}
 

--- a/gasboat/controller/internal/bridge/bot_thread_test.go
+++ b/gasboat/controller/internal/bridge/bot_thread_test.go
@@ -73,6 +73,34 @@ func TestRemoveThreadAgentByAgent(t *testing.T) {
 	}
 }
 
+func TestRemoveThreadAgentByAgent_CleansListenFlags(t *testing.T) {
+	dir := t.TempDir()
+	state, err := NewStateManager(filepath.Join(dir, "state.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Set up threads with listen mode.
+	_ = state.SetThreadAgent("C-a", "1.1", "agent-a")
+	_ = state.SetListenThread("C-a", "1.1")
+	_ = state.SetThreadAgent("C-b", "2.2", "agent-b")
+	_ = state.SetListenThread("C-b", "2.2")
+
+	// Remove agent-a — should also clean up its listen flag.
+	if err := state.RemoveThreadAgentByAgent("agent-a"); err != nil {
+		t.Fatal(err)
+	}
+
+	// agent-a's listen flag should be gone.
+	if state.IsListenThread("C-a", "1.1") {
+		t.Error("expected listen flag for C-a:1.1 to be removed")
+	}
+	// agent-b's listen flag should remain.
+	if !state.IsListenThread("C-b", "2.2") {
+		t.Error("expected listen flag for C-b:2.2 to remain")
+	}
+}
+
 func TestHandleThreadSpawn_CreatesBeadAndState(t *testing.T) {
 	daemon := newMockDaemon()
 

--- a/gasboat/controller/internal/bridge/state.go
+++ b/gasboat/controller/internal/bridge/state.go
@@ -207,13 +207,15 @@ func (sm *StateManager) RemoveThreadAgent(channel, threadTS string) error {
 	return sm.saveLocked()
 }
 
-// RemoveThreadAgentByAgent removes all thread associations for a given agent and persists.
+// RemoveThreadAgentByAgent removes all thread associations for a given agent
+// and their corresponding listen-thread flags, then persists.
 func (sm *StateManager) RemoveThreadAgentByAgent(agent string) error {
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
 	for k, v := range sm.data.ThreadAgents {
 		if v == agent {
 			delete(sm.data.ThreadAgents, k)
+			delete(sm.data.ListenThreads, k)
 		}
 	}
 	return sm.saveLocked()


### PR DESCRIPTION
## Summary
- `RemoveThreadAgentByAgent` now also removes listen thread entries for matching thread keys, preventing stale `--listen` flags from being inherited by respawned agents
- Added nil guards on `b.api` in `handleKillThreadAgent` and `handleRestartThreadAgent` to prevent panics in test/API-less contexts
- Added test for listen flag cleanup behavior

## Test plan
- [x] `TestRemoveThreadAgentByAgent_CleansListenFlags` — verifies listen flags removed for killed agent, preserved for others
- [x] Full bridge test suite passes (22s)
- [x] `go build ./...` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)