### PR TITLE
feat(gasboat/bridge): add per-schedule Slack channel routing

### DIFF
--- a/gasboat/controller/internal/bridge/bot_agents.go
+++ b/gasboat/controller/internal/bridge/bot_agents.go
@@ -237,6 +237,11 @@ func (b *Bot) NotifyAgentSpawn(ctx context.Context, bead BeadEvent) {
 	if spawnCh := bead.Fields["slack_spawn_channel"]; spawnCh != "" {
 		b.agentSpawnChannel[agent] = spawnCh
 	}
+	// Schedule-level channel override: use as spawn channel so resolveChannel
+	// routes all notifications (spawn, completion, card) to the right place.
+	if schedCh := bead.Fields["schedule_slack_channel"]; schedCh != "" {
+		b.agentSpawnChannel[agent] = schedCh
+	}
 	b.mu.Unlock()
 
 	// Fetch pod_name from the agent bead notes for coopmux terminal linking.

--- a/gasboat/controller/internal/bridge/bot_schedule_notify_test.go
+++ b/gasboat/controller/internal/bridge/bot_schedule_notify_test.go
@@ -103,6 +103,69 @@ func TestNotifyAgentSpawn_ScheduledAgent_PostsScheduleNotification(t *testing.T)
 	}
 }
 
+func TestNotifyAgentSpawn_ScheduledAgent_UsesScheduleSlackChannel(t *testing.T) {
+	daemon := newMockDaemon()
+	daemon.beads["sched-agent-ch"] = &beadsapi.BeadDetail{
+		ID: "sched-agent-ch", Type: "agent", Status: "open",
+		Title: "sched-ch-1234", Fields: map[string]string{
+			"agent":                  "sched-ch-1234",
+			"schedule_id":            "kd-sched-ch",
+			"schedule_title":         "Weekly Report",
+			"schedule_cron":          "0 9 * * 1",
+			"schedule_slack_channel": "C_REPORTS",
+		},
+	}
+
+	var mu sync.Mutex
+	var postedChannels []string
+	slackSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/chat.postMessage" {
+			_ = r.ParseForm()
+			mu.Lock()
+			postedChannels = append(postedChannels, r.FormValue("channel"))
+			mu.Unlock()
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"ok": true, "channel": "C_REPORTS", "ts": "1234.5678"})
+	}))
+	defer slackSrv.Close()
+
+	bot := newTestBot(daemon, slackSrv)
+	bot.channel = "C_DEFAULT" // default channel — should NOT be used
+
+	bot.NotifyAgentSpawn(context.Background(), BeadEvent{
+		ID:       "sched-agent-ch",
+		Type:     "agent",
+		Title:    "sched-ch-1234",
+		Assignee: "sched-ch-1234",
+		Fields: map[string]string{
+			"agent":                  "sched-ch-1234",
+			"schedule_id":            "kd-sched-ch",
+			"schedule_title":         "Weekly Report",
+			"schedule_cron":          "0 9 * * 1",
+			"schedule_slack_channel": "C_REPORTS",
+		},
+	})
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	// All messages should go to C_REPORTS, not C_DEFAULT.
+	for _, ch := range postedChannels {
+		if ch != "C_REPORTS" {
+			t.Errorf("expected all posts to C_REPORTS, got channel %q", ch)
+		}
+	}
+	if len(postedChannels) == 0 {
+		t.Error("expected at least one message to be posted")
+	}
+
+	// Verify spawn channel was cached for future notifications.
+	if got := bot.agentSpawnChannel["sched-ch-1234"]; got != "C_REPORTS" {
+		t.Errorf("expected agentSpawnChannel=C_REPORTS, got %q", got)
+	}
+}
+
 func TestNotifyAgentSpawn_NonScheduled_NoScheduleFields(t *testing.T) {
 	daemon := newMockDaemon()
 	daemon.beads["normal-agent"] = &beadsapi.BeadDetail{

--- a/gasboat/controller/internal/bridge/init.go
+++ b/gasboat/controller/internal/bridge/init.go
@@ -252,6 +252,7 @@ func configs() map[string]any {
 				{Name: "prompt", Type: "string", Required: true},
 				{Name: "enabled", Type: "boolean"},
 				{Name: "timezone", Type: "string"},
+				{Name: "slack_channel", Type: "string"},
 				{Name: "last_run", Type: "string"},
 				{Name: "last_agent_id", Type: "string"},
 			},

--- a/gasboat/controller/internal/scheduler/scheduler.go
+++ b/gasboat/controller/internal/scheduler/scheduler.go
@@ -33,16 +33,17 @@ func New(daemon *beadsapi.Client, logger *slog.Logger) *Scheduler {
 
 // Schedule represents a parsed schedule bead.
 type Schedule struct {
-	ID          string
-	Title       string
-	Cron        string
-	Project     string
-	Role        string
-	Prompt      string
-	Enabled     bool
-	Timezone    string
-	LastRun     time.Time
-	LastAgentID string
+	ID           string
+	Title        string
+	Cron         string
+	Project      string
+	Role         string
+	Prompt       string
+	Enabled      bool
+	Timezone     string
+	SlackChannel string // optional override: Slack channel for notifications
+	LastRun      time.Time
+	LastAgentID  string
 
 	// Guard rails.
 	MaxConcurrent       int           // max concurrent agents (default 2)
@@ -409,6 +410,7 @@ func (s *Scheduler) listSchedules(ctx context.Context) ([]Schedule, error) {
 			Prompt:              b.Fields["prompt"],
 			Enabled:             enabled,
 			Timezone:            b.Fields["timezone"],
+			SlackChannel:        b.Fields["slack_channel"],
 			LastRun:             lastRun,
 			LastAgentID:         b.Fields["last_agent_id"],
 			MaxConcurrent:       parseIntField(b.Fields["max_concurrent"], defaultMaxConcurrent),
@@ -463,6 +465,9 @@ func (s *Scheduler) spawnScheduledAgent(ctx context.Context, sched Schedule) (st
 		"schedule_id":    sched.ID,
 		"schedule_title": sched.Title,
 		"schedule_cron":  sched.Cron,
+	}
+	if sched.SlackChannel != "" {
+		schedFields["schedule_slack_channel"] = sched.SlackChannel
 	}
 	beadID, err := s.daemon.SpawnAgent(ctx, agentName, project, taskID, role, prompt, schedFields)
 	if err != nil {


### PR DESCRIPTION
## Summary
- Adds `slack_channel` field to schedule bead type definition, allowing each scheduled task to specify which Slack channel receives its notifications
- Scheduler passes the channel through to spawned agent beads as `schedule_slack_channel`
- Bridge reads `schedule_slack_channel` from agent bead and uses it as the spawn channel, so all notifications (spawn, completion, failure, agent card) route to the specified channel
- Falls back to existing behavior (project primary channel → default) when `slack_channel` is not set

## Usage
```bash
kd create "Weekly Report" --type=schedule \
  -f cron="0 9 * * 1" \
  -f project=myproject \
  -f prompt="Generate weekly report" \
  -f enabled=true \
  -f slack_channel=C0REPORTING
```

## Test plan
- [x] New test: `TestNotifyAgentSpawn_ScheduledAgent_UsesScheduleSlackChannel` verifies messages post to override channel
- [x] All existing scheduler and bridge tests pass
- [x] Build succeeds (`go build ./cmd/controller/`, `go build ./cmd/slack-bridge/`)
- [x] Helm lint passes
- [ ] Manual: create a schedule bead with `slack_channel` set and verify notifications go to the right channel

🤖 Generated with [Claude Code](https://claude.com/claude-code)