### PR TITLE
feat(kbeads): migrate kd view/context/watch to config beads

### DIFF
--- a/kbeads/cmd/kd/context_cmd.go
+++ b/kbeads/cmd/kd/context_cmd.go
@@ -35,13 +35,13 @@ var contextCmd = &cobra.Command{
 		name := args[0]
 
 		// 1. Fetch the context config.
-		config, err := resolveConfigBead(context.Background(), "context:"+name)
+		ctxCfg, err := resolveConfigBead(context.Background(), "context:"+name)
 		if err != nil {
 			return fmt.Errorf("getting context config %q: %w", name, err)
 		}
 
 		var cc contextConfig
-		if err := json.Unmarshal(config.Value, &cc); err != nil {
+		if err := json.Unmarshal(ctxCfg.Value, &cc); err != nil {
 			return fmt.Errorf("parsing context config %q: %w", name, err)
 		}
 

--- a/kbeads/cmd/kd/view.go
+++ b/kbeads/cmd/kd/view.go
@@ -49,13 +49,13 @@ var viewCmd = &cobra.Command{
 		limitOverride, _ := cmd.Flags().GetInt("limit")
 
 		// 1. Fetch the view config.
-		config, err := resolveConfigBead(context.Background(), "view:"+name)
+		cfg, err := resolveConfigBead(context.Background(), "view:"+name)
 		if err != nil {
 			return fmt.Errorf("getting view config %q: %w", name, err)
 		}
 
 		var vc viewConfig
-		if err := json.Unmarshal(config.Value, &vc); err != nil {
+		if err := json.Unmarshal(cfg.Value, &vc); err != nil {
 			return fmt.Errorf("parsing view config %q: %w", name, err)
 		}
 

--- a/kbeads/cmd/kd/watch.go
+++ b/kbeads/cmd/kd/watch.go
@@ -27,13 +27,13 @@ var watchCmd = &cobra.Command{
 		once, _ := cmd.Flags().GetBool("once")
 
 		// 1. Fetch the view config.
-		config, err := resolveConfigBead(context.Background(), "view:"+name)
+		cfg, err := resolveConfigBead(context.Background(), "view:"+name)
 		if err != nil {
 			return fmt.Errorf("getting view config %q: %w", name, err)
 		}
 
 		var vc viewConfig
-		if err := json.Unmarshal(config.Value, &vc); err != nil {
+		if err := json.Unmarshal(cfg.Value, &vc); err != nil {
 			return fmt.Errorf("parsing view config %q: %w", name, err)
 		}
 


### PR DESCRIPTION
## Summary

- Migrate `kd view`, `kd context`, and `kd watch` commands to resolve configs from config beads (via `ListBeads` with `type=config`) instead of the legacy KV store (`GetConfig`)
- Add `resolveConfigBeads()` helper that fetches all open config beads and caches them as a map, with fallback to `GetConfig` for backward compatibility during rollout
- Update `EnsureConfigs` in gasboat controller to also create config beads for `view:*` and `context:*` entries (alongside KV writes), so kd commands can resolve them
- Stop writing `config:*` entries to KV (only config beads) — aligns with PR #58
- Extend `parseConfigKey` to handle `view:*`/`context:*` keys (full key as title, `["global"]` labels)

This is a prerequisite for removing the KV config endpoints entirely (epic kd-HGhv7ko00h).

## Test plan

- [x] All gasboat controller tests pass (`go test ./...`)
- [x] All kbeads tests pass (`go test ./...`)
- [x] Both binaries compile
- [ ] Deploy and verify `kd view agents:active`, `kd context crew`, `kd watch agents:active` work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)