### PR TITLE
fix(gasboat/bridge): prevent duplicate thread agent spawns

### DIFF
--- a/gasboat/controller/internal/bridge/bot.go
+++ b/gasboat/controller/internal/bridge/bot.go
@@ -78,6 +78,7 @@ type Bot struct {
 
 	threadSpawnMsgs  map[string]MessageRef // agent identity → spawn confirmation message ref (for in-place update)
 	beadMsgs         map[string]MessageRef // "agent:beadID" → Slack message ref for inline bead status updates
+	spawnInFlight    map[string]bool       // "{channel}:{thread_ts}" → true while spawn is in progress (race guard)
 
 	// Nudge throttling for thread reply forwarding.
 	// Key: "agent:thread_ts", value: last nudge time.
@@ -151,6 +152,7 @@ func NewBot(cfg BotConfig) *Bot {
 		agentProject:     make(map[string]string),
 		threadSpawnMsgs:  make(map[string]MessageRef),
 		beadMsgs:         make(map[string]MessageRef),
+		spawnInFlight:    make(map[string]bool),
 		lastThreadNudge: make(map[string]time.Time),
 		github:           gh,
 		repos:            cfg.Repos,

--- a/gasboat/controller/internal/bridge/bot_mentions.go
+++ b/gasboat/controller/internal/bridge/bot_mentions.go
@@ -369,6 +369,25 @@ func (b *Bot) handleThreadSpawn(ctx context.Context, ev *slackevents.AppMentionE
 		}
 	}
 
+	// Atomic check-and-set: prevent concurrent spawn attempts for the same thread.
+	// The state guard above catches already-completed spawns; this catches
+	// in-flight spawns where state hasn't been persisted yet.
+	spawnKey := channel + ":" + threadTS
+	b.mu.Lock()
+	if b.spawnInFlight[spawnKey] {
+		b.mu.Unlock()
+		b.logger.Info("thread-spawn: spawn already in flight, skipping",
+			"channel", channel, "thread_ts", threadTS)
+		return
+	}
+	b.spawnInFlight[spawnKey] = true
+	b.mu.Unlock()
+	defer func() {
+		b.mu.Lock()
+		delete(b.spawnInFlight, spawnKey)
+		b.mu.Unlock()
+	}()
+
 	// Check for --listen flag (auto-forward all thread replies without @mention).
 	listen, text := parseListenFlag(text)
 

--- a/gasboat/controller/internal/bridge/bot_start_test.go
+++ b/gasboat/controller/internal/bridge/bot_start_test.go
@@ -33,6 +33,7 @@ func newTestBot(daemon BeadClient, slackSrv *httptest.Server) *Bot {
 		agentRole:       make(map[string]string),
 		agentProject:    make(map[string]string),
 		threadSpawnMsgs: make(map[string]MessageRef),
+		spawnInFlight:   make(map[string]bool),
 	}
 }
 

--- a/gasboat/controller/internal/bridge/bot_thread_test.go
+++ b/gasboat/controller/internal/bridge/bot_thread_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log/slog"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -480,5 +481,56 @@ func TestHandleAppMention_InactiveThreadAgent_Respawns(t *testing.T) {
 	// Mapping should be preserved.
 	if _, ok := state.GetThreadAgent("C-test", "1111.2222"); !ok {
 		t.Error("expected thread→agent mapping to be preserved after respawn")
+	}
+}
+
+func TestHandleThreadSpawn_ConcurrentMentionsSpawnOnce(t *testing.T) {
+	daemon := newMockDaemon()
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+
+	bot := newTestBot(daemon, slackSrv)
+
+	dir := t.TempDir()
+	state, err := NewStateManager(filepath.Join(dir, "state.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	bot.state = state
+	bot.botUserID = "U-BOT"
+	bot.lastThreadNudge = make(map[string]time.Time)
+
+	channel := "C-race-test"
+	threadTS := "9999.1111"
+
+	// Fire 5 concurrent mentions to the same thread.
+	var wg sync.WaitGroup
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			bot.handleThreadSpawn(context.Background(), &slackevents.AppMentionEvent{
+				User:            "U-USER",
+				Text:            "<@U-BOT> help me",
+				TimeStamp:       "2222.3333",
+				ThreadTimeStamp: threadTS,
+				Channel:         channel,
+			}, "help me")
+		}()
+	}
+	wg.Wait()
+
+	// Count how many agent beads were created for this thread.
+	daemon.mu.Lock()
+	var agentCount int
+	for _, b := range daemon.beads {
+		if b.Type == "agent" {
+			agentCount++
+		}
+	}
+	daemon.mu.Unlock()
+
+	if agentCount != 1 {
+		t.Errorf("expected exactly 1 agent bead from concurrent spawns, got %d", agentCount)
 	}
 }


### PR DESCRIPTION
## Summary
- Added `spawnInFlight` in-memory guard to prevent concurrent `@mention` events from spawning duplicate agents for the same thread
- The existing `state.GetThreadAgent()` check catches already-completed spawns, but two concurrent mentions could both pass it before either persisted. The new check-and-set atomically blocks the second spawn while the first is in progress
- Guard auto-clears via `defer` after spawn completes (whether success or failure)

## Test plan
- [x] `TestHandleThreadSpawn_ConcurrentMentionsSpawnOnce` — fires 5 concurrent mentions, verifies exactly 1 agent created
- [x] Full bridge test suite passes (22s)
- [x] `go build ./...` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)