### PR TITLE
fix(gasboat/bridge): unify card and thread routing for agent message delivery

### DIFF
--- a/gasboat/controller/cmd/slack-bridge/main.go
+++ b/gasboat/controller/cmd/slack-bridge/main.go
@@ -344,6 +344,12 @@ func main() {
 	// doesn't re-fire created events (prevents state flicker on restart).
 	dedup.CatchUpAgents(ctx, daemon, logger)
 
+	// Reconcile thread→agent mappings from active agent beads so thread
+	// replies reach agents that were spawned by a previous bridge instance.
+	if bot != nil {
+		bot.ReconcileThreadAgents(ctx)
+	}
+
 	// Start the shared SSE stream (delivers events to all watchers).
 	go func() {
 		if err := sseStream.Start(ctx); err != nil && ctx.Err() == nil {

--- a/gasboat/controller/internal/bridge/bot.go
+++ b/gasboat/controller/internal/bridge/bot.go
@@ -193,6 +193,38 @@ func NewBot(cfg BotConfig) *Bot {
 	return b
 }
 
+// ReconcileThreadAgents rebuilds the ThreadAgents mapping from active agent
+// beads that have slack_thread_channel/slack_thread_ts fields. This recovers
+// thread→agent associations that were lost during bridge restart (the mapping
+// is only set when the bridge instance itself spawns/respawns the agent).
+func (b *Bot) ReconcileThreadAgents(ctx context.Context) {
+	if b.state == nil || b.daemon == nil {
+		return
+	}
+	agents, err := b.daemon.ListAgentBeads(ctx)
+	if err != nil {
+		b.logger.Warn("reconcile thread agents: failed to list agents", "error", err)
+		return
+	}
+	var restored int
+	for _, a := range agents {
+		ch := a.Metadata["slack_thread_channel"]
+		ts := a.Metadata["slack_thread_ts"]
+		if ch == "" || ts == "" {
+			continue
+		}
+		agentName := extractAgentName(a.AgentName)
+		// Only set if not already mapped (don't overwrite fresh mappings).
+		if _, ok := b.state.GetThreadAgent(ch, ts); !ok {
+			_ = b.state.SetThreadAgent(ch, ts, agentName)
+			restored++
+		}
+	}
+	if restored > 0 {
+		b.logger.Info("reconciled thread agents from daemon", "restored", restored)
+	}
+}
+
 // API returns the underlying Slack API client for direct API calls.
 func (b *Bot) API() *slack.Client {
 	return b.api

--- a/gasboat/controller/internal/bridge/bot_agents.go
+++ b/gasboat/controller/internal/bridge/bot_agents.go
@@ -133,7 +133,10 @@ func (b *Bot) agentTaskTitle(ctx context.Context, agent string) string {
 
 // ensureAgentCard posts or retrieves the agent status card for threading.
 // Returns the card's message timestamp for use as threadTS.
-func (b *Bot) ensureAgentCard(ctx context.Context, agent, channelID string) (string, error) {
+// If inThreadTS is provided (non-empty), the card is posted as a reply in that
+// thread. This is used for thread-bound agents so the card lives inside the
+// agent's thread and getAgentByThread can match via ref.ThreadTS.
+func (b *Bot) ensureAgentCard(ctx context.Context, agent, channelID string, inThreadTS ...string) (string, error) {
 	b.mu.Lock()
 	if ref, ok := b.agentCards[agent]; ok && ref.ChannelID == channelID {
 		b.mu.Unlock()
@@ -153,15 +156,22 @@ func (b *Bot) ensureAgentCard(ctx context.Context, agent, channelID string) (str
 
 	taskTitle := b.agentTaskTitle(ctx, agent)
 	blocks := buildAgentCardBlocks(agent, pending, state, taskTitle, seen, b.coopmuxPublicURL, podName, imageTag, role)
-	cardChannel, ts, err := b.api.PostMessageContext(ctx, channelID,
+	opts := []slack.MsgOption{
 		slack.MsgOptionText(fmt.Sprintf("Agent: %s", extractAgentName(agent)), false),
 		slack.MsgOptionBlocks(blocks...),
-	)
+	}
+	// Post in-thread if a parent thread was specified.
+	var parentTS string
+	if len(inThreadTS) > 0 && inThreadTS[0] != "" {
+		parentTS = inThreadTS[0]
+		opts = append(opts, slack.MsgOptionTS(parentTS))
+	}
+	cardChannel, ts, err := b.api.PostMessageContext(ctx, channelID, opts...)
 	if err != nil {
 		return "", fmt.Errorf("post agent card: %w", err)
 	}
 
-	ref := MessageRef{ChannelID: cardChannel, Timestamp: ts, Agent: agent}
+	ref := MessageRef{ChannelID: cardChannel, Timestamp: ts, Agent: agent, ThreadTS: parentTS}
 
 	b.mu.Lock()
 	b.agentCards[agent] = ref
@@ -171,7 +181,7 @@ func (b *Bot) ensureAgentCard(ctx context.Context, agent, channelID string) (str
 		_ = b.state.SetAgentCard(agent, ref)
 	}
 
-	b.logger.Info("posted agent status card", "agent", agent, "channel", cardChannel, "ts", ts)
+	b.logger.Info("posted agent status card", "agent", agent, "channel", cardChannel, "ts", ts, "thread_ts", parentTS)
 	return ts, nil
 }
 
@@ -414,7 +424,15 @@ func (b *Bot) updateAgentCard(ctx context.Context, agent string) {
 		// full assignee path) by posting a card under the canonical identity.
 		if b.agentThreadingEnabled() {
 			channel := b.resolveChannel(agent)
-			if _, err := b.ensureAgentCard(ctx, agent, channel); err != nil {
+			// Thread-bound agents: post the card IN the agent's thread so that
+			// getAgentByThread can match via ref.ThreadTS. Without this, a card
+			// posted top-level is invisible to thread-reply routing.
+			var threadTS string
+			if ch, ts := b.resolveAgentThread(ctx, agent); ch != "" && ts != "" {
+				channel = ch
+				threadTS = ts
+			}
+			if _, err := b.ensureAgentCard(ctx, agent, channel, threadTS); err != nil {
 				b.logger.Error("failed to create agent card on state update",
 					"agent", agent, "error", err)
 			}

--- a/gasboat/controller/internal/bridge/bot_agents_notify_test.go
+++ b/gasboat/controller/internal/bridge/bot_agents_notify_test.go
@@ -766,3 +766,47 @@ func TestEnsureAgentCard_DifferentChannel_PostsNewCard(t *testing.T) {
 		t.Error("expected new card timestamp, got old one")
 	}
 }
+
+func TestEnsureAgentCard_InThread_SetsThreadTS(t *testing.T) {
+	daemon := newMockDaemon()
+
+	var mu sync.Mutex
+	var postedThreadTS string
+	slackSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/chat.postMessage" {
+			_ = r.ParseForm()
+			mu.Lock()
+			postedThreadTS = r.FormValue("thread_ts")
+			mu.Unlock()
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"ok": true, "channel": "C-THREAD", "ts": "8888.9999"})
+	}))
+	defer slackSrv.Close()
+
+	bot := newTestBot(daemon, slackSrv)
+
+	ts, err := bot.ensureAgentCard(context.Background(), "thread-agent", "C-THREAD", "1234.5678")
+	if err != nil {
+		t.Fatalf("ensureAgentCard: %v", err)
+	}
+	if ts != "8888.9999" {
+		t.Errorf("expected new timestamp 8888.9999, got %q", ts)
+	}
+
+	// Verify the card was posted in the thread.
+	mu.Lock()
+	defer mu.Unlock()
+	if postedThreadTS != "1234.5678" {
+		t.Errorf("expected thread_ts 1234.5678, got %q", postedThreadTS)
+	}
+
+	// Verify the cached ref has ThreadTS set.
+	ref, ok := bot.agentCards["thread-agent"]
+	if !ok {
+		t.Fatal("expected agent card to be cached")
+	}
+	if ref.ThreadTS != "1234.5678" {
+		t.Errorf("expected cached ThreadTS 1234.5678, got %q", ref.ThreadTS)
+	}
+}

--- a/gasboat/controller/internal/bridge/bot_mentions.go
+++ b/gasboat/controller/internal/bridge/bot_mentions.go
@@ -248,9 +248,11 @@ func (b *Bot) getAgentByThread(channelID, threadTS string) string {
 	}
 
 	// Check agentCards hot cache (agent card threads).
+	// Match on both ref.Timestamp (card is the thread parent) and
+	// ref.ThreadTS (card posted inside a thread — e.g. thread-bound agents).
 	b.mu.Lock()
 	for agent, ref := range b.agentCards {
-		if ref.ChannelID == channelID && ref.Timestamp == threadTS {
+		if ref.ChannelID == channelID && (ref.Timestamp == threadTS || ref.ThreadTS == threadTS) {
 			b.mu.Unlock()
 			return agent
 		}
@@ -260,7 +262,7 @@ func (b *Bot) getAgentByThread(channelID, threadTS string) string {
 	// Fall back to persisted agentCards state.
 	if b.state != nil {
 		for agent, ref := range b.state.AllAgentCards() {
-			if ref.ChannelID == channelID && ref.Timestamp == threadTS {
+			if ref.ChannelID == channelID && (ref.Timestamp == threadTS || ref.ThreadTS == threadTS) {
 				return agent
 			}
 		}

--- a/gasboat/controller/internal/bridge/bot_mentions_test.go
+++ b/gasboat/controller/internal/bridge/bot_mentions_test.go
@@ -198,6 +198,46 @@ func TestGetAgentByThread_ThreadAgents(t *testing.T) {
 			t.Errorf("got %q, want %q", got, "gasboat/crew/k8s")
 		}
 	})
+
+	t.Run("matches card posted in-thread via ThreadTS", func(t *testing.T) {
+		// Card posted as a reply in thread 5555.6666 — card's own timestamp
+		// is 5555.7777 but ThreadTS points to the parent thread.
+		b.mu.Lock()
+		b.agentCards["thread-bound-agent"] = MessageRef{
+			ChannelID: "C-thread",
+			Timestamp: "5555.7777", // card's own ts
+			ThreadTS:  "5555.6666", // parent thread ts
+			Agent:     "thread-bound-agent",
+		}
+		b.mu.Unlock()
+
+		// Should match when looking up the parent thread ts.
+		got := b.getAgentByThread("C-thread", "5555.6666")
+		if got != "thread-bound-agent" {
+			t.Errorf("got %q, want %q", got, "thread-bound-agent")
+		}
+
+		// Should also match via card's own ts (replies under the card itself).
+		got = b.getAgentByThread("C-thread", "5555.7777")
+		if got != "thread-bound-agent" {
+			t.Errorf("got %q, want %q", got, "thread-bound-agent")
+		}
+	})
+
+	t.Run("matches persisted card via ThreadTS", func(t *testing.T) {
+		// Store an in-thread card only in persisted state (not hot cache).
+		_ = state.SetAgentCard("persisted-thread-agent", MessageRef{
+			ChannelID: "C-persist",
+			Timestamp: "6666.7777",
+			ThreadTS:  "6666.5555",
+			Agent:     "persisted-thread-agent",
+		})
+
+		got := b.getAgentByThread("C-persist", "6666.5555")
+		if got != "persisted-thread-agent" {
+			t.Errorf("got %q, want %q", got, "persisted-thread-agent")
+		}
+	})
 }
 
 func TestResolveAgentFromText(t *testing.T) {

--- a/gasboat/controller/internal/bridge/bot_thread_test.go
+++ b/gasboat/controller/internal/bridge/bot_thread_test.go
@@ -607,3 +607,85 @@ func TestHandleThreadSpawn_ConcurrentMentionsSpawnOnce(t *testing.T) {
 		t.Errorf("expected exactly 1 agent bead from concurrent spawns, got %d", agentCount)
 	}
 }
+
+func TestReconcileThreadAgents(t *testing.T) {
+	daemon := newMockDaemon()
+
+	dir := t.TempDir()
+	state, err := NewStateManager(filepath.Join(dir, "state.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	b := &Bot{
+		daemon:     daemon,
+		state:      state,
+		logger:     slog.Default(),
+		agentCards: make(map[string]MessageRef),
+	}
+
+	t.Run("restores thread mappings from agent beads", func(t *testing.T) {
+		// Simulate an agent bead with thread fields (spawned by a previous bridge).
+		daemon.mu.Lock()
+		daemon.beads["bd-thread-agent"] = &beadsapi.BeadDetail{
+			ID:    "bd-thread-agent",
+			Title: "my-thread-agent",
+			Type:  "agent",
+			Fields: map[string]string{
+				"agent":                "my-thread-agent",
+				"role":                 "thread",
+				"project":              "gasboat",
+				"slack_thread_channel": "C-test",
+				"slack_thread_ts":      "1111.2222",
+			},
+		}
+		daemon.mu.Unlock()
+
+		b.ReconcileThreadAgents(context.Background())
+
+		agent, ok := state.GetThreadAgent("C-test", "1111.2222")
+		if !ok {
+			t.Fatal("expected thread→agent mapping to be restored")
+		}
+		if agent != "my-thread-agent" {
+			t.Errorf("got %q, want %q", agent, "my-thread-agent")
+		}
+	})
+
+	t.Run("does not overwrite existing mappings", func(t *testing.T) {
+		// Pre-set a mapping for the same thread.
+		_ = state.SetThreadAgent("C-test", "1111.2222", "existing-agent")
+
+		b.ReconcileThreadAgents(context.Background())
+
+		agent, _ := state.GetThreadAgent("C-test", "1111.2222")
+		if agent != "existing-agent" {
+			t.Errorf("existing mapping was overwritten: got %q, want %q", agent, "existing-agent")
+		}
+	})
+
+	t.Run("skips agents without thread fields", func(t *testing.T) {
+		// Clear all previous state and beads.
+		state.ClearAllThreadAgents()
+		daemon.mu.Lock()
+		daemon.beads = map[string]*beadsapi.BeadDetail{
+			"bd-card-agent": {
+				ID:    "bd-card-agent",
+				Title: "card-only-agent",
+				Type:  "agent",
+				Fields: map[string]string{
+					"agent":   "card-only-agent",
+					"role":    "crew",
+					"project": "gasboat",
+				},
+			},
+		}
+		daemon.mu.Unlock()
+
+		b.ReconcileThreadAgents(context.Background())
+
+		if len(state.AllThreadAgents()) != 0 {
+			t.Errorf("expected no thread agents, got %d", len(state.AllThreadAgents()))
+		}
+	})
+}


### PR DESCRIPTION
## Summary

- `getAgentByThread` now matches on `ref.ThreadTS` in addition to `ref.Timestamp`, so cards posted inside a thread (as replies) are found when looking up the parent thread
- `updateAgentCard` posts cards inside the agent's thread for thread-bound agents instead of as top-level messages, ensuring the card's ThreadTS matches the thread
- `ReconcileThreadAgents` rebuilds the ThreadAgents mapping from active agent beads on startup, recovering associations set by a previous bridge instance

## Root Cause

After a bridge restart, thread→agent mappings were lost because they were only set when the bridge instance itself spawned/respawned the agent. If a different bridge instance created the mapping, the new instance had no way to recover it. Additionally, `updateAgentCard` would bypass the thread-bound check in `NotifyAgentSpawn` and post cards as top-level messages, making them invisible to thread-reply routing.

## Test plan

- [x] `go build ./cmd/slack-bridge/` — compiles
- [x] `go build ./cmd/controller/` — compiles
- [x] `go test ./internal/bridge/...` — all tests pass (22.7s)
- [x] `helm lint gasboat/helm/gasboat/` — passes
- [ ] Verify in staging: restart bridge, check thread agents are reconciled from agent beads
- [ ] Verify: reply in agent card thread routes to the agent after bridge restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)