### PR TITLE
fix(gasboat): playwright MCP browser path and version mismatch

### DIFF
--- a/gasboat/.rwx/docker.yml
+++ b/gasboat/.rwx/docker.yml
@@ -749,7 +749,10 @@ tasks:
         done || true
       done
       # Install Chromium browser (managed by Playwright).
+      # Install for both the standalone playwright and the @playwright/mcp bundled
+      # version — they may expect different chromium revisions.
       PLAYWRIGHT_BROWSERS_PATH=$OUT/ms-playwright npx playwright install chromium
+      PLAYWRIGHT_BROWSERS_PATH=$OUT/ms-playwright npx --package=@playwright/mcp playwright install chromium
       chmod -R 777 $OUT/ms-playwright
 
       # Install Google Chrome Stable (system browser at /opt/google/chrome/chrome).

--- a/gasboat/controller/cmd/gb/setup_config.go
+++ b/gasboat/controller/cmd/gb/setup_config.go
@@ -80,11 +80,12 @@ func writeMCPConfig(workspace string, config map[string]any) error {
 		}
 	}
 
-	// Ensure playwright MCP always has --browser specified.
+	// Ensure playwright MCP always has --browser and PLAYWRIGHT_BROWSERS_PATH.
 	// Without --browser, playwright-mcp defaults to "chrome" which requires
 	// system-installed Google Chrome. Add --browser chromium as a fallback
 	// to guarantee browser availability.
 	fixPlaywrightBrowser(existingServers)
+	fixPlaywrightEnv(existingServers)
 
 	existing["mcpServers"] = existingServers
 
@@ -133,6 +134,9 @@ func defaultMCPConfig() map[string]any {
 			"playwright": map[string]any{
 				"command": "playwright-mcp",
 				"args":    []any{"--browser", "chromium", "--headless", "--no-sandbox"},
+				"env": map[string]any{
+					"PLAYWRIGHT_BROWSERS_PATH": "/ms-playwright",
+				},
 			},
 		},
 	}
@@ -164,6 +168,31 @@ func fixPlaywrightBrowser(servers map[string]any) {
 	// Prepend --browser chromium so the bundled Chromium is used as fallback.
 	cfg["args"] = append([]any{"--browser", "chromium"}, args...)
 	fmt.Fprintf(os.Stderr, "[setup] playwright MCP: added --browser chromium (no --browser flag found)\n")
+}
+
+// fixPlaywrightEnv ensures the playwright MCP server config includes
+// PLAYWRIGHT_BROWSERS_PATH in its env block. Without it, the MCP server
+// cannot find Chromium installed at /ms-playwright/ even though the
+// Dockerfile sets the env var — config beads or user-provided .mcp.json
+// may override the default config, losing the env section.
+func fixPlaywrightEnv(servers map[string]any) {
+	pw, ok := servers["playwright"]
+	if !ok {
+		return
+	}
+	cfg, ok := pw.(map[string]any)
+	if !ok {
+		return
+	}
+	env, ok := cfg["env"].(map[string]any)
+	if !ok {
+		env = make(map[string]any)
+		cfg["env"] = env
+	}
+	if _, ok := env["PLAYWRIGHT_BROWSERS_PATH"]; !ok {
+		env["PLAYWRIGHT_BROWSERS_PATH"] = "/ms-playwright"
+		fmt.Fprintf(os.Stderr, "[setup] playwright MCP: added PLAYWRIGHT_BROWSERS_PATH=/ms-playwright\n")
+	}
 }
 
 // appendDetectedPlugins auto-detects installed LSP servers and adds them

