### PR TITLE
feat(agent-image): bake fonts into agent image for Playwright rendering

### DIFF
--- a/gasboat/images/agent/Dockerfile
+++ b/gasboat/images/agent/Dockerfile
@@ -287,7 +287,8 @@ RUN apt-get update && \
       | gpg --dearmor -o /etc/apt/keyrings/google-chrome.gpg && \
     echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/google-chrome.gpg] https://dl.google.com/linux/chrome/deb/ stable main" \
       > /etc/apt/sources.list.d/google-chrome.list && \
-    apt-get update && apt-get install -y --no-install-recommends google-chrome-stable && \
+    apt-get update && apt-get install -y --no-install-recommends google-chrome-stable \
+      fonts-noto-core fontconfig && \
     apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* && \
     npm cache clean --force && \
     chmod -R 777 ${PLAYWRIGHT_BROWSERS_PATH}


### PR DESCRIPTION
## Summary

Gasboat agent containers lack system fonts, causing Playwright MCP screenshots to render as blank grey rectangles and snapshots to time out on heavy SPAs.

This adds `fonts-noto-core` and `fontconfig` to the existing Chrome `apt-get install` step in the agent Dockerfile — a 1-line diff that eliminates the need for per-session manual font setup (Phase 0 of the E2E repro formula).

## Changes

- `gasboat/images/agent/Dockerfile`: Added `fonts-noto-core fontconfig` to the Playwright/Chrome apt-get install line

## What this fixes

- Blank/grey Playwright screenshots in agent containers
- Snapshot timeouts on font-heavy pages
- Removes need for manual `~/.local/share/fonts` setup in every session

## Test plan

- [ ] Build the image: `docker build --target agent -t gasboat-agent:test -f gasboat/images/agent/Dockerfile .`
- [ ] Run a container and verify fonts exist: `fc-list | grep -i noto`
- [ ] Take a Playwright screenshot of any web page and confirm text renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)