### PR TITLE
fix(agent): fix sudo PAM failure and Playwright version mismatch

### DIFF
--- a/gasboat/images/agent/Dockerfile
+++ b/gasboat/images/agent/Dockerfile
@@ -68,9 +68,13 @@ RUN set -e && \
 COPY --from=gb-builder /gb /usr/local/bin/gb
 
 # ── Agent user ───────────────────────────────────────────────────
+# Rename the default ubuntu user (UID 1000) to agent across passwd,
+# shadow, and group so that sudo/PAM account checks work correctly
+# in containers that lack CAP_AUDIT_WRITE.
 RUN sed -i 's/^ubuntu:/agent:/' /etc/passwd && \
     sed -i 's|/home/ubuntu|/home/agent|' /etc/passwd && \
     sed -i 's|/bin/sh|/bin/bash|' /etc/passwd && \
+    sed -i 's/^ubuntu:/agent:/' /etc/shadow && \
     sed -i 's/^ubuntu:/agent:/' /etc/group && \
     mkdir -p /home/agent/workspace && \
     chown -R 1000:1000 /home/agent && \
@@ -266,10 +270,14 @@ RUN curl -fsSL "https://github.com/ggml-org/whisper.cpp/archive/refs/tags/v${WHI
 # browser system library dependencies (libglib, libnss3, etc.).
 # Both chromium and chrome are installed because @playwright/mcp
 # defaults to --browser=chrome (Chrome for Testing).
-ARG PLAYWRIGHT_VERSION=1.58.2
+#
+# Only @playwright/mcp is installed explicitly — it pulls in the
+# correct playwright version as a dependency. Do NOT also install a
+# separate playwright@<version> or the two may expect different
+# browser revisions, leaving Chrome for Testing empty.
 ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
 RUN apt-get update && \
-    npm install -g playwright@${PLAYWRIGHT_VERSION} @playwright/mcp && \
+    npm install -g @playwright/mcp && \
     npx playwright install --with-deps chromium chrome && \
     apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* && \
     npm cache clean --force && \


### PR DESCRIPTION
## Summary

Two bugs in the agent Dockerfile that break `sudo` and Playwright browser automation at runtime:

### 1. sudo fails with "account validation failure"

The ubuntu→agent user rename edits `/etc/passwd` and `/etc/group` but misses `/etc/shadow`. When `sudo` runs, PAM's `pam_unix.so` account module can't find the shadow entry for `agent`, and the audit message fails because containers lack `CAP_AUDIT_WRITE`, producing:

```
sudo: unable to send audit message: Operation not permitted
sudo: account validation failure, is your account locked?
```

**Fix:** Also rename `ubuntu` to `agent` in `/etc/shadow`.

### 2. Playwright Chrome for Testing directory is empty

The Dockerfile installs both `playwright@1.58.2` (explicit) and `@playwright/mcp` (which depends on `playwright@1.59.0-alpha`). The two versions expect different Chrome for Testing revisions. The MCP's playwright downloads Chrome to a revision-specific directory, but the global `playwright` binary looks for a different revision — result: "Chromium distribution 'chrome' is not found" at runtime.

**Fix:** Remove the explicit `playwright@${PLAYWRIGHT_VERSION}` install. Only install `@playwright/mcp`, which pulls the correct playwright version as its dependency. This ensures `npx playwright install` downloads browsers matching the version @playwright/mcp expects.

## Test plan

- [ ] Build the image: `docker build -t gasboat-agent -f gasboat/images/agent/Dockerfile .`
- [ ] Verify sudo works: `docker run --rm gasboat-agent sudo whoami` → `root`
- [ ] Verify Playwright Chrome exists: `docker run --rm gasboat-agent ls /ms-playwright/` shows populated chrome directory
- [ ] Verify Playwright MCP launches: `docker run --rm gasboat-agent playwright-mcp --headless --no-sandbox`