### PR TITLE
fix(gasboat/podmanager): run DinD sidecar as root

### DIFF
--- a/gasboat/controller/internal/podmanager/dind.go
+++ b/gasboat/controller/internal/podmanager/dind.go
@@ -15,7 +15,9 @@ func (m *K8sManager) buildDindSidecar() corev1.Container {
 			{Name: "DOCKER_TLS_CERTDIR", Value: ""},
 		},
 		SecurityContext: &corev1.SecurityContext{
-			Privileged: boolPtr(true),
+			Privileged:  boolPtr(true),
+			RunAsUser:   intPtr(0),
+			RunAsNonRoot: boolPtr(false),
 		},
 		VolumeMounts: []corev1.VolumeMount{
 			{Name: VolumeDindStorage, MountPath: MountDindStorage},

--- a/gasboat/controller/internal/podmanager/dind_test.go
+++ b/gasboat/controller/internal/podmanager/dind_test.go
@@ -62,6 +62,14 @@ func TestBuildPod_DockerEnabled(t *testing.T) {
 		t.Error("DinD sidecar should run in privileged mode")
 	}
 
+	// Verify RunAsUser=0 to override pod-level runAsUser (dockerd must run as root).
+	if dind.SecurityContext.RunAsUser == nil || *dind.SecurityContext.RunAsUser != 0 {
+		t.Error("DinD sidecar should have RunAsUser=0 to run dockerd as root")
+	}
+	if dind.SecurityContext.RunAsNonRoot == nil || *dind.SecurityContext.RunAsNonRoot != false {
+		t.Error("DinD sidecar should have RunAsNonRoot=false")
+	}
+
 	// Verify DOCKER_TLS_CERTDIR="" env var.
 	foundTLSEnv := false
 	for _, env := range dind.Env {


### PR DESCRIPTION
## Summary

- DinD sidecar was in CrashLoopBackOff because pod-level `runAsUser: 1000` / `runAsNonRoot: true` prevented dockerd from running as root
- Added `RunAsUser: 0` and `RunAsNonRoot: false` to the DinD container's security context to override pod-level settings
- Added test coverage for the new security context fields

## Root Cause

The `docker:dind` entrypoint detects it's not running as root and tries rootless mode, but `rootlesskit` is not available in the `docker:dind` image (only in `docker:dind-rootless`). Error:
```
error: attempting to run rootless dockerd but missing 'rootlesskit'
```

## Test plan

- [x] `go test ./internal/podmanager/ -run Docker` passes
- [x] `go test ./...` — all controller tests pass
- [x] `go build ./cmd/controller/` and `go build ./cmd/slack-bridge/` succeed
- [ ] Deploy and verify `docker info` works from an agent pod with docker=true

Fixes kd-eWQ5dnHeBU

🤖 Generated with [Claude Code](https://claude.com/claude-code)