### PR TITLE
refactor(gasboat): eliminate KV store for config entries

### DIFF
--- a/gasboat/controller/internal/bridge/init_test.go
+++ b/gasboat/controller/internal/bridge/init_test.go
@@ -51,6 +51,7 @@ func findBead(beads []*beadsapi.BeadDetail, title string, labels []string) *bead
 	return nil
 }
 
+
 // findConfigBeadDescription finds a config bead by title and labels and returns
 // its description. Calls t.Fatal if not found.
 func findConfigBeadDescription(t *testing.T, beads []*beadsapi.BeadDetail, title string, labels []string) string {


### PR DESCRIPTION
## Summary

### Phase 1: Stop dual-writing config entries to KV (kd-yUJMq0VlG8)
- Stop writing `config:*` entries (nudge-prompts, claude-instructions) to the KV store during `EnsureConfigs()` startup
- Config entries are consumed exclusively via config beads through `ResolveConfigBeads()` — the KV writes were redundant
- `type:*`, `view:*`, and `context:*` entries continue to be written to KV (daemon still uses them)
- Update 3 tests to verify config entries via config beads instead of KV store

### Phase 2: Remove deprecated KV client methods (kd-N6q173cWwT)
- Remove `GetConfig()` and `DeleteConfig()` from `beadsapi.Client` — no callers remain
- Retain `ListConfigs()` (still used by `gb config migrate` to scan legacy entries)
- Updated deprecation comment on `ListConfigs`

Part of the KV store elimination epic (kd-HGhv7ko00h).

## Test plan

- [x] All bridge tests pass (`go test ./internal/bridge/...`)
- [x] All controller tests pass (`go test ./...`)
- [x] Controller and slack-bridge binaries compile
- [ ] Deploy and verify `gb prime`, `gb setup claude`, `gb nudge-prompt` still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)