### PR TITLE
fix(agent): bake fonts and add viewport-size for Playwright

### DIFF
--- a/.rwx/docker.yml
+++ b/.rwx/docker.yml
@@ -717,14 +717,14 @@ tasks:
         libcairo2 libcups2t64 libdbus-1-3 libdrm2 libgbm1 libglib2.0-0t64 \
         libnspr4 libnss3 libpango-1.0-0 libx11-6 libxcb1 \
         libxcomposite1 libxdamage1 libxext6 libxfixes3 libxkbcommon0 \
-        libxrandr2 fonts-noto-color-emoji libfontconfig1 libfreetype6 \
+        libxrandr2 fonts-noto-color-emoji fonts-noto-core libfontconfig1 libfreetype6 \
         libsqlite3-0 libavahi-client3
       # Copy dpkg-managed files (use -a to preserve symlinks)
       for pkg in libasound2t64 libatk-bridge2.0-0t64 libatk1.0-0t64 libatspi2.0-0t64 \
           libcairo2 libcups2t64 libdbus-1-3 libdrm2 libgbm1 libglib2.0-0t64 \
           libnspr4 libnss3 libpango-1.0-0 libx11-6 libxcb1 \
           libxcomposite1 libxdamage1 libxext6 libxfixes3 libxkbcommon0 \
-          libxrandr2 libfontconfig1 libfreetype6 fonts-noto-color-emoji \
+          libxrandr2 libfontconfig1 libfreetype6 fonts-noto-color-emoji fonts-noto-core \
           libsqlite3-0 libavahi-client3; do
         dpkg -L "$pkg" 2>/dev/null | while read -r f; do
           [ -e "$f" ] || continue

--- a/gasboat/.rwx/agent-playwright.lock
+++ b/gasboat/.rwx/agent-playwright.lock
@@ -1,7 +1,8 @@
 # Cache key for agent-install-playwright task.
 # Touch this file to force a rebuild of Playwright + Chromium + Chrome only.
-cache-epoch=5
+cache-epoch=6
 playwright=1.58.2
 # epoch 3: add Chrome for Testing browser, fix system deps, ldd sweep
 # epoch 4: install Google Chrome Stable via apt, fix usrmerge symlinks in push-agent
 # epoch 5: install MCP's own chromium revision (npx resolves global playwright, not MCP's bundled one)
+# epoch 6: add fonts-noto-core for Playwright text rendering

