### PR TITLE
feat(ci): allow agent-only builds from feature branches

### DIFF
--- a/.rwx/docker.yml
+++ b/.rwx/docker.yml
@@ -18,6 +18,10 @@
 #
 # Key monorepo improvement: coop and kd are built FROM SOURCE, not downloaded
 # from GitHub releases. No cross-repo dispatch needed.
+#
+# Feature branch builds (agent-only):
+#   rwx run .rwx/docker.yml --init build-target=agent
+#   Builds and pushes only the agent image, tagged "cli".
 
 on:
   github:
@@ -26,12 +30,14 @@ on:
       init:
         commit-sha: ${{ event.git.sha }}
         ref-name: ${{ event.git.ref }}
+        build-target: all
       status-checks:
         name: Docker
     pull_request:
       init:
         commit-sha: ${{ event.git.sha }}
         ref-name: pr
+        build-target: all
       status-checks:
         - tasks: [build-controller, build-gb, build-slack-bridge, build-jira-bridge, build-gitlab-bridge, build-advice-viewer, build-coop, build-kd]
           name: Docker
@@ -39,6 +45,7 @@ on:
     init:
       commit-sha: ${{ event.git.sha }}
       ref-name: cli
+      build-target: all
 
 base:
   image: ubuntu:24.04
@@ -328,7 +335,7 @@ tasks:
   # ── Push controller ─────────────────────────────────────────────────
   - key: push-controller
     use: [code, build-controller, install-crane]
-    if: ${{ init.ref-name != 'pr' }}
+    if: ${{ init.ref-name != 'pr' && init.build-target == 'all' }}
     cache: false
     run: |
       set -ex
@@ -356,7 +363,7 @@ tasks:
   # ── Push slack-bridge ───────────────────────────────────────────────
   - key: push-slack-bridge
     use: [code, build-slack-bridge, install-crane]
-    if: ${{ init.ref-name != 'pr' }}
+    if: ${{ init.ref-name != 'pr' && init.build-target == 'all' }}
     cache: false
     run: |
       set -ex
@@ -380,7 +387,7 @@ tasks:
   # ── Push jira-bridge ────────────────────────────────────────────────
   - key: push-jira-bridge
     use: [build-jira-bridge, install-crane]
-    if: ${{ init.ref-name != 'pr' }}
+    if: ${{ init.ref-name != 'pr' && init.build-target == 'all' }}
     cache: false
     run: |
       set -ex
@@ -404,7 +411,7 @@ tasks:
   # ── Push gitlab-bridge ──────────────────────────────────────────────
   - key: push-gitlab-bridge
     use: [build-gitlab-bridge, install-crane]
-    if: ${{ init.ref-name != 'pr' }}
+    if: ${{ init.ref-name != 'pr' && init.build-target == 'all' }}
     cache: false
     run: |
       set -ex
@@ -428,7 +435,7 @@ tasks:
   # ── Push advice-viewer ──────────────────────────────────────────────
   - key: push-advice-viewer
     use: [build-advice-viewer, install-crane]
-    if: ${{ init.ref-name != 'pr' }}
+    if: ${{ init.ref-name != 'pr' && init.build-target == 'all' }}
     cache: false
     run: |
       set -ex
@@ -452,7 +459,7 @@ tasks:
   # ── Push kbeads (MONOREPO: built from source, no cross-repo dispatch) ─
   - key: push-kbeads
     use: [build-kd, install-crane]
-    if: ${{ init.ref-name != 'pr' }}
+    if: ${{ init.ref-name != 'pr' && init.build-target == 'all' }}
     cache: false
     run: |
       set -ex
@@ -476,7 +483,7 @@ tasks:
   # ── Push coop/coopmux (MONOREPO: built from source) ────────────────
   - key: push-coop
     use: [build-coop, install-crane]
-    if: ${{ init.ref-name != 'pr' }}
+    if: ${{ init.ref-name != 'pr' && init.build-target == 'all' }}
     cache: false
     run: |
       set -ex
@@ -514,7 +521,7 @@ tasks:
   # ── Push beads3d (MONOREPO: built from source, no more retag) ──────
   - key: push-beads3d
     use: [build-beads3d, install-crane]
-    if: ${{ init.ref-name != 'pr' }}
+    if: ${{ init.ref-name != 'pr' && init.build-target == 'all' }}
     cache: false
     run: |
       set -ex
@@ -934,7 +941,7 @@ tasks:
   # ── Agent assembly: merge all layers + push ────────────────────────
   - key: push-agent
     use: [code, build-gb, build-coop, build-kd, install-crane, agent-install-syspackages, agent-install-node, agent-install-playwright, agent-install-go, agent-install-rust, agent-install-clis]
-    if: ${{ init.ref-name != 'pr' }}
+    if: ${{ init.ref-name != 'pr' && (init.build-target == 'all' || init.build-target == 'agent') }}
     cache: false
     timeout: 10m
     run: |


### PR DESCRIPTION
## Summary
- Add `build-target` init variable to `.rwx/docker.yml` (default: `all`)
- When `build-target=agent`, only the agent image is built and pushed — all other push tasks are skipped
- Enables pre-merge testing of agent image changes (e.g., new CLI tools, dependency updates) without rebuilding all 9 images

### Usage
```bash
# Build + push ONLY the agent image (from any branch)
rwx run .rwx/docker.yml --init build-target=agent

# Default behavior unchanged — builds all images
rwx run .rwx/docker.yml
```

Fixes kd-sBqHwHxBai

## Test plan
- [ ] Verify existing `main` push still builds all images (build-target defaults to `all`)
- [ ] Verify PR trigger still skips all push tasks (ref-name is `pr`)
- [ ] Run `rwx run .rwx/docker.yml --init build-target=agent` from a feature branch and confirm only agent image is pushed

🤖 Generated with [Claude Code](https://claude.com/claude-code)