### PR TITLE
fix(bridge): route agent card to spawn channel

### DIFF
--- a/gasboat/controller/internal/bridge/bot.go
+++ b/gasboat/controller/internal/bridge/bot.go
@@ -70,7 +70,8 @@ type Bot struct {
 	agentPodName  map[string]string    // agent identity → pod hostname (coopmux session ID)
 	agentImageTag map[string]string   // agent identity → deployed image tag
 	agentRole     map[string]string   // agent identity → role (e.g., "crew", "lead", "ops")
-	agentProject  map[string]string   // agent identity → project name (for channel routing)
+	agentProject      map[string]string // agent identity → project name (for channel routing)
+	agentSpawnChannel map[string]string // agent identity → Slack channel where /spawn was issued
 
 	// TTL-cached project→primary channel mapping (refreshed every projectChannelCacheTTL).
 	projectChannelCache   map[string]string // project name → primary Slack channel ID
@@ -156,8 +157,9 @@ func NewBot(cfg BotConfig) *Bot {
 		agentPodName:     make(map[string]string),
 		agentImageTag:    make(map[string]string),
 		agentRole:        make(map[string]string),
-		agentProject:     make(map[string]string),
-		threadSpawnMsgs:  make(map[string]MessageRef),
+		agentProject:      make(map[string]string),
+		agentSpawnChannel: make(map[string]string),
+		threadSpawnMsgs:   make(map[string]MessageRef),
 		beadMsgs:         make(map[string]MessageRef),
 		spawnInFlight:    make(map[string]bool),
 		lastThreadNudge:    make(map[string]time.Time),

--- a/gasboat/controller/internal/bridge/bot_agents.go
+++ b/gasboat/controller/internal/bridge/bot_agents.go
@@ -217,9 +217,13 @@ func (b *Bot) NotifyAgentSpawn(ctx context.Context, bead BeadEvent) {
 	if project := bead.Fields["project"]; project != "" {
 		b.agentProject[agent] = project
 	}
+	if spawnCh := bead.Fields["slack_spawn_channel"]; spawnCh != "" {
+		b.agentSpawnChannel[agent] = spawnCh
+	}
 	b.mu.Unlock()
 
 	// Fetch pod_name from the agent bead notes for coopmux terminal linking.
+	// Also picks up slack_spawn_channel if the created event didn't have it.
 	b.fetchAndCachePodName(ctx, agent)
 
 	// Thread-bound agents: skip the spawn notification here because
@@ -643,6 +647,9 @@ func (b *Bot) fetchAndCachePodName(ctx context.Context, agent string) {
 	if project != "" {
 		b.agentProject[agent] = project
 	}
+	if spawnCh := detail.Fields["slack_spawn_channel"]; spawnCh != "" {
+		b.agentSpawnChannel[agent] = spawnCh
+	}
 	b.mu.Unlock()
 }
 
@@ -671,14 +678,26 @@ func extractAgentProject(identity string) string {
 // resolveChannel returns the target Slack channel for an agent.
 // Priority:
 //  1. Router override/pattern match (if router configured)
-//  2. Agent's project primary channel (first channel in project bead's slack_channel)
-//  3. Router default / bot default channel
+//  2. Spawn channel (the channel where /spawn was issued)
+//  3. Agent's project primary channel (first channel in project bead's slack_channel)
+//  4. Router default / bot default channel
 func (b *Bot) resolveChannel(agent string) string {
 	var routerResult RouteResult
 	if b.router != nil && agent != "" {
 		routerResult = b.router.Resolve(agent)
 		if routerResult.ChannelID != "" && !routerResult.IsDefault {
 			return routerResult.ChannelID
+		}
+	}
+
+	// Prefer the channel where the agent was spawned, so the card appears
+	// in the same channel as the /spawn command.
+	if agent != "" {
+		b.mu.Lock()
+		spawnCh := b.agentSpawnChannel[agent]
+		b.mu.Unlock()
+		if spawnCh != "" {
+			return spawnCh
 		}
 	}
 

--- a/gasboat/controller/internal/bridge/bot_commands.go
+++ b/gasboat/controller/internal/bridge/bot_commands.go
@@ -304,12 +304,20 @@ func (b *Bot) spawnAndRespond(ctx context.Context, cmd slack.SlashCommand, agent
 
 	b.logger.Info("spawned agent via Slack", "agent", agentName, "project", project, "task", taskID, "role", role, "prompt", customPrompt, "bead", beadID, "user", cmd.UserID)
 
-	// Best-effort: store the Slack user ID of the spawner on the agent bead
-	// so decision notifications can @mention the right person.
-	if cmd.UserID != "" {
-		_ = b.daemon.UpdateBeadFields(ctx, beadID, map[string]string{
-			"slack_user_id": cmd.UserID,
-		})
+	// Best-effort: store the Slack user ID and source channel on the agent
+	// bead so decision notifications can @mention the right person and the
+	// agent card is posted to the channel where /spawn was issued.
+	{
+		fields := map[string]string{}
+		if cmd.UserID != "" {
+			fields["slack_user_id"] = cmd.UserID
+		}
+		if cmd.ChannelID != "" {
+			fields["slack_spawn_channel"] = cmd.ChannelID
+		}
+		if len(fields) > 0 {
+			_ = b.daemon.UpdateBeadFields(ctx, beadID, fields)
+		}
 	}
 
 	text := fmt.Sprintf(":rocket: Spawning agent *%s*", agentName)

--- a/gasboat/controller/internal/bridge/bot_spawn_test.go
+++ b/gasboat/controller/internal/bridge/bot_spawn_test.go
@@ -829,6 +829,32 @@ func TestHandleSpawnCommand_ProjectFlag_WithRole(t *testing.T) {
 	}
 }
 
+func TestHandleSpawnCommand_StoresSpawnChannel(t *testing.T) {
+	daemon := newMockDaemon()
+	daemon.seedProjectWithChannel("gasboat", "C-GASBOAT")
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+
+	bot := newTestBot(daemon, slackSrv)
+
+	bot.handleSpawnCommand(context.Background(), slack.SlashCommand{
+		Command:   "/spawn",
+		Text:      "",
+		ChannelID: "C-GASBOAT",
+		UserID:    "U456",
+	})
+
+	agentBeads := filterAgentBeads(daemon.beads)
+	if len(agentBeads) != 1 {
+		t.Fatalf("expected 1 agent bead created, got %d", len(agentBeads))
+	}
+	for _, b := range agentBeads {
+		if b.Fields["slack_spawn_channel"] != "C-GASBOAT" {
+			t.Errorf("expected slack_spawn_channel=C-GASBOAT, got %q", b.Fields["slack_spawn_channel"])
+		}
+	}
+}
+
 func TestHandleSpawnCommand_ProjectFlag_NoChannel(t *testing.T) {
 	daemon := newMockDaemon()
 	daemon.seedProject("gasboat")
@@ -853,6 +879,70 @@ func TestHandleSpawnCommand_ProjectFlag_NoChannel(t *testing.T) {
 		if b.Fields["project"] != "gasboat" {
 			t.Errorf("expected project=gasboat (from --project in unmapped channel), got %s", b.Fields["project"])
 		}
+	}
+}
+
+// --- resolveChannel spawn-channel-aware tests ---
+
+func TestResolveChannel_SpawnChannel_TakesPrecedenceOverProjectPrimary(t *testing.T) {
+	daemon := newMockDaemon()
+	// Project has C-PRIMARY as its first (primary) channel.
+	daemon.seedProjectWithChannel("monorepo", "C-PRIMARY")
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+
+	bot := newTestBot(daemon, slackSrv)
+	bot.channel = "C-DEFAULT"
+
+	bot.agentProject["my-agent"] = "monorepo"
+	// Agent was spawned from C-GASBOATS (a different channel than the primary).
+	bot.agentSpawnChannel["my-agent"] = "C-GASBOATS"
+
+	result := bot.resolveChannel("my-agent")
+	if result != "C-GASBOATS" {
+		t.Errorf("expected C-GASBOATS (spawn channel > project primary), got %q", result)
+	}
+}
+
+func TestResolveChannel_SpawnChannel_NoSpawnChannel_FallsBackToProject(t *testing.T) {
+	daemon := newMockDaemon()
+	daemon.seedProjectWithChannel("gasboat", "C-GASBOAT")
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+
+	bot := newTestBot(daemon, slackSrv)
+	bot.channel = "C-DEFAULT"
+
+	bot.agentProject["my-agent"] = "gasboat"
+	// No spawn channel set — should fall back to project primary.
+
+	result := bot.resolveChannel("my-agent")
+	if result != "C-GASBOAT" {
+		t.Errorf("expected C-GASBOAT (project primary, no spawn channel), got %q", result)
+	}
+}
+
+func TestResolveChannel_RouterOverride_TakesPrecedenceOverSpawnChannel(t *testing.T) {
+	daemon := newMockDaemon()
+	daemon.seedProjectWithChannel("gasboat", "C-GASBOAT")
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+
+	bot := newTestBot(daemon, slackSrv)
+	bot.channel = "C-DEFAULT"
+	bot.router = NewRouter(RouterConfig{
+		DefaultChannel: "C-ROUTER-DEFAULT",
+		Overrides: map[string]string{
+			"my-agent": "C-OVERRIDE",
+		},
+	})
+
+	bot.agentProject["my-agent"] = "gasboat"
+	bot.agentSpawnChannel["my-agent"] = "C-GASBOATS"
+
+	result := bot.resolveChannel("my-agent")
+	if result != "C-OVERRIDE" {
+		t.Errorf("expected C-OVERRIDE (router override > spawn channel), got %q", result)
 	}
 }
 

--- a/gasboat/controller/internal/bridge/bot_start_test.go
+++ b/gasboat/controller/internal/bridge/bot_start_test.go
@@ -31,8 +31,9 @@ func newTestBot(daemon BeadClient, slackSrv *httptest.Server) *Bot {
 		agentPodName:    make(map[string]string),
 		agentImageTag:   make(map[string]string),
 		agentRole:       make(map[string]string),
-		agentProject:    make(map[string]string),
-		threadSpawnMsgs: make(map[string]MessageRef),
+		agentProject:      make(map[string]string),
+		agentSpawnChannel: make(map[string]string),
+		threadSpawnMsgs:   make(map[string]MessageRef),
 		spawnInFlight:      make(map[string]bool),
 		conciergeDebouncer: newConciergeDebouncer(),
 	}


### PR DESCRIPTION
## Summary

- When `/spawn` is issued from a Slack channel that maps to a project with multiple channels, the agent card was always posted to the project's **first** (primary) channel instead of the channel where the command was run
- Now stores `slack_spawn_channel` on the agent bead and uses it as the preferred routing target in `resolveChannel()`
- Priority order: router override > spawn channel > project primary > default

## Root Cause

`resolveChannel()` used `projectPrimaryChannel()` which returns `SlackChannels[0]` — the first channel in the project bead's `slack_channel` field. For projects with multiple channels (e.g. monorepo mapped to both `C02PKVB1KNF` and the gasboats channel), the card always went to the first one regardless of where `/spawn` was run.

## Test plan

- [x] `TestResolveChannel_SpawnChannel_TakesPrecedenceOverProjectPrimary` — spawn channel wins over project primary
- [x] `TestResolveChannel_SpawnChannel_NoSpawnChannel_FallsBackToProject` — graceful fallback when no spawn channel
- [x] `TestResolveChannel_RouterOverride_TakesPrecedenceOverSpawnChannel` — router override still wins
- [x] `TestHandleSpawnCommand_StoresSpawnChannel` — /spawn stores source channel on bead
- [x] All existing resolveChannel and spawn tests pass (17 tests)
- [x] Full controller test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)