### PR TITLE
fix: stop gate operator overrides persist across stop attempts

### DIFF
--- a/gasboat/controller/cmd/gb/gate.go
+++ b/gasboat/controller/cmd/gb/gate.go
@@ -112,7 +112,7 @@ var gateMarkCmd = &cobra.Command{
 
 var gateClearCmd = &cobra.Command{
 	Use:   "clear <gate-id>",
-	Short: "Clear a gate (reset to pending)",
+	Short: "Clear a gate (satisfy as operator so stop hook allows through persistently)",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		gateID := args[0]
@@ -121,19 +121,22 @@ var gateClearCmd = &cobra.Command{
 			return err
 		}
 
-		if err := daemon.ClearGate(cmd.Context(), agentID, gateID); err != nil {
+		// Satisfy the gate instead of resetting to pending. The stop hook handler
+		// in http_hooks.go skips gate consumption for operator-satisfied gates,
+		// so this persists across repeated stop attempts (e.g. idle thread agents).
+		if err := daemon.SatisfyGate(cmd.Context(), agentID, gateID); err != nil {
 			return fmt.Errorf("clearing gate: %w", err)
 		}
 
-		// When clearing the decision gate, also clear the gate_satisfied_by marker
-		// so stale values don't mislead stop-gate.sh in the next session.
+		// Set gate_satisfied_by=operator so the stop hook handler recognizes this
+		// as an authorized override and does not consume the gate.
 		if gateID == "decision" {
 			clearCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
 			if err := daemon.UpdateBeadFields(clearCtx, agentID, map[string]string{
-				"gate_satisfied_by": "",
+				"gate_satisfied_by": "operator",
 			}); err != nil {
-				fmt.Fprintf(os.Stderr, "Warning: failed to clear gate_satisfied_by: %v\n", err)
+				fmt.Fprintf(os.Stderr, "Warning: failed to set gate_satisfied_by: %v\n", err)
 			}
 		}
 

--- a/kbeads/internal/server/decision_test.go
+++ b/kbeads/internal/server/decision_test.go
@@ -517,6 +517,128 @@ func TestDecisionGateOperatorOverride(t *testing.T) {
 	}
 }
 
+// TestDecisionGateOperatorNotConsumed verifies that operator overrides persist
+// across multiple Stop attempts. Unlike yield-based satisfaction (which is
+// consumed after one Stop), operator overrides must survive repeated Stop hooks
+// so thread agents and operator-cleared gates don't loop indefinitely.
+func TestDecisionGateOperatorNotConsumed(t *testing.T) {
+	_, gs, h := newGatedTestServer()
+
+	const agentID = "kd-agent-operator-persist"
+
+	// Step 1: Stop → gate pending → blocked.
+	stop1 := doJSON(t, h, "POST", "/v1/hooks/emit", map[string]any{
+		"agent_bead_id": agentID,
+		"hook_type":     "Stop",
+		"actor":         "test-agent",
+	})
+	requireStatus(t, stop1, 200)
+	var r1 map[string]any
+	decodeJSON(t, stop1, &r1)
+	if r1["block"] != true {
+		t.Fatalf("step 1: expected block=true, got %v", r1)
+	}
+
+	// Step 2: Operator satisfies gate + sets gate_satisfied_by=operator.
+	satisfyRec := doJSON(t, h, "POST", "/v1/agents/"+agentID+"/gates/decision/satisfy", nil)
+	requireStatus(t, satisfyRec, 200)
+	gs.beads[agentID] = &model.Bead{
+		ID:     agentID,
+		Fields: json.RawMessage(`{"gate_satisfied_by":"operator"}`),
+	}
+
+	// Step 3: First Stop after operator override → allowed.
+	stop2 := doJSON(t, h, "POST", "/v1/hooks/emit", map[string]any{
+		"agent_bead_id": agentID,
+		"hook_type":     "Stop",
+		"actor":         "test-agent",
+	})
+	requireStatus(t, stop2, 200)
+	var r2 map[string]any
+	decodeJSON(t, stop2, &r2)
+	if r2["block"] == true {
+		t.Fatalf("step 3: expected unblocked, got %v", r2)
+	}
+
+	// Step 4: Second Stop → operator override was NOT consumed → still allowed.
+	// This is the key assertion: without the fix, the gate would be consumed
+	// after step 3, and this step would block, causing an infinite loop for
+	// thread agents.
+	stop3 := doJSON(t, h, "POST", "/v1/hooks/emit", map[string]any{
+		"agent_bead_id": agentID,
+		"hook_type":     "Stop",
+		"actor":         "test-agent",
+	})
+	requireStatus(t, stop3, 200)
+	var r3 map[string]any
+	decodeJSON(t, stop3, &r3)
+	if r3["block"] == true {
+		t.Fatalf("step 4: expected operator override to persist (not consumed), got block=true")
+	}
+
+	// Step 5: Third Stop → still allowed (persistence is indefinite).
+	stop4 := doJSON(t, h, "POST", "/v1/hooks/emit", map[string]any{
+		"agent_bead_id": agentID,
+		"hook_type":     "Stop",
+		"actor":         "test-agent",
+	})
+	requireStatus(t, stop4, 200)
+	var r4 map[string]any
+	decodeJSON(t, stop4, &r4)
+	if r4["block"] == true {
+		t.Fatalf("step 5: expected operator override to persist on third attempt, got block=true")
+	}
+}
+
+// TestDecisionGateManualForceNotConsumed verifies the legacy "manual-force"
+// value for gate_satisfied_by also persists across Stop attempts, matching
+// the operator override behavior for backward compatibility.
+func TestDecisionGateManualForceNotConsumed(t *testing.T) {
+	_, gs, h := newGatedTestServer()
+
+	const agentID = "kd-agent-manual-force-persist"
+
+	// Register gate via Stop.
+	doJSON(t, h, "POST", "/v1/hooks/emit", map[string]any{
+		"agent_bead_id": agentID,
+		"hook_type":     "Stop",
+		"actor":         "test-agent",
+	})
+
+	// Satisfy gate + set legacy manual-force marker.
+	doJSON(t, h, "POST", "/v1/agents/"+agentID+"/gates/decision/satisfy", nil)
+	gs.beads[agentID] = &model.Bead{
+		ID:     agentID,
+		Fields: json.RawMessage(`{"gate_satisfied_by":"manual-force"}`),
+	}
+
+	// First Stop → allowed.
+	stop1 := doJSON(t, h, "POST", "/v1/hooks/emit", map[string]any{
+		"agent_bead_id": agentID,
+		"hook_type":     "Stop",
+		"actor":         "test-agent",
+	})
+	requireStatus(t, stop1, 200)
+	var r1 map[string]any
+	decodeJSON(t, stop1, &r1)
+	if r1["block"] == true {
+		t.Fatalf("expected unblocked with manual-force, got block=true")
+	}
+
+	// Second Stop → still allowed (not consumed).
+	stop2 := doJSON(t, h, "POST", "/v1/hooks/emit", map[string]any{
+		"agent_bead_id": agentID,
+		"hook_type":     "Stop",
+		"actor":         "test-agent",
+	})
+	requireStatus(t, stop2, 200)
+	var r2 map[string]any
+	decodeJSON(t, stop2, &r2)
+	if r2["block"] == true {
+		t.Fatalf("expected manual-force to persist (not consumed), got block=true")
+	}
+}
+
 // ── report-gated decision flow ─────────────────────────────────────────
 
 // TestDecisionReportGatedFlow exercises the report-gated lifecycle:

--- a/kbeads/internal/server/http_hooks.go
+++ b/kbeads/internal/server/http_hooks.go
@@ -96,12 +96,16 @@ func (s *BeadsServer) handleHookEmit(w http.ResponseWriter, r *http.Request) {
 		}
 
 		// Consume the gate (reset to pending) so the next Stop blocks again.
-		if err := s.store.ClearGate(ctx, req.AgentBeadID, "decision"); err != nil {
-			slog.Warn("hookEmit: failed to clear decision gate after consume", "agent", req.AgentBeadID, "err", err)
-		}
-		// Clear gate_satisfied_by field so it doesn't carry over to the next session.
-		if err := s.mergeBeadFields(ctx, req.AgentBeadID, map[string]any{"gate_satisfied_by": nil}); err != nil {
-			slog.Warn("hookEmit: failed to clear gate_satisfied_by field", "agent", req.AgentBeadID, "err", err)
+		// Skip consume for operator overrides — these persist across stop attempts
+		// so thread agents and operator-cleared gates don't loop indefinitely.
+		if satisfiedBy != "operator" && satisfiedBy != "manual-force" {
+			if err := s.store.ClearGate(ctx, req.AgentBeadID, "decision"); err != nil {
+				slog.Warn("hookEmit: failed to clear decision gate after consume", "agent", req.AgentBeadID, "err", err)
+			}
+			// Clear gate_satisfied_by field so it doesn't carry over to the next session.
+			if err := s.mergeBeadFields(ctx, req.AgentBeadID, map[string]any{"gate_satisfied_by": nil}); err != nil {
+				slog.Warn("hookEmit: failed to clear gate_satisfied_by field", "agent", req.AgentBeadID, "err", err)
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary

Fixes the infinite stop gate loop for thread agents and operator-cleared gates (kd-itH9zRjSwR).

**Root cause**: The stop gate was designed for ephemeral agents (one stop per session). Thread agents never stop — every stop attempt consumed the gate and re-blocked on the next attempt.

**Changes:**

- **Server** (`http_hooks.go`): Skip gate consumption when `gate_satisfied_by=operator|manual-force` so operator overrides persist across stop attempts
- **`gb gate clear`** (`gate.go`): Now calls `SatisfyGate` + sets `gate_satisfied_by=operator` instead of resetting to pending
- **`gb decision create`** (`decision.go`): Satisfies the gate immediately on decision creation — creating a decision IS the checkpoint. No need for `gb yield` to block.
- **`stop-gate.sh`**: Remove redundant `gb gate clear` on allowed stop (was undoing operator overrides). Add debug logging to `/tmp/stop-gate-debug.log`. Echo injected text to stderr for operator visibility.

**New model**: Agent creates decision → gate satisfied → agent can stop cleanly → decision resolution nudges agent back.

## Test plan

- [x] `TestDecisionGateOperatorNotConsumed` — 3 consecutive Stops pass with operator override
- [x] `TestDecisionGateManualForceNotConsumed` — legacy manual-force also persists  
- [x] All existing gate tests pass (yield consumption, manual mark blocked, etc.)
- [x] `go test ./...` passes across all kbeads packages
- [x] Local test: `gb decision create` → stop hook passes immediately (rc=0)
- [x] Live test: decision resolved via Slack, nudge delivered

🤖 Generated with [Claude Code](https://claude.com/claude-code)