--- a/gasboat/controller/cmd/gb/setup_test.go
+++ b/gasboat/controller/cmd/gb/setup_test.go
@@ -313,6 +313,14 @@ func TestWriteMCPConfig_DoesNotOverrideExistingServer(t *testing.T) {
 	if len(args) != 3 || args[0] != "--browser" || args[1] != "chromium" || args[2] != "--custom" {
 		t.Errorf("expected [--browser chromium --custom], got args=%v", args)
 	}
+	// fixPlaywrightEnv adds PLAYWRIGHT_BROWSERS_PATH.
+	env, ok := pw["env"].(map[string]any)
+	if !ok {
+		t.Fatal("expected env to be added by fixPlaywrightEnv")
+	}
+	if env["PLAYWRIGHT_BROWSERS_PATH"] != "/ms-playwright" {
+		t.Errorf("expected PLAYWRIGHT_BROWSERS_PATH=/ms-playwright, got %v", env["PLAYWRIGHT_BROWSERS_PATH"])
+	}
 }
 
 func TestWriteMCPConfig_EmptyServers(t *testing.T) {
@@ -629,6 +637,14 @@ func TestDefaultMCPConfig_PlaywrightFound(t *testing.T) {
 	if servers["playwright"] == nil {
 		t.Error("expected playwright server entry")
 	}
+	pw := servers["playwright"].(map[string]any)
+	env, ok := pw["env"].(map[string]any)
+	if !ok {
+		t.Fatal("expected env key in playwright config")
+	}
+	if env["PLAYWRIGHT_BROWSERS_PATH"] != "/ms-playwright" {
+		t.Errorf("expected PLAYWRIGHT_BROWSERS_PATH=/ms-playwright, got %v", env["PLAYWRIGHT_BROWSERS_PATH"])
+	}
 }
 
 func TestDefaultMCPConfig_PlaywrightNotFound(t *testing.T) {
@@ -692,6 +708,57 @@ func TestFixPlaywrightBrowser_NoPlaywright(t *testing.T) {
 
 	// Should not panic or modify anything
 	fixPlaywrightBrowser(servers)
+
+	if _, ok := servers["playwright"]; ok {
+		t.Error("should not create playwright entry")
+	}
+}
+
+func TestFixPlaywrightEnv_AddsWhenMissing(t *testing.T) {
+	servers := map[string]any{
+		"playwright": map[string]any{
+			"command": "playwright-mcp",
+			"args":    []any{"--browser", "chromium"},
+		},
+	}
+
+	fixPlaywrightEnv(servers)
+
+	cfg := servers["playwright"].(map[string]any)
+	env, ok := cfg["env"].(map[string]any)
+	if !ok {
+		t.Fatal("expected env to be added")
+	}
+	if env["PLAYWRIGHT_BROWSERS_PATH"] != "/ms-playwright" {
+		t.Errorf("expected PLAYWRIGHT_BROWSERS_PATH=/ms-playwright, got %v", env["PLAYWRIGHT_BROWSERS_PATH"])
+	}
+}
+
+func TestFixPlaywrightEnv_SkipsWhenPresent(t *testing.T) {
+	servers := map[string]any{
+		"playwright": map[string]any{
+			"command": "playwright-mcp",
+			"env": map[string]any{
+				"PLAYWRIGHT_BROWSERS_PATH": "/custom/path",
+			},
+		},
+	}
+
+	fixPlaywrightEnv(servers)
+
+	cfg := servers["playwright"].(map[string]any)
+	env := cfg["env"].(map[string]any)
+	if env["PLAYWRIGHT_BROWSERS_PATH"] != "/custom/path" {
+		t.Errorf("expected custom path to be preserved, got %v", env["PLAYWRIGHT_BROWSERS_PATH"])
+	}
+}
+
+func TestFixPlaywrightEnv_NoPlaywright(t *testing.T) {
+	servers := map[string]any{
+		"other-server": map[string]any{"command": "foo"},
+	}
+
+	fixPlaywrightEnv(servers)
 
 	if _, ok := servers["playwright"]; ok {
 		t.Error("should not create playwright entry")

--- a/gasboat/images/agent/Dockerfile
+++ b/gasboat/images/agent/Dockerfile
@@ -282,6 +282,7 @@ ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
 RUN apt-get update && \
     npm install -g playwright@${PLAYWRIGHT_VERSION} @playwright/mcp && \
     npx playwright install --with-deps chromium && \
+    npx --package=@playwright/mcp playwright install chromium && \
     curl -fsSL https://dl.google.com/linux/linux_signing_key.pub \
       | gpg --dearmor -o /etc/apt/keyrings/google-chrome.gpg && \
     echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/google-chrome.gpg] https://dl.google.com/linux/chrome/deb/ stable main" \


### PR DESCRIPTION
## Summary
- Add `PLAYWRIGHT_BROWSERS_PATH=/ms-playwright` to the playwright MCP server env config generated by `gb setup claude`, ensuring the MCP server finds the pre-installed Chromium
- Add `fixPlaywrightEnv()` function that injects the env var even when config beads override the default MCP config (analogous to existing `fixPlaywrightBrowser()`)
- Install chromium for both the standalone `playwright` and `@playwright/mcp`'s bundled playwright version (they expect different revisions: v1208 vs v1212) in both the Dockerfile and RWX CI

## Root cause
`@playwright/mcp@0.0.68` depends on `playwright@1.59.0-alpha` which expects chromium revision 1212, but the agent image installed chromium v1208 (for `playwright@1.58.2`). Combined with the missing `PLAYWRIGHT_BROWSERS_PATH` in the MCP server config, this caused "Browser chromium is not installed" errors.

## Test plan
- [x] All existing `TestWriteMCPConfig_*` tests pass
- [x] All existing `TestFixPlaywrightBrowser_*` tests pass
- [x] New `TestFixPlaywrightEnv_*` tests (3 cases: adds when missing, skips when present, no-op without playwright)
- [x] Updated `TestDefaultMCPConfig_PlaywrightFound` to verify env is included
- [x] Full `go test ./...` passes
- [ ] Rebuild agent image and verify Playwright MCP can navigate

Closes kd-uag2n9cYc4, kd-zyH4TEC4rz

🤖 Generated with [Claude Code](https://claude.com/claude-code)