### PR TITLE
fix(agent): explicitly capture chromium runtime deps in playwright build

### DIFF
--- a/.rwx/docker.yml
+++ b/.rwx/docker.yml
@@ -698,20 +698,36 @@ tasks:
         | tar -xJ --strip-components=1 -C $OUT/usr/local
 
       PATH=$OUT/usr/local/bin:$PATH npm install -g playwright@1.58.2 @playwright/mcp
-      # Snapshot installed packages before playwright deps
-      dpkg-query -W -f='${Package}\n' | sort > /tmp/pkgs-before.txt
-
       PLAYWRIGHT_BROWSERS_PATH=$OUT/ms-playwright PATH=$OUT/usr/local/bin:$PATH npx playwright install --with-deps chromium
 
-      # Capture ALL system deps installed by playwright --with-deps
-      # ldd only finds direct .so links; Chromium dlopen's X11/GTK libs at runtime
+      # Capture chromium system deps for the agent image.
+      # The dpkg before/after diff misses packages already in the RWX runner,
+      # so we explicitly capture all chromium runtime deps + transitive deps.
       DEPS_OUT=/tmp/pw-deps
       mkdir -p $DEPS_OUT
 
-      # 1. Diff packages to find everything --with-deps installed
-      dpkg-query -W -f='${Package}\n' | sort > /tmp/pkgs-after.txt
-      NEW_PKGS=$(comm -13 /tmp/pkgs-before.txt /tmp/pkgs-after.txt)
-      for pkg in $NEW_PKGS; do
+      # Parse chromium's declared deps from deb.deps and resolve transitive deps
+      CHROME_DIR=$(find $OUT/ms-playwright -maxdepth 2 -name 'deb.deps' -path '*/chromium-*/chrome-linux*/deb.deps' | head -1)
+      if [ -n "$CHROME_DIR" ]; then
+        # Extract package names from deb.deps (strip version constraints)
+        DECLARED_DEPS=$(sed 's/ (.*)//g' "$CHROME_DIR" | tr '\n' ' ')
+      else
+        DECLARED_DEPS=""
+      fi
+
+      # Combine declared deps with known transitive deps that chromium dlopen's
+      ALL_DEPS="$DECLARED_DEPS libsqlite3-0 libfontconfig1 libfreetype6 libpng16-16t64 \
+        libx11-6 libx11-xcb1 libxcb1 libxcomposite1 libxdamage1 libxext6 \
+        libxfixes3 libxrandr2 libxshmfence1 libxkbcommon0 libxkbfile1 \
+        libdrm2 libdrm-amdgpu1 libdrm-intel1 libgbm1 \
+        libatk1.0-0 libatk-bridge2.0-0 libatspi2.0-0 \
+        libnss3 libnspr4 libcups2t64 libcairo2 libpango-1.0-0 \
+        libasound2t64 libdbus-1-3 libglib2.0-0t64 libexpat1 \
+        libpixman-1-0 libthai0 libdatrie1 libfribidi0 libharfbuzz0b \
+        libgraphite2-3 libpciaccess0 libxcb-dri3-0 libxcb-present0 \
+        libxcb-randr0 libxcb-render0 libxcb-shm0 libxcb-sync1 libxcb-xfixes0"
+
+      for pkg in $ALL_DEPS; do
         dpkg -L "$pkg" 2>/dev/null | while read -r f; do
           [ -e "$f" ] || continue
           [ -d "$f" ] && { mkdir -p "$DEPS_OUT$f"; continue; }
@@ -719,9 +735,9 @@ tasks:
         done || true
       done
 
-      # 2. Also capture direct .so deps via ldd as fallback
-      for lib in $(find $OUT/ms-playwright -name '*.so*' -type f 2>/dev/null); do
-        ldd "$lib" 2>/dev/null | grep "=> /" | awk '{print $3}' | while read -r dep; do
+      # Also capture .so deps via ldd on the chrome binary itself
+      for bin in $(find $OUT/ms-playwright -name 'chrome' -o -name 'chrome-headless-shell' 2>/dev/null); do
+        ldd "$bin" 2>/dev/null | grep "=> /" | awk '{print $3}' | while read -r dep; do
           [ -f "$dep" ] || continue
           mkdir -p "$DEPS_OUT$(dirname "$dep")"
           cp -n "$dep" "$DEPS_OUT${dep}" 2>/dev/null || true


### PR DESCRIPTION
## Summary

- **Root cause**: The dpkg before/after diff in the playwright build task missed packages already present in the RWX runner image (libx11-6, libxext6, libsqlite3-0, libxcomposite1, libxdamage1, libxfixes3, libxrandr2). Chrome crashed at runtime with `FATAL: Error initializing NSS: libsqlite3.so.0 not found`.
- **Fix**: Replace the brittle dpkg diff with an explicit dep list: parse chromium's `deb.deps` for declared deps, combine with known transitive deps, and `dpkg -L` each one to capture all files.
- **Also**: Run `ldd` on the chrome binaries directly instead of scanning all `.so` files in the ms-playwright dir.

## Investigation findings

- Chrome binary loads fine (`--version` works) but crashes on navigation because NSS initialization fails without libsqlite3
- 7 critical .so files missing from the image: libsqlite3.so.0, libX11.so.6, libXcomposite.so.1, libXdamage.so.1, libXext.so.6, libXfixes.so.3, libXrandr.so.2
- Dynamic linker has `/usr/lib/x86_64-linux-gnu/` hardcoded as fallback search path, so no ldconfig needed — just need the files to be present
- Workaround confirmed: downloading debs + extracting + `LD_LIBRARY_PATH` makes Playwright fully functional

## Test plan

- [ ] Build agent image from this branch (needs manual `rwx dispatch` or branch build support — see kd-sBqHwHxBai)
- [ ] Verify chromium can navigate to https://example.com without LD_LIBRARY_PATH workaround
- [ ] Verify Playwright MCP browser_navigate works end-to-end
- [ ] Check that `ldd chrome` shows no "not found" entries

## Related beads

- kd-wGDLAzQBgR: parent task (see if playwright works now)
- kd-yL1W7XgbWe: this fix
- kd-NNjFcgtUT7: verification task (test after image rebuild)
- kd-51HHrxXoYG: rwx CLI missing from agent pods (recurring)
- kd-sBqHwHxBai: allow image builds from feature branches

🤖 Generated with [Claude Code](https://claude.com/claude-code)