--- a/gasboat/controller/cmd/gb/setup_config.go
+++ b/gasboat/controller/cmd/gb/setup_config.go
@@ -86,6 +86,7 @@ func writeMCPConfig(workspace string, config map[string]any) error {
 	// to guarantee browser availability.
 	fixPlaywrightBrowser(existingServers)
 	fixPlaywrightEnv(existingServers)
+	fixPlaywrightViewport(existingServers)
 
 	existing["mcpServers"] = existingServers
 
@@ -133,7 +134,7 @@ func defaultMCPConfig() map[string]any {
 		"mcpServers": map[string]any{
 			"playwright": map[string]any{
 				"command": "playwright-mcp",
-				"args":    []any{"--browser", "chromium", "--headless", "--no-sandbox"},
+				"args":    []any{"--browser", "chromium", "--headless", "--no-sandbox", "--viewport-size", "1280,720"},
 				"env": map[string]any{
 					"PLAYWRIGHT_BROWSERS_PATH": "/ms-playwright",
 				},
@@ -193,6 +194,31 @@ func fixPlaywrightEnv(servers map[string]any) {
 		env["PLAYWRIGHT_BROWSERS_PATH"] = "/ms-playwright"
 		fmt.Fprintf(os.Stderr, "[setup] playwright MCP: added PLAYWRIGHT_BROWSERS_PATH=/ms-playwright\n")
 	}
+}
+
+// fixPlaywrightViewport ensures the playwright MCP server config includes
+// a --viewport-size flag. Without it, headless Chromium starts with a null
+// viewport, causing screenshots to be 0x0 or blank on heavy SPAs.
+func fixPlaywrightViewport(servers map[string]any) {
+	pw, ok := servers["playwright"]
+	if !ok {
+		return
+	}
+	cfg, ok := pw.(map[string]any)
+	if !ok {
+		return
+	}
+	args, ok := cfg["args"].([]any)
+	if !ok {
+		return
+	}
+	for _, a := range args {
+		if s, ok := a.(string); ok && s == "--viewport-size" {
+			return // already has --viewport-size flag
+		}
+	}
+	cfg["args"] = append(args, "--viewport-size", "1280,720")
+	fmt.Fprintf(os.Stderr, "[setup] playwright MCP: added --viewport-size 1280,720\n")
 }
 
 // appendDetectedPlugins auto-detects installed LSP servers and adds them

--- a/gasboat/controller/cmd/gb/setup_test.go
+++ b/gasboat/controller/cmd/gb/setup_test.go
@@ -309,9 +309,11 @@ func TestWriteMCPConfig_DoesNotOverrideExistingServer(t *testing.T) {
 	args := pw["args"].([]any)
 	// Existing server is preserved (not overwritten by new config).
 	// fixPlaywrightBrowser adds --browser chromium since the existing
-	// config doesn't specify --browser.
-	if len(args) != 3 || args[0] != "--browser" || args[1] != "chromium" || args[2] != "--custom" {
-		t.Errorf("expected [--browser chromium --custom], got args=%v", args)
+	// config doesn't specify --browser. fixPlaywrightViewport adds
+	// --viewport-size 1280,720.
+	if len(args) != 5 || args[0] != "--browser" || args[1] != "chromium" || args[2] != "--custom" ||
+		args[3] != "--viewport-size" || args[4] != "1280,720" {
+		t.Errorf("expected [--browser chromium --custom --viewport-size 1280,720], got args=%v", args)
 	}
 	// fixPlaywrightEnv adds PLAYWRIGHT_BROWSERS_PATH.
 	env, ok := pw["env"].(map[string]any)
@@ -762,6 +764,43 @@ func TestFixPlaywrightEnv_NoPlaywright(t *testing.T) {
 
 	if _, ok := servers["playwright"]; ok {
 		t.Error("should not create playwright entry")
+	}
+}
+
+func TestFixPlaywrightViewport_AddsWhenMissing(t *testing.T) {
+	servers := map[string]any{
+		"playwright": map[string]any{
+			"command": "playwright-mcp",
+			"args":    []any{"--browser", "chromium", "--headless"},
+		},
+	}
+
+	fixPlaywrightViewport(servers)
+
+	cfg := servers["playwright"].(map[string]any)
+	args := cfg["args"].([]any)
+	if len(args) != 5 {
+		t.Fatalf("expected 5 args, got %d: %v", len(args), args)
+	}
+	if args[3] != "--viewport-size" || args[4] != "1280,720" {
+		t.Errorf("expected --viewport-size 1280,720 appended, got %v %v", args[3], args[4])
+	}
+}
+
+func TestFixPlaywrightViewport_SkipsWhenPresent(t *testing.T) {
+	servers := map[string]any{
+		"playwright": map[string]any{
+			"command": "playwright-mcp",
+			"args":    []any{"--viewport-size", "1920,1080"},
+		},
+	}
+
+	fixPlaywrightViewport(servers)
+
+	cfg := servers["playwright"].(map[string]any)
+	args := cfg["args"].([]any)
+	if len(args) != 2 {
+		t.Fatalf("expected 2 args (unchanged), got %d: %v", len(args), args)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add `fonts-noto-core` to RWX CI playwright task so the agent image has actual text fonts (not just emoji). Without fonts, Chromium renders text at 0px height → blank screenshots.
- Add `--viewport-size 1280,720` to default MCP config and new `fixPlaywrightViewport()` function to inject it into existing configs. Without this, headless Chromium starts with a null viewport.
- Bump playwright cache epoch to 6.

## Test plan

- [x] All Go tests pass (including new viewport tests)
- [ ] Agent screenshots render text correctly after image rebuild
- [ ] MCP config includes `--viewport-size` on agent startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)