### PR TITLE
fix(gasboat/bridge): spawn agent after formula pour

### DIFF
--- a/gasboat/controller/internal/bridge/bot_formula.go
+++ b/gasboat/controller/internal/bridge/bot_formula.go
@@ -373,9 +373,33 @@ func (b *Bot) handleFormulaPour(ctx context.Context, cmd slack.SlashCommand, arg
 		b.logger.Info("formula poured via Slack",
 			"formula", formula.ID, "molecule", molID, "steps", stepCount,
 			"phase", phase, "user", cmd.UserID)
+
+		// Spawn an agent to work on the molecule.
+		agentMsg := ""
+		if project != "" {
+			agentName := ""
+			if formula.Fields != nil {
+				agentName = formula.Fields["assigned_agent"]
+			}
+			if agentName == "" {
+				molTitle := formulaSubstituteVars(formula.Title, varPairs)
+				agentName = generateAgentName(molTitle)
+			}
+			agentID, spawnErr := b.daemon.SpawnAgent(
+				context.Background(), agentName, project, molID, "crew", "")
+			if spawnErr != nil {
+				b.logger.Error("formula pour: failed to spawn agent",
+					"formula", formula.ID, "molecule", molID, "error", spawnErr)
+			} else {
+				b.logger.Info("formula pour: spawned agent for molecule",
+					"formula", formula.ID, "molecule", molID, "agent", agentID, "agentName", agentName)
+				agentMsg = fmt.Sprintf("\n:robot_face: Agent `%s` spawned to work on it.", agentName)
+			}
+		}
+
 		b.postEphemeral(cmd, fmt.Sprintf(
-			":bubbles: Created %s `%s` from formula *%s*\n%d step%s instantiated. Use `kd mol show %s` for details.",
-			phase, molID, formula.Title, stepCount, plural(stepCount), molID))
+			":bubbles: Created %s `%s` from formula *%s*\n%d step%s instantiated. Use `kd mol show %s` for details.%s",
+			phase, molID, formula.Title, stepCount, plural(stepCount), molID, agentMsg))
 	}()
 
 	b.postEphemeral(cmd, fmt.Sprintf(":hourglass_flowing_sand: Pouring formula *%s* (%d steps)...", formula.Title, len(active)))

--- a/gasboat/controller/internal/bridge/bot_formula_pour_test.go
+++ b/gasboat/controller/internal/bridge/bot_formula_pour_test.go
@@ -413,6 +413,206 @@ func TestHandleFormulaCommand_Routing(t *testing.T) {
 	}
 }
 
+// --- formula pour agent spawn tests ---
+
+func TestHandleFormulaPour_SpawnsAgent(t *testing.T) {
+	daemon := newFormulaMockDaemon()
+	daemon.seedProjectWithChannel("gasboat", "C1")
+	seedFormula(daemon.mockDaemon, "kd-spawn1", "Deploy service",
+		nil,
+		[]formulaStep{{ID: "step1", Title: "Build"}},
+	)
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+
+	bot := newTestBot(daemon, slackSrv)
+	bot.daemon = daemon
+
+	bot.handleFormulaPour(context.Background(),
+		slack.SlashCommand{ChannelID: "C1", UserID: "U1"},
+		[]string{"kd-spawn1"}, false)
+
+	// Wait for the async goroutine to create the molecule and spawn an agent.
+	assertEventually(t, func() bool {
+		daemon.mu.Lock()
+		defer daemon.mu.Unlock()
+		for _, b := range daemon.beads {
+			if b.Type == "agent" {
+				return true
+			}
+		}
+		return false
+	}, "expected an agent bead to be spawned after formula pour")
+
+	// Verify the agent bead fields.
+	daemon.mu.Lock()
+	defer daemon.mu.Unlock()
+	var agentBead *beadsapi.BeadDetail
+	var molBead *beadsapi.BeadDetail
+	for _, b := range daemon.beads {
+		if b.Type == "agent" {
+			agentBead = b
+		}
+		if b.Type == "molecule" {
+			molBead = b
+		}
+	}
+	if agentBead == nil {
+		t.Fatal("no agent bead found")
+	}
+	if molBead == nil {
+		t.Fatal("no molecule bead found")
+	}
+	if agentBead.Fields["project"] != "gasboat" {
+		t.Errorf("expected agent project=gasboat, got %q", agentBead.Fields["project"])
+	}
+	if agentBead.Fields["task_id"] != molBead.ID {
+		t.Errorf("expected agent task_id=%s, got %q", molBead.ID, agentBead.Fields["task_id"])
+	}
+}
+
+func TestHandleFormulaPour_UsesAssignedAgent(t *testing.T) {
+	daemon := newFormulaMockDaemon()
+	daemon.seedProjectWithChannel("gasboat", "C1")
+
+	// Seed formula with assigned_agent field.
+	varsJSON, _ := json.Marshal([]formulaVarDef{})
+	stepsJSON, _ := json.Marshal([]formulaStep{{ID: "step1", Title: "Do work"}})
+	daemon.mu.Lock()
+	daemon.beads["kd-spawn2"] = &beadsapi.BeadDetail{
+		ID:     "kd-spawn2",
+		Title:  "Custom Agent Formula",
+		Type:   "formula",
+		Status: "open",
+		Fields: map[string]string{
+			"vars":           string(varsJSON),
+			"steps":          string(stepsJSON),
+			"assigned_agent": "my-custom-agent",
+		},
+	}
+	daemon.mu.Unlock()
+
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+
+	bot := newTestBot(daemon, slackSrv)
+	bot.daemon = daemon
+
+	bot.handleFormulaPour(context.Background(),
+		slack.SlashCommand{ChannelID: "C1", UserID: "U1"},
+		[]string{"kd-spawn2"}, false)
+
+	assertEventually(t, func() bool {
+		daemon.mu.Lock()
+		defer daemon.mu.Unlock()
+		for _, b := range daemon.beads {
+			if b.Type == "agent" {
+				return true
+			}
+		}
+		return false
+	}, "expected an agent bead to be spawned with assigned_agent name")
+
+	daemon.mu.Lock()
+	defer daemon.mu.Unlock()
+	for _, b := range daemon.beads {
+		if b.Type == "agent" {
+			if b.Fields["agent"] != "my-custom-agent" {
+				t.Errorf("expected agent name 'my-custom-agent', got %q", b.Fields["agent"])
+			}
+			return
+		}
+	}
+}
+
+func TestHandleFormulaPour_NoSpawnWithoutProject(t *testing.T) {
+	daemon := newFormulaMockDaemon()
+	// No project seeded — projectFromChannel will return "".
+	seedFormula(daemon.mockDaemon, "kd-spawn3", "No project formula",
+		nil,
+		[]formulaStep{{ID: "step1", Title: "Build"}},
+	)
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+
+	bot := newTestBot(daemon, slackSrv)
+	bot.daemon = daemon
+
+	bot.handleFormulaPour(context.Background(),
+		slack.SlashCommand{ChannelID: "C-unknown", UserID: "U1"},
+		[]string{"kd-spawn3"}, false)
+
+	// Wait for molecule to be created.
+	assertEventually(t, func() bool {
+		daemon.mu.Lock()
+		defer daemon.mu.Unlock()
+		for _, b := range daemon.beads {
+			if b.Type == "molecule" {
+				return true
+			}
+		}
+		return false
+	}, "expected molecule to be created")
+
+	// Give a moment for any async agent spawn to happen.
+	time.Sleep(100 * time.Millisecond)
+
+	// Verify no agent was spawned.
+	daemon.mu.Lock()
+	defer daemon.mu.Unlock()
+	for _, b := range daemon.beads {
+		if b.Type == "agent" {
+			t.Error("expected no agent bead when project is empty")
+		}
+	}
+}
+
+func TestHandleFormulaPour_AgentNameFromFormulaTitle(t *testing.T) {
+	daemon := newFormulaMockDaemon()
+	daemon.seedProjectWithChannel("gasboat", "C1")
+	seedFormula(daemon.mockDaemon, "kd-spawn4", "Deploy {{env}} service",
+		[]formulaVarDef{{Name: "env", Default: "staging"}},
+		[]formulaStep{{ID: "step1", Title: "Build"}},
+	)
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+
+	bot := newTestBot(daemon, slackSrv)
+	bot.daemon = daemon
+
+	bot.handleFormulaPour(context.Background(),
+		slack.SlashCommand{ChannelID: "C1", UserID: "U1"},
+		[]string{"kd-spawn4"}, false)
+
+	assertEventually(t, func() bool {
+		daemon.mu.Lock()
+		defer daemon.mu.Unlock()
+		for _, b := range daemon.beads {
+			if b.Type == "agent" {
+				return true
+			}
+		}
+		return false
+	}, "expected agent bead to be spawned")
+
+	// Agent name should be derived from the var-substituted title "Deploy staging service".
+	daemon.mu.Lock()
+	defer daemon.mu.Unlock()
+	for _, b := range daemon.beads {
+		if b.Type == "agent" {
+			name := b.Fields["agent"]
+			// generateAgentName("Deploy staging service") produces "deploy-staging-service-XXX"
+			if len(name) == 0 {
+				t.Error("expected non-empty agent name")
+			}
+			if name == "Deploy staging service" {
+				t.Error("expected agent name to be slugified, not raw title")
+			}
+			return
+		}
+	}
+}
+
 // --- assertEventually helper ---
 
 func assertEventually(t *testing.T, check func() bool, msg string) {


### PR DESCRIPTION
## Summary

- Formula pour (`/formula pour`) created molecule + step beads but never spawned an agent to work on them, leaving steps orphaned
- After successful instantiation, now spawns an agent assigned to the molecule
- Uses the formula's `assigned_agent` field if set, otherwise generates a name from the formula title
- Only spawns when a project is resolved from the Slack channel

Fixes kd-dcGQzmUhLm

## Test plan

- [x] `TestHandleFormulaPour_SpawnsAgent` — agent spawned with correct project and task_id
- [x] `TestHandleFormulaPour_UsesAssignedAgent` — `assigned_agent` field is respected
- [x] `TestHandleFormulaPour_NoSpawnWithoutProject` — no agent when project is empty
- [x] `TestHandleFormulaPour_AgentNameFromFormulaTitle` — name slugified from var-substituted title
- [x] All existing formula tests pass (22 tests total)

🤖 Generated with [Claude Code](https://claude.com/claude-code)