### PR TITLE
docs(kbeads): remove KV store references from docs and advice

### DIFF
--- a/gasboat/controller/internal/bridge/init_prompts.go
+++ b/gasboat/controller/internal/bridge/init_prompts.go
@@ -1,7 +1,6 @@
 package bridge
 
-// configBeadEntries returns the config:* entries that are seeded as both
-// KV configs (for backward compat) and config beads (for ResolveConfigBeads).
+// configBeadEntries returns the config:* entries that are seeded as config beads.
 // These are merged into the main configs() map in init.go.
 func configBeadEntries() map[string]any {
 	return map[string]any{

--- a/kbeads/CLAUDE.md
+++ b/kbeads/CLAUDE.md
@@ -4,7 +4,7 @@ Beads is an event-driven work-tracking system. It manages hierarchical work item
 
 ## kd vs gb
 
-kd handles **data operations**: bead CRUD (create, show, list, close), deps, labels, comments, views, jacks, config, remotes, and `kd serve`. Agent **orchestration** commands (agent lifecycle, decisions, gates, hooks, bus emit, mail, prime, yield, ready, setup, advice, news) have moved to `gb` (gasboat CLI). Running deprecated kd commands prints a notice pointing to gb.
+kd handles **data operations**: bead CRUD (create, show, list, close), deps, labels, comments, views, jacks, remotes, and `kd serve`. Agent **orchestration** commands (agent lifecycle, decisions, gates, hooks, bus emit, mail, prime, yield, ready, setup, advice, news) have moved to `gb` (gasboat CLI). Running deprecated kd commands prints a notice pointing to gb.
 
 ## Key concepts
 
@@ -14,7 +14,7 @@ kd handles **data operations**: bead CRUD (create, show, list, close), deps, lab
 - **Store** — persistence interface (`internal/store/store.go`) with a PostgreSQL implementation. All mutations are wrapped in transactions and recorded as events.
 - **Events** — every mutation records an event row in Postgres and publishes to an event bus via the `Publisher` interface (`internal/events`). Publishing is optional; a no-op publisher is used when no bus is configured.
 - **IDs** — nanoid format, prefixed `kd-` (see `internal/idgen`).
-- **Type configuration** — bead types are extensible. Built-in types are defined in `internal/server/config.go`; custom types are registered via `SetConfig` with key `type:<name>`. Config is defined by `TypeConfig` / `FieldDef` in `internal/model/type_config.go`. Legacy type names `template` and `bundle` are aliased to `formula` and `molecule` at the API layer (see `model.TypeAliases`).
+- **Type configuration** — bead types are extensible. Built-in types are defined in `internal/server/config.go` as the `builtinConfigs` map. Config is defined by `TypeConfig` / `FieldDef` in `internal/model/type_config.go`. Legacy type names `template` and `bundle` are aliased to `formula` and `molecule` at the API layer (see `model.TypeAliases`).
 
 ## Directory structure
 

--- a/kbeads/README.md
+++ b/kbeads/README.md
@@ -32,10 +32,9 @@ kd dep kd-abc123 add kd-def456
 kd search "login"
 ```
 
-Custom types can be registered at runtime:
+Built-in types (task, bug, feature, epic, decision, etc.) are defined in `internal/server/config.go`. Example:
 
 ```sh
-kd config create type:decision '{"kind":"issue","fields":[{"name":"outcome","type":"enum","values":["approved","rejected","pending"],"required":true}]}'
 kd create "Approve Q1 roadmap" --type decision --fields '{"outcome":"pending"}'
 ```
 

--- a/kbeads/internal/eventbus/external_handler.go
+++ b/kbeads/internal/eventbus/external_handler.go
@@ -11,11 +11,9 @@ import (
 )
 
 // HandlerConfigPrefix is the config key prefix for persisted external handlers.
-// Config table entries with this prefix are loaded as external handlers.
 const HandlerConfigPrefix = "bus.handler."
 
 // ExternalHandlerConfig is the serializable configuration for an external handler.
-// Stored in the config table as JSON under keys like "bus.handler.<id>".
 type ExternalHandlerConfig struct {
 	ID       string   `json:"id"`
 	Command  string   `json:"command"`           // Shell command to run
@@ -113,7 +111,7 @@ func (h *ExternalHandler) Handle(ctx context.Context, event *Event, result *Resu
 	return nil
 }
 
-// LoadPersistedHandlers loads external handlers from config table entries
+// LoadPersistedHandlers loads external handlers from a config map
 // with the "bus.handler." prefix. Each value is a JSON-encoded ExternalHandlerConfig.
 // Returns the number of handlers loaded.
 func (b *Bus) LoadPersistedHandlers(configs map[string]string) int {

--- a/kbeads/scripts/seed-advice.sh
+++ b/kbeads/scripts/seed-advice.sh
@@ -98,7 +98,7 @@ kbeads uses a different architecture from beads:
 - **Server**: HTTP API at KD_HOST (not Unix socket daemon)
 - **Env vars**: KD_ACTOR, KD_AGENT_ID, KD_HOST (not BD_ACTOR, BEADS_ACTOR)
 - **No .beads/ directory**: kbeads does not use local file storage
-- **Config**: `kd config` backed by Postgres config table
+- **Config**: Config beads via `gb config dump/load`
 - **Setup**: `gb setup claude --defaults` installs Claude Code hooks'
 
 echo "  [4/6] Platform differences"


### PR DESCRIPTION
## Summary

- Update kbeads CLAUDE.md: remove `SetConfig` reference, remove `kd config` from command list
- Update kbeads README.md: replace deprecated `kd config create` example with current approach
- Update seed-advice.sh: reference config beads instead of Postgres config table
- Clean up eventbus and bridge code comments referencing the config table
- Update Config Beads advice bead (kd-z19tFetLvO): remove "Migration from KV store" section and `gb config migrate` references

Part of epic: kd-HGhv7ko00h (Eliminate KV store in favor of project beads) — final task

## Test plan

- [x] `go build ./kbeads/...` — builds cleanly
- [x] `go test ./kbeads/...` — all tests pass
- [x] Verified no remaining KV/config store references in docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)