### PR TITLE
feat(gasboat/agent): add rwx CLI to agent image

### DIFF
--- a/.rwx/docker.yml
+++ b/.rwx/docker.yml
@@ -897,6 +897,12 @@ tasks:
         chmod +x $OUT/usr/local/bin/claudeless
       ) &
       (
+        # RWX CLI
+        curl -fsSL "https://github.com/rwx-cloud/cli/releases/download/v3.7.1/rwx-linux-x86_64" \
+          -o $OUT/usr/local/bin/rwx
+        chmod +x $OUT/usr/local/bin/rwx
+      ) &
+      (
         # whisper-cli
         sudo apt-get update && sudo apt-get install -y cmake libsdl2-dev gcc g++ make
         curl -fsSL "https://github.com/ggml-org/whisper.cpp/archive/refs/tags/v1.8.3.tar.gz" \

--- a/gasboat/.rwx/agent-clis.lock
+++ b/gasboat/.rwx/agent-clis.lock
@@ -7,3 +7,4 @@ terragrunt=0.77.11
 stern=1.30.0
 claudeless=v0.4.0
 rtk=v0.23.0
+rwx=v3.7.1

--- a/gasboat/images/agent/Dockerfile
+++ b/gasboat/images/agent/Dockerfile
@@ -254,6 +254,13 @@ RUN case "${TARGETARCH}" in arm64) RTK_TRIPLE=aarch64-unknown-linux-gnu ;; *) RT
     curl -fsSL "https://github.com/rtk-ai/rtk/releases/download/v${RTK_VERSION}/rtk-${RTK_TRIPLE}.tar.gz" \
       | tar -xz -C /usr/local/bin rtk
 
+# ── RWX CLI (CI pipeline runner) ──────────────────────────────
+ARG RWX_VERSION=3.7.1
+RUN case "${TARGETARCH}" in arm64) RWX_ARCH=aarch64 ;; *) RWX_ARCH=x86_64 ;; esac && \
+    curl -fsSL "https://github.com/rwx-cloud/cli/releases/download/v${RWX_VERSION}/rwx-linux-${RWX_ARCH}" \
+      -o /usr/local/bin/rwx && \
+    chmod +x /usr/local/bin/rwx
+
 # ── whisper-cli (audio transcription for JIRA video attachments) ──
 ARG WHISPER_CPP_VERSION=1.8.3
 RUN curl -fsSL "https://github.com/ggml-org/whisper.cpp/archive/refs/tags/v${WHISPER_CPP_VERSION}.tar.gz" \


### PR DESCRIPTION
## Summary
- Adds rwx CLI v3.7.1 to the agent image (both Dockerfile and RWX CI build)
- Agents can now run `rwx run`, `rwx dispatch`, `rwx results` etc. from within sessions
- Binary downloaded from `rwx-cloud/cli` GitHub releases, installed at `/usr/local/bin/rwx`

## Changes
- `gasboat/images/agent/Dockerfile`: Added RWX CLI install step (multi-arch: x86_64 + aarch64)
- `.rwx/docker.yml`: Added RWX CLI to `agent-install-clis` parallel download block
- `gasboat/.rwx/agent-clis.lock`: Added `rwx=v3.7.1` to bust cache

## Test plan
- [ ] CI builds successfully (Go builds + tests pass)
- [ ] Agent image contains `/usr/local/bin/rwx` after next release
- [ ] `rwx --version` works in agent pod

Fixes kd-wHyUQ2gp2Y

🤖 Generated with [Claude Code](https://claude.com/claude-code)