### PR TITLE
feat(kbeads,gasboat): add project type schema with channel_roles

### DIFF
--- a/gasboat/controller/internal/beadsapi/projects.go
+++ b/gasboat/controller/internal/beadsapi/projects.go
@@ -57,6 +57,11 @@ type ProjectInfo struct {
 	// Keys absent or empty in the JSON are silently skipped.
 	EnvOverrides map[string]string
 
+	// ChannelRoles maps Slack channel IDs to agent role overrides.
+	// When /spawn is invoked from a channel listed here, the agent
+	// is assigned the specified role instead of the default.
+	ChannelRoles map[string]string
+
 	Secrets        []SecretEntry       // Per-project secret overrides
 	EnvVars        []EnvEntry          // Per-project plain env vars
 	Repos          []RepoEntry         // Multi-repo definitions
@@ -102,6 +107,13 @@ func (c *Client) ListProjectBeads(ctx context.Context) (map[string]ProjectInfo, 
 			MemoryRequest:  fields["memory_request"],
 			MemoryLimit:    fields["memory_limit"],
 			SlackChannels:  parseSlackChannels(fields["slack_channel"]),
+		}
+		// Parse per-channel role overrides from JSON field.
+		if raw := fields["channel_roles"]; raw != "" {
+			var roles map[string]string
+			if json.Unmarshal([]byte(raw), &roles) == nil {
+				info.ChannelRoles = roles
+			}
 		}
 		// Parse per-project secrets from JSON field.
 		if raw := fields["secrets"]; raw != "" {
@@ -190,4 +202,9 @@ func (p ProjectInfo) HasChannel(channelID string) bool {
 		}
 	}
 	return false
+}
+
+// ChannelRole returns the role override for the given Slack channel, or empty string if none.
+func (p ProjectInfo) ChannelRole(channelID string) string {
+	return p.ChannelRoles[channelID]
 }

--- a/kbeads/internal/server/config.go
+++ b/kbeads/internal/server/config.go
@@ -101,6 +101,33 @@ var builtinConfigs = map[string]*model.Config{
 		]
 	}`)},
 
+	"type:project": {Key: "type:project", Value: json.RawMessage(`{
+		"kind": "config",
+		"fields": [
+			{"name": "prefix",          "type": "string"},
+			{"name": "git_url",         "type": "string"},
+			{"name": "default_branch",  "type": "string"},
+			{"name": "image",           "type": "string"},
+			{"name": "storage_class",   "type": "string"},
+			{"name": "service_account", "type": "string"},
+			{"name": "rtk_enabled",     "type": "boolean"},
+			{"name": "docker",          "type": "boolean"},
+			{"name": "cpu_request",     "type": "string"},
+			{"name": "cpu_limit",       "type": "string"},
+			{"name": "memory_request",  "type": "string"},
+			{"name": "memory_limit",    "type": "string"},
+			{"name": "secrets",         "type": "json"},
+			{"name": "env",             "type": "json"},
+			{"name": "env_json",        "type": "json"},
+			{"name": "repos",           "type": "json"},
+			{"name": "slack_channel",   "type": "string"},
+			{"name": "channel_roles",   "type": "json"},
+			{"name": "auto_assign",     "type": "string"},
+			{"name": "prewarmed_pool",  "type": "json"},
+			{"name": "nudge_prompts",   "type": "json"}
+		]
+	}`)},
+
 	// Infrastructure types — config kind.
 	"type:role":    {Key: "type:role", Value: json.RawMessage(`{"kind":"config","fields":[]}`)},
 	"type:rig":     {Key: "type:rig", Value: json.RawMessage(`{"kind":"config","fields":[]}`)},


### PR DESCRIPTION
## Summary
- Adds `type:project` as a builtin config in kbeads with all 21 fields (including `channel_roles` and `docker` which were missing from the runtime schema)
- Adds `ChannelRoles` field to `ProjectInfo` in the controller's beadsapi client, with JSON parsing and a `ChannelRole()` helper method
- Fixes `kd update` failing on project beads that have `channel_roles` set (e.g. monorepo)

## Context
The monorepo project bead had a `channel_roles` field that wasn't declared in the `type:project` schema. Since kbeads validates ALL existing fields on update (not just the changed field), any `kd update` on that bead would fail with "validation failed: channel_roles: unknown field". The runtime schema has already been patched via `kd config create`; this PR adds the builtin default for fresh deployments and makes the controller aware of channel role overrides.

## Test plan
- [x] `go test ./kbeads/...` — all pass
- [x] `go test ./gasboat/controller/...` — all pass
- [x] `go build ./kbeads/...` and `go build ./gasboat/controller/...` — both compile
- [ ] Verify `kd update` works on monorepo project bead (done live: added C0AL2AFMFS5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)