### PR TITLE
fix(gasboat/agent): install chromium for MCP's bundled playwright

### DIFF
--- a/.rwx/docker.yml
+++ b/.rwx/docker.yml
@@ -699,6 +699,7 @@ tasks:
 
       PATH=$OUT/usr/local/bin:$PATH npm install -g playwright@1.58.2 @playwright/mcp
       PLAYWRIGHT_BROWSERS_PATH=$OUT/ms-playwright PATH=$OUT/usr/local/bin:$PATH npx playwright install --with-deps chromium
+      PLAYWRIGHT_BROWSERS_PATH=$OUT/ms-playwright $OUT/usr/local/lib/node_modules/@playwright/mcp/node_modules/.bin/playwright install chromium
 
       # Capture chromium system deps for the agent image.
       # The dpkg before/after diff misses packages already in the RWX runner,

--- a/gasboat/.rwx/agent-playwright.lock
+++ b/gasboat/.rwx/agent-playwright.lock
@@ -1,6 +1,7 @@
 # Cache key for agent-install-playwright task.
 # Touch this file to force a rebuild of Playwright + Chromium + Chrome only.
-cache-epoch=4
+cache-epoch=5
 playwright=1.58.2
 # epoch 3: add Chrome for Testing browser, fix system deps, ldd sweep
 # epoch 4: install Google Chrome Stable via apt, fix usrmerge symlinks in push-agent
+# epoch 5: install MCP's own chromium revision (npx resolves global playwright, not MCP's bundled one)

--- a/gasboat/images/agent/Dockerfile
+++ b/gasboat/images/agent/Dockerfile
@@ -282,7 +282,7 @@ ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
 RUN apt-get update && \
     npm install -g playwright@${PLAYWRIGHT_VERSION} @playwright/mcp && \
     npx playwright install --with-deps chromium && \
-    npx --package=@playwright/mcp playwright install chromium && \
+    $(npm root -g)/@playwright/mcp/node_modules/.bin/playwright install chromium && \
     curl -fsSL https://dl.google.com/linux/linux_signing_key.pub \
       | gpg --dearmor -o /etc/apt/keyrings/google-chrome.gpg && \
     echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/google-chrome.gpg] https://dl.google.com/linux/chrome/deb/ stable main" \


### PR DESCRIPTION
## Summary

- `npx --package=@playwright/mcp playwright install chromium` was broken — npx resolves the global `playwright` binary (v1.58.2 → chromium-1208) instead of the one bundled with `@playwright/mcp` (v1.59.0-alpha → chromium-1212)
- Fixed both **Dockerfile** and **RWX CI** to call the MCP package's own playwright binary directly: `$(npm root -g)/@playwright/mcp/node_modules/.bin/playwright install chromium`
- Bumped playwright cache epoch to 5 to force a rebuild

## Root cause

`@playwright/mcp@0.0.68` depends on `playwright@1.59.0-alpha` which needs chromium v1212. The global install is `playwright@1.58.2` which needs chromium v1208. When `npx` sees `playwright` is already globally installed, it uses the global one regardless of the `--package` flag. The MCP server then fails at runtime with "Browser chromium is not installed".

## Test plan

- [x] Verified fix manually: installed MCP's chromium via the direct binary path, then `browser_navigate` to example.com succeeded
- [ ] RWX CI rebuild will validate the full image build path

🤖 Generated with [Claude Code](https://claude.com/claude-code)