### PR TITLE
feat(gasboat): add gb init command to replace entrypoint curl calls

### DIFF
--- a/gasboat/controller/cmd/gb/init_agent.go
+++ b/gasboat/controller/cmd/gb/init_agent.go
@@ -1,0 +1,682 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"os/signal"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"gasboat/controller/internal/coopapi"
+
+	"github.com/spf13/cobra"
+)
+
+var initAgentCmd = &cobra.Command{
+	Use:   "init",
+	Short: "Manage agent lifecycle alongside coop",
+	Long: `Orchestrates the agent lifecycle by communicating with the coop REST API.
+
+Replaces the curl-based functions in entrypoint.sh with a single Go binary:
+  - Bypass startup prompts (trust dialog, setup wizard, resume picker)
+  - Inject initial work prompt (via nudge-prompt resolution)
+  - Monitor agent state (idle/working/exited/rate_limited)
+  - Refresh OAuth credentials
+  - Handle graceful shutdown signals
+
+Runs as a long-lived process alongside coop, exiting when the agent exits.`,
+	GroupID: "agent",
+	RunE:   runInitAgent,
+}
+
+var (
+	initCoopURL  string
+	initStandby  bool
+	initMockMode bool
+)
+
+func init() { //nolint:gochecknoinits
+	initAgentCmd.Flags().StringVar(&initCoopURL, "coop-url", "http://localhost:8080", "coop API base URL")
+	initAgentCmd.Flags().BoolVar(&initStandby, "standby", false, "enable standby mode (prewarmed pool agents)")
+	initAgentCmd.Flags().BoolVar(&initMockMode, "mock", false, "mock mode (skip OAuth refresh)")
+}
+
+func runInitAgent(cmd *cobra.Command, args []string) error {
+	coop := coopapi.New(initCoopURL)
+	ctx, cancel := context.WithCancel(cmd.Context())
+	defer cancel()
+
+	// Wait for coop to become available.
+	if err := waitForCoop(ctx, coop); err != nil {
+		return fmt.Errorf("coop not available: %w", err)
+	}
+
+	var wg sync.WaitGroup
+	errCh := make(chan error, 1)
+
+	// Signal handling: catch SIGTERM/SIGINT for graceful shutdown.
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGINT)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		handleSignals(ctx, cancel, coop, sigCh)
+	}()
+
+	// Main lifecycle chain: bypass startup → [standby] → inject prompt.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		if err := bypassStartup(ctx, coop); err != nil {
+			logInit("bypass startup failed: %v", err)
+			return
+		}
+
+		if initStandby && os.Getenv("BOAT_AGENT_BEAD_ID") != "" {
+			if err := standbyWait(ctx, coop); err != nil {
+				logInit("standby wait failed: %v", err)
+				return
+			}
+		}
+
+		if err := injectPrompt(ctx, coop); err != nil {
+			logInit("inject prompt failed: %v", err)
+		}
+	}()
+
+	// Monitor agent exit — this drives the process lifecycle.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		if err := monitorExit(ctx, coop); err != nil {
+			select {
+			case errCh <- err:
+			default:
+			}
+		}
+		cancel() // agent exited, shut everything down
+	}()
+
+	// Monitor agent idle state (update bead).
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		monitorIdle(ctx, coop)
+	}()
+
+	// OAuth credential refresh (unless mock mode).
+	if !initMockMode {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			refreshCredentials(ctx, coop)
+		}()
+	}
+
+	wg.Wait()
+	return nil
+}
+
+// waitForCoop polls the coop API until it responds.
+func waitForCoop(ctx context.Context, coop *coopapi.Client) error {
+	logInit("Waiting for coop at %s", initCoopURL)
+	for i := 0; i < 60; i++ {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+		if _, err := coop.GetAgentState(ctx); err == nil {
+			logInit("Coop is ready")
+			return nil
+		}
+		time.Sleep(2 * time.Second)
+	}
+	return fmt.Errorf("timed out after 120s waiting for coop")
+}
+
+// bypassStartup handles startup prompts (trust dialog, setup wizard, resume picker).
+func bypassStartup(ctx context.Context, coop *coopapi.Client) error {
+	logInit("Bypassing startup prompts")
+	falsePositiveCount := 0
+
+	for i := 0; i < 60; i++ {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		time.Sleep(2 * time.Second)
+
+		state, err := coop.GetAgentState(ctx)
+		if err != nil {
+			continue
+		}
+
+		promptType := ""
+		promptSubtype := ""
+		if state.Prompt != nil {
+			promptType = state.Prompt.Type
+			promptSubtype = state.Prompt.Subtype
+		}
+		_ = promptSubtype
+
+		// Handle interactive prompts while agent is starting.
+		if state.State == "starting" {
+			screen, err := coop.GetScreenText(ctx)
+			if err == nil {
+				// "Resume Session" picker — press Enter to resume.
+				if containsCI(screen, "resume") && containsCI(screen, "session") {
+					logInit("Detected resume session picker, selecting resume")
+					_ = coop.SendKeys(ctx, []string{"Return"})
+					time.Sleep(3 * time.Second)
+					continue
+				}
+			}
+		}
+
+		// Handle "Detected a custom API key" or trust prompts.
+		if state.State == "starting" || promptType == "permission" {
+			screen, err := coop.GetScreenText(ctx)
+			if err == nil {
+				if strings.Contains(screen, "Detected a custom API key") {
+					logInit("Detected API key prompt, selecting 'Yes'")
+					_ = coop.SendKeys(ctx, []string{"Up", "Return"})
+					time.Sleep(3 * time.Second)
+					continue
+				}
+				if strings.Contains(screen, "trust this folder") {
+					logInit("Auto-accepting trust folder prompt")
+					_ = coop.Respond(ctx, 0)
+					time.Sleep(3 * time.Second)
+					continue
+				}
+			}
+		}
+
+		// Handle setup prompts.
+		if promptType == "setup" {
+			screen, err := coop.GetScreen(ctx)
+			if err == nil {
+				if strings.Contains(screen, "No, exit") {
+					logInit("Auto-accepting setup prompt (subtype: %s)", promptSubtype)
+					_ = coop.Respond(ctx, 2)
+					falsePositiveCount = 0
+					time.Sleep(5 * time.Second)
+					continue
+				}
+				falsePositiveCount++
+				if falsePositiveCount >= 5 {
+					logInit("Skipping false-positive setup prompt (no dialog after %d checks)", falsePositiveCount)
+					return nil
+				}
+				continue
+			}
+		}
+
+		// If agent is past setup prompts, we're done.
+		if state.State == "idle" || state.State == "working" {
+			logInit("Startup bypass complete (agent state: %s)", state.State)
+			return nil
+		}
+	}
+
+	logInit("WARNING: auto-bypass timed out after 120s")
+	return nil
+}
+
+// injectPrompt resolves the nudge prompt and injects it into the agent.
+func injectPrompt(ctx context.Context, coop *coopapi.Client) error {
+	// Wait for agent to be idle.
+	for i := 0; i < 60; i++ {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		time.Sleep(2 * time.Second)
+
+		state, err := coop.GetAgentState(ctx)
+		if err != nil {
+			continue
+		}
+
+		if state.State == "idle" {
+			break
+		}
+		if state.State == "working" {
+			logInit("Agent already working, skipping initial prompt")
+			return nil
+		}
+	}
+
+	// Resolve nudge prompt. Use the daemon (beadsapi) client which is
+	// connected by PersistentPreRunE in main.go.
+	promptType := detectNudgeType()
+	vars := buildNudgeVars()
+	nudgeMsg := resolveNudgeFromConfig(promptType, vars)
+
+	if nudgeMsg == "" {
+		logInit("WARNING: nudge-prompt resolution failed — using fallback")
+		nudgeMsg = "Run gb ready to find work."
+	}
+
+	role := os.Getenv("BOAT_ROLE")
+	logInit("Injecting initial work prompt (role: %s)", role)
+
+	resp, err := coop.Nudge(ctx, nudgeMsg)
+	if err != nil {
+		logInit("WARNING: nudge failed: %v", err)
+		return nil
+	}
+
+	if resp.Delivered {
+		logInit("Initial prompt delivered successfully")
+	} else {
+		logInit("WARNING: nudge not delivered: %s", resp.Reason)
+	}
+	return nil
+}
+
+// standbyWait polls the agent bead until the pool manager assigns work.
+func standbyWait(ctx context.Context, coop *coopapi.Client) error {
+	// Signal monitor_agent_idle to skip state updates.
+	if err := os.WriteFile("/tmp/standby_active", []byte("1"), 0644); err != nil {
+		logInit("WARNING: failed to write standby sentinel: %v", err)
+	}
+
+	beadID := os.Getenv("BOAT_AGENT_BEAD_ID")
+	logInit("Standby mode: Claude is idle, waiting for assignment (bead: %s)", beadID)
+
+	pollInterval := envDuration("BOAT_STANDBY_POLL", 5*time.Second)
+	maxWait := envDuration("BOAT_STANDBY_MAX_TTL", 24*time.Hour)
+	deadline := time.Now().Add(maxWait)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		if time.Now().After(deadline) {
+			logInit("Standby safety-net TTL (%s) exceeded, shutting down", maxWait)
+			os.Remove("/tmp/standby_active")
+			_ = os.WriteFile("/tmp/standby_expired", []byte("1"), 0644)
+			_ = coop.Shutdown(ctx)
+			return fmt.Errorf("standby TTL exceeded")
+		}
+
+		// Check agent_state via beads daemon.
+		currentState := "prewarmed"
+		if daemon != nil {
+			bead, err := daemon.GetBead(ctx, beadID)
+			if err == nil {
+				if s := bead.Fields["agent_state"]; s != "" {
+					currentState = s
+				}
+			}
+		}
+
+		if currentState != "prewarmed" {
+			logInit("Assignment received (state: %s), exiting standby", currentState)
+
+			// Hydrate env vars from the assigned bead's fields.
+			if daemon != nil {
+				hydrateAssignmentEnv(ctx, beadID)
+			}
+
+			os.Remove("/tmp/standby_active")
+			return nil
+		}
+
+		time.Sleep(pollInterval)
+	}
+}
+
+// hydrateAssignmentEnv fetches the agent bead and exports thread/task env vars.
+func hydrateAssignmentEnv(ctx context.Context, beadID string) {
+	bead, err := daemon.GetBead(ctx, beadID)
+	if err != nil {
+		return
+	}
+
+	if ch := bead.Fields["slack_thread_channel"]; ch != "" {
+		os.Setenv("SLACK_THREAD_CHANNEL", ch)
+		logInit("Hydrated SLACK_THREAD_CHANNEL=%s", ch)
+	}
+	if ts := bead.Fields["slack_thread_ts"]; ts != "" {
+		os.Setenv("SLACK_THREAD_TS", ts)
+		logInit("Hydrated SLACK_THREAD_TS=%s", ts)
+	}
+	if proj := bead.Fields["project"]; proj != "" && os.Getenv("PROJECT") == "" {
+		os.Setenv("PROJECT", proj)
+		logInit("Hydrated PROJECT=%s", proj)
+	}
+	if tid := bead.Fields["task_id"]; tid != "" {
+		os.Setenv("BOAT_TASK_ID", tid)
+		logInit("Hydrated BOAT_TASK_ID=%s", tid)
+	}
+}
+
+// monitorExit polls agent state and triggers shutdown when agent exits or is rate-limited.
+func monitorExit(ctx context.Context, coop *coopapi.Client) error {
+	time.Sleep(10 * time.Second)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		default:
+		}
+
+		time.Sleep(5 * time.Second)
+
+		state, err := coop.GetAgentState(ctx)
+		if err != nil {
+			// coop is gone, agent exited
+			return nil
+		}
+
+		if state.State == "exited" {
+			logInit("Agent exited, requesting coop shutdown")
+			_ = coop.Shutdown(ctx)
+			return nil
+		}
+
+		// Detect rate-limited state and park the pod.
+		if state.ErrorCategory == "rate_limited" {
+			logInit("Agent rate-limited, dismissing prompt")
+			_ = coop.SendKeys(ctx, []string{"Return"})
+			logInit("Rate limit info: %s", state.LastMessage)
+
+			// Report rate_limited status to agent bead.
+			agentID := os.Getenv("KD_AGENT_ID")
+			if agentID != "" && daemon != nil {
+				_ = daemon.UpdateAgentState(ctx, agentID, "rate_limited")
+			}
+
+			// Write sentinel so the restart loop knows to sleep until reset.
+			_ = os.WriteFile("/tmp/rate_limit_reset", []byte(state.LastMessage), 0644)
+			time.Sleep(2 * time.Second)
+
+			logInit("Requesting coop shutdown (rate-limited)")
+			_ = coop.Shutdown(ctx)
+			return nil
+		}
+	}
+}
+
+// monitorIdle polls agent state and updates the agent bead.
+func monitorIdle(ctx context.Context, coop *coopapi.Client) {
+	agentID := os.Getenv("KD_AGENT_ID")
+	if agentID == "" || daemon == nil {
+		return
+	}
+
+	time.Sleep(15 * time.Second)
+	prevState := ""
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+
+		time.Sleep(10 * time.Second)
+
+		state, err := coop.GetAgentState(ctx)
+		if err != nil {
+			return // coop gone
+		}
+
+		if state.State != prevState && state.State != "" {
+			// Skip state updates while in standby.
+			if _, err := os.Stat("/tmp/standby_active"); err != nil {
+				switch state.State {
+				case "idle", "working":
+					_ = daemon.UpdateAgentState(ctx, agentID, state.State)
+				}
+			}
+			prevState = state.State
+		}
+
+		if state.State == "exited" {
+			return
+		}
+	}
+}
+
+// oauthCredentials holds the Claude AI OAuth credentials file structure.
+type oauthCredentials struct {
+	ClaudeAiOauth *oauthTokenData `json:"claudeAiOauth,omitempty"`
+}
+
+type oauthTokenData struct {
+	AccessToken  string `json:"accessToken"`
+	RefreshToken string `json:"refreshToken"`
+	ExpiresAt    int64  `json:"expiresAt"`
+}
+
+// refreshCredentials handles OAuth token refresh in a loop.
+func refreshCredentials(ctx context.Context, coop *coopapi.Client) {
+	// Skip if API key mode (no OAuth credentials to refresh).
+	credsFile := os.Getenv("XDG_STATE_HOME")
+	if credsFile == "" {
+		credsFile = os.Getenv("HOME") + "/.local/state"
+	}
+	credsFile += "/claude-code/.credentials.json"
+
+	apiKey := os.Getenv("ANTHROPIC_API_KEY")
+	if apiKey != "" {
+		if _, err := os.Stat(credsFile); os.IsNotExist(err) {
+			logInit("API key mode — skipping OAuth refresh loop")
+			return
+		}
+	}
+
+	time.Sleep(30 * time.Second) // let Claude start first
+	consecutiveFailures := 0
+	maxFailures := 5
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+
+		time.Sleep(5 * time.Minute)
+
+		data, err := os.ReadFile(credsFile)
+		if err != nil {
+			continue
+		}
+
+		var creds oauthCredentials
+		if err := json.Unmarshal(data, &creds); err != nil || creds.ClaudeAiOauth == nil {
+			continue
+		}
+
+		token := creds.ClaudeAiOauth
+		if token.RefreshToken == "" || token.ExpiresAt == 0 {
+			continue
+		}
+
+		// Coop-provisioned credentials use a sentinel expiresAt (>= 10^12 ms).
+		if token.ExpiresAt >= 9999999999000 {
+			consecutiveFailures = 0
+			continue
+		}
+
+		// Check if within 1 hour of expiry (3600000ms).
+		nowMs := time.Now().UnixMilli()
+		remainingMs := token.ExpiresAt - nowMs
+		if remainingMs > 3600000 {
+			consecutiveFailures = 0
+			continue
+		}
+
+		logInit("OAuth token expires in %dm, refreshing...", remainingMs/60000)
+
+		newAccess, newRefresh, expiresIn, err := doOAuthRefresh(ctx, token.RefreshToken)
+		if err != nil {
+			consecutiveFailures++
+			logInit("WARNING: OAuth refresh failed (attempt %d/%d): %v", consecutiveFailures, maxFailures, err)
+			if consecutiveFailures >= maxFailures {
+				if shouldTerminateOnAuthFailure(ctx, coop) {
+					logInit("FATAL: OAuth refresh failed %d consecutive times, terminating pod", maxFailures)
+					syscall.Kill(syscall.Getpid(), syscall.SIGTERM)
+					return
+				}
+				consecutiveFailures = 0
+			}
+			continue
+		}
+
+		consecutiveFailures = 0
+		newExpiresAt := time.Now().UnixMilli() + int64(expiresIn)*1000
+
+		// Update credentials file.
+		creds.ClaudeAiOauth.AccessToken = newAccess
+		creds.ClaudeAiOauth.RefreshToken = newRefresh
+		creds.ClaudeAiOauth.ExpiresAt = newExpiresAt
+
+		updatedData, err := json.MarshalIndent(creds, "", "  ")
+		if err != nil {
+			logInit("WARNING: failed to marshal updated credentials: %v", err)
+			continue
+		}
+
+		tmpFile := credsFile + ".tmp"
+		if err := os.WriteFile(tmpFile, updatedData, 0600); err != nil {
+			logInit("WARNING: failed to write credentials: %v", err)
+			continue
+		}
+		if err := os.Rename(tmpFile, credsFile); err != nil {
+			logInit("WARNING: failed to rename credentials: %v", err)
+			continue
+		}
+
+		logInit("OAuth credentials refreshed (expires in %dh)", expiresIn/3600)
+	}
+}
+
+// oauthRefreshRequest is the request body for token refresh.
+type oauthRefreshRequest struct {
+	GrantType    string `json:"grant_type"`
+	RefreshToken string `json:"refresh_token"`
+	ClientID     string `json:"client_id"`
+}
+
+// oauthRefreshResponse is the response from the token endpoint.
+type oauthRefreshResponse struct {
+	AccessToken  string `json:"access_token"`
+	RefreshToken string `json:"refresh_token"`
+	ExpiresIn    int    `json:"expires_in"`
+}
+
+// doOAuthRefresh performs the actual token refresh HTTP request.
+func doOAuthRefresh(ctx context.Context, refreshToken string) (accessToken, newRefreshToken string, expiresIn int, err error) {
+	reqBody := oauthRefreshRequest{
+		GrantType:    "refresh_token",
+		RefreshToken: refreshToken,
+		ClientID:     oauthClientID,
+	}
+
+	bodyData, err := json.Marshal(reqBody)
+	if err != nil {
+		return "", "", 0, fmt.Errorf("marshal request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, oauthTokenURL, strings.NewReader(string(bodyData)))
+	if err != nil {
+		return "", "", 0, fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", "", 0, fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", "", 0, fmt.Errorf("unexpected status %d", resp.StatusCode)
+	}
+
+	var tokenResp oauthRefreshResponse
+	if err := json.NewDecoder(resp.Body).Decode(&tokenResp); err != nil {
+		return "", "", 0, fmt.Errorf("decode response: %w", err)
+	}
+
+	if tokenResp.AccessToken == "" || tokenResp.RefreshToken == "" {
+		return "", "", 0, fmt.Errorf("response missing tokens")
+	}
+
+	return tokenResp.AccessToken, tokenResp.RefreshToken, tokenResp.ExpiresIn, nil
+}
+
+// shouldTerminateOnAuthFailure checks if the agent is still active (don't kill a working agent).
+func shouldTerminateOnAuthFailure(ctx context.Context, coop *coopapi.Client) bool {
+	state, err := coop.GetAgentState(ctx)
+	if err != nil {
+		return true
+	}
+	if state.State == "working" || state.State == "idle" {
+		logInit("WARNING: OAuth refresh failing but agent is %s, not terminating", state.State)
+		return false
+	}
+	return true
+}
+
+// handleSignals catches SIGTERM/SIGINT and performs graceful shutdown via coop API.
+func handleSignals(ctx context.Context, cancel context.CancelFunc, coop *coopapi.Client, sigCh <-chan os.Signal) {
+	select {
+	case sig := <-sigCh:
+		logInit("Graceful shutdown: interrupting Claude before forwarding %s", sig)
+		// Send Escape to interrupt Claude mid-generation.
+		shutCtx, shutCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer shutCancel()
+		_ = coop.SendKeys(shutCtx, []string{"Escape"})
+		time.Sleep(2 * time.Second)
+		// Request graceful coop shutdown via API.
+		_ = coop.Shutdown(shutCtx)
+		time.Sleep(3 * time.Second)
+		cancel()
+	case <-ctx.Done():
+	}
+}
+
+// containsCI performs a case-insensitive substring search.
+func containsCI(s, substr string) bool {
+	return strings.Contains(strings.ToLower(s), strings.ToLower(substr))
+}
+
+// envDuration reads a duration from an environment variable (as seconds).
+func envDuration(key string, defaultVal time.Duration) time.Duration {
+	s := os.Getenv(key)
+	if s == "" {
+		return defaultVal
+	}
+	var secs int
+	if _, err := fmt.Sscanf(s, "%d", &secs); err != nil {
+		return defaultVal
+	}
+	return time.Duration(secs) * time.Second
+}
+
+func logInit(format string, args ...interface{}) {
+	log.Printf("[gb init] "+format, args...)
+}

--- a/gasboat/controller/cmd/gb/init_agent_test.go
+++ b/gasboat/controller/cmd/gb/init_agent_test.go
@@ -1,0 +1,175 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"gasboat/controller/internal/coopapi"
+)
+
+func TestBypassStartup_IdleAgent(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(coopapi.AgentState{State: "idle"})
+	}))
+	defer srv.Close()
+
+	coop := coopapi.New(srv.URL)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	err := bypassStartup(ctx, coop)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestBypassStartup_WorkingAgent(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(coopapi.AgentState{State: "working"})
+	}))
+	defer srv.Close()
+
+	coop := coopapi.New(srv.URL)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	err := bypassStartup(ctx, coop)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestBypassStartup_SetupPromptWithExit(t *testing.T) {
+	callCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		switch r.URL.Path {
+		case "/api/v1/agent":
+			if callCount <= 3 {
+				json.NewEncoder(w).Encode(map[string]interface{}{
+					"state": "starting",
+					"prompt": map[string]string{
+						"type": "setup",
+					},
+				})
+			} else {
+				json.NewEncoder(w).Encode(coopapi.AgentState{State: "idle"})
+			}
+		case "/api/v1/screen":
+			w.Write([]byte("Please select:\n1. Yes\n2. No, exit"))
+		case "/api/v1/agent/respond":
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer srv.Close()
+
+	coop := coopapi.New(srv.URL)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	err := bypassStartup(ctx, coop)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestBypassStartup_Cancelled(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(coopapi.AgentState{State: "starting"})
+	}))
+	defer srv.Close()
+
+	coop := coopapi.New(srv.URL)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // immediately cancelled
+
+	err := bypassStartup(ctx, coop)
+	if err != context.Canceled {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+}
+
+func TestWaitForCoop_Ready(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(coopapi.AgentState{State: "idle"})
+	}))
+	defer srv.Close()
+
+	initCoopURL = srv.URL
+	coop := coopapi.New(srv.URL)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	err := waitForCoop(ctx, coop)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestContainsCI(t *testing.T) {
+	tests := []struct {
+		s, substr string
+		want      bool
+	}{
+		{"Resume Session", "resume", true},
+		{"RESUME SESSION", "session", true},
+		{"hello world", "Resume", false},
+		{"Resume a session", "resume", true},
+	}
+	for _, tt := range tests {
+		got := containsCI(tt.s, tt.substr)
+		if got != tt.want {
+			t.Errorf("containsCI(%q, %q) = %v, want %v", tt.s, tt.substr, got, tt.want)
+		}
+	}
+}
+
+func TestEnvDuration_Default(t *testing.T) {
+	d := envDuration("NONEXISTENT_GB_TEST_VAR_12345", 42*time.Second)
+	if d != 42*time.Second {
+		t.Errorf("expected 42s, got %v", d)
+	}
+}
+
+func TestEnvDuration_Set(t *testing.T) {
+	t.Setenv("TEST_GB_INIT_DUR", "10")
+	d := envDuration("TEST_GB_INIT_DUR", 42*time.Second)
+	if d != 10*time.Second {
+		t.Errorf("expected 10s, got %v", d)
+	}
+}
+
+func TestMonitorExit_AgentExited(t *testing.T) {
+	callCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		switch r.URL.Path {
+		case "/api/v1/agent":
+			if callCount <= 2 {
+				json.NewEncoder(w).Encode(coopapi.AgentState{State: "working"})
+			} else {
+				json.NewEncoder(w).Encode(coopapi.AgentState{State: "exited"})
+			}
+		case "/api/v1/shutdown":
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer srv.Close()
+
+	coop := coopapi.New(srv.URL)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// Reduce sleeps for test speed — monitorExit has 10s initial sleep + 5s poll.
+	// We test the logic, not the timing, by using a context that'll be faster.
+	err := monitorExit(ctx, coop)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/gasboat/controller/cmd/gb/main.go
+++ b/gasboat/controller/cmd/gb/main.go
@@ -107,6 +107,7 @@ func init() {
 	rootCmd.AddCommand(agentCmd)
 	rootCmd.AddCommand(spawnCmd)
 	rootCmd.AddCommand(startCmd)
+	rootCmd.AddCommand(initAgentCmd)
 
 	// Orchestration
 	rootCmd.AddCommand(gateCmd)

--- a/gasboat/controller/internal/coopapi/client.go
+++ b/gasboat/controller/internal/coopapi/client.go
@@ -1,0 +1,167 @@
+// Package coopapi provides an HTTP client for the coop REST API.
+//
+// Coop is the terminal session manager that wraps Claude Code.
+// It exposes a REST API on localhost:8080 for agent state, screen
+// content, input injection, nudging, and shutdown.
+package coopapi
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+// Client talks to the coop HTTP API.
+type Client struct {
+	baseURL    string
+	httpClient *http.Client
+}
+
+// New creates a coop API client. baseURL is typically "http://localhost:8080".
+func New(baseURL string) *Client {
+	return &Client{
+		baseURL: baseURL,
+		httpClient: &http.Client{
+			Timeout: 10 * time.Second,
+		},
+	}
+}
+
+// AgentState is the response from GET /api/v1/agent.
+type AgentState struct {
+	State         string       `json:"state"`
+	ErrorCategory string       `json:"error_category,omitempty"`
+	LastMessage   string       `json:"last_message,omitempty"`
+	Prompt        *AgentPrompt `json:"prompt,omitempty"`
+}
+
+// AgentPrompt describes a pending prompt from the agent.
+type AgentPrompt struct {
+	Type    string `json:"type,omitempty"`
+	Subtype string `json:"subtype,omitempty"`
+}
+
+// NudgeResponse is the response from POST /api/v1/agent/nudge.
+type NudgeResponse struct {
+	Delivered bool   `json:"delivered"`
+	Reason    string `json:"reason,omitempty"`
+}
+
+// GetAgentState returns the current agent state.
+func (c *Client) GetAgentState(ctx context.Context) (*AgentState, error) {
+	var state AgentState
+	if err := c.getJSON(ctx, "/api/v1/agent", &state); err != nil {
+		return nil, err
+	}
+	return &state, nil
+}
+
+// GetScreenText returns the current screen content as plain text.
+func (c *Client) GetScreenText(ctx context.Context) (string, error) {
+	return c.getText(ctx, "/api/v1/screen/text")
+}
+
+// GetScreen returns the current screen content (may include formatting).
+func (c *Client) GetScreen(ctx context.Context) (string, error) {
+	return c.getText(ctx, "/api/v1/screen")
+}
+
+// SendKeys sends keyboard input to the agent.
+func (c *Client) SendKeys(ctx context.Context, keys []string) error {
+	body := map[string][]string{"keys": keys}
+	return c.postJSON(ctx, "/api/v1/input/keys", body, nil)
+}
+
+// Respond selects an option on a prompt dialog.
+func (c *Client) Respond(ctx context.Context, option int) error {
+	body := map[string]int{"option": option}
+	return c.postJSON(ctx, "/api/v1/agent/respond", body, nil)
+}
+
+// Nudge injects a message into the agent's input.
+func (c *Client) Nudge(ctx context.Context, message string) (*NudgeResponse, error) {
+	body := map[string]string{"message": message}
+	var resp NudgeResponse
+	if err := c.postJSON(ctx, "/api/v1/agent/nudge", body, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// Shutdown requests a graceful coop shutdown.
+func (c *Client) Shutdown(ctx context.Context) error {
+	return c.postJSON(ctx, "/api/v1/shutdown", nil, nil)
+}
+
+// getJSON performs a GET request and decodes the JSON response.
+func (c *Client) getJSON(ctx context.Context, path string, out interface{}) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+path, nil)
+	if err != nil {
+		return fmt.Errorf("creating request: %w", err)
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("unexpected status %d from %s", resp.StatusCode, path)
+	}
+	return json.NewDecoder(resp.Body).Decode(out)
+}
+
+// getText performs a GET request and returns the body as a string.
+func (c *Client) getText(ctx context.Context, path string) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+path, nil)
+	if err != nil {
+		return "", fmt.Errorf("creating request: %w", err)
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("unexpected status %d from %s", resp.StatusCode, path)
+	}
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("reading response: %w", err)
+	}
+	return string(data), nil
+}
+
+// postJSON performs a POST request with a JSON body and optionally decodes the response.
+func (c *Client) postJSON(ctx context.Context, path string, body interface{}, out interface{}) error {
+	var bodyReader io.Reader
+	if body != nil {
+		data, err := json.Marshal(body)
+		if err != nil {
+			return fmt.Errorf("marshaling body: %w", err)
+		}
+		bodyReader = bytes.NewReader(data)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+path, bodyReader)
+	if err != nil {
+		return fmt.Errorf("creating request: %w", err)
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("unexpected status %d from %s", resp.StatusCode, path)
+	}
+	if out != nil {
+		return json.NewDecoder(resp.Body).Decode(out)
+	}
+	return nil
+}

--- a/gasboat/controller/internal/coopapi/client_test.go
+++ b/gasboat/controller/internal/coopapi/client_test.go
@@ -1,0 +1,191 @@
+package coopapi
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestGetAgentState(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/agent" || r.Method != http.MethodGet {
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		json.NewEncoder(w).Encode(AgentState{
+			State:         "idle",
+			ErrorCategory: "",
+			LastMessage:   "hello",
+		})
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL)
+	state, err := c.GetAgentState(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if state.State != "idle" {
+		t.Errorf("expected state=idle, got %q", state.State)
+	}
+	if state.LastMessage != "hello" {
+		t.Errorf("expected last_message=hello, got %q", state.LastMessage)
+	}
+}
+
+func TestGetAgentState_WithPrompt(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"state": "starting",
+			"prompt": map[string]string{
+				"type":    "setup",
+				"subtype": "project",
+			},
+		})
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL)
+	state, err := c.GetAgentState(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if state.Prompt == nil {
+		t.Fatal("expected prompt to be non-nil")
+	}
+	if state.Prompt.Type != "setup" {
+		t.Errorf("expected prompt type=setup, got %q", state.Prompt.Type)
+	}
+}
+
+func TestSendKeys(t *testing.T) {
+	var received struct {
+		Keys []string `json:"keys"`
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/input/keys" || r.Method != http.MethodPost {
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		json.NewDecoder(r.Body).Decode(&received)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL)
+	err := c.SendKeys(context.Background(), []string{"Escape", "Return"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(received.Keys) != 2 || received.Keys[0] != "Escape" || received.Keys[1] != "Return" {
+		t.Errorf("unexpected keys sent: %v", received.Keys)
+	}
+}
+
+func TestRespond(t *testing.T) {
+	var received struct {
+		Option int `json:"option"`
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/agent/respond" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		json.NewDecoder(r.Body).Decode(&received)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL)
+	err := c.Respond(context.Background(), 2)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if received.Option != 2 {
+		t.Errorf("expected option=2, got %d", received.Option)
+	}
+}
+
+func TestNudge(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/agent/nudge" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		var req map[string]string
+		json.NewDecoder(r.Body).Decode(&req)
+		if req["message"] != "do work" {
+			t.Errorf("expected message='do work', got %q", req["message"])
+		}
+		json.NewEncoder(w).Encode(NudgeResponse{Delivered: true})
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL)
+	resp, err := c.Nudge(context.Background(), "do work")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !resp.Delivered {
+		t.Error("expected delivered=true")
+	}
+}
+
+func TestShutdown(t *testing.T) {
+	called := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/shutdown" || r.Method != http.MethodPost {
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		called = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL)
+	err := c.Shutdown(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !called {
+		t.Error("expected shutdown endpoint to be called")
+	}
+}
+
+func TestGetScreenText(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/screen/text" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.Write([]byte("Resume Session\n> Latest"))
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL)
+	text, err := c.GetScreenText(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if text != "Resume Session\n> Latest" {
+		t.Errorf("unexpected text: %q", text)
+	}
+}
+
+func TestGetAgentState_ServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL)
+	_, err := c.GetAgentState(context.Background())
+	if err == nil {
+		t.Fatal("expected error for 500 response")
+	}
+}
+
+func TestGetAgentState_ConnectionRefused(t *testing.T) {
+	c := New("http://localhost:1") // nothing listening
+	_, err := c.GetAgentState(context.Background())
+	if err == nil {
+		t.Fatal("expected connection error")
+	}
+}

--- a/gasboat/images/agent/entrypoint.sh
+++ b/gasboat/images/agent/entrypoint.sh
@@ -418,407 +418,27 @@ fi
 # Coop log level (overridable via pod env).
 export COOP_LOG_LEVEL="${COOP_LOG_LEVEL:-info}"
 
-# ── Auto-bypass startup prompts ────────────────────────────────────────
-auto_bypass_startup() {
-    false_positive_count=0
-    # Increased from 30 to 60 iterations (120s) to handle large session replays.
-    for i in $(seq 1 60); do
-        sleep 2
-        state=$(curl -sf http://localhost:8080/api/v1/agent 2>/dev/null) || continue
-        agent_state=$(echo "${state}" | jq -r '.state // empty' 2>/dev/null)
-        prompt_type=$(echo "${state}" | jq -r '.prompt.type // empty' 2>/dev/null)
-        subtype=$(echo "${state}" | jq -r '.prompt.subtype // empty' 2>/dev/null)
-
-        # Handle interactive prompts while agent is in "starting" state.
-        if [ "${agent_state}" = "starting" ]; then
-            screen=$(curl -sf http://localhost:8080/api/v1/screen/text 2>/dev/null)
-
-            # Handle "Resume Session" picker — press Enter to resume the most recent session.
-            # Previously pressed Escape which caused a new .jsonl to accumulate on the PVC.
-            # Case-insensitive match to handle potential text changes across Claude versions.
-            if echo "${screen}" | grep -qi "resume.*session\|Resume Session"; then
-                echo "[entrypoint] Detected resume session picker, selecting resume"
-                curl -sf -X POST http://localhost:8080/api/v1/input/keys \
-                    -H 'Content-Type: application/json' \
-                    -d '{"keys":["Return"]}' 2>&1 || true
-                sleep 3
-                continue
-            fi
-        fi
-
-        # Handle "Detected a custom API key" prompt — can appear as state
-        # "starting" or "prompt" (type=permission, subtype=trust).
-        # Normally avoided by unsetting ANTHROPIC_API_KEY when OAuth is
-        # present, but kept as a safety net.
-        if [ "${agent_state}" = "starting" ] || [ "${prompt_type}" = "permission" ]; then
-            screen=$(curl -sf http://localhost:8080/api/v1/screen/text 2>/dev/null)
-            if echo "${screen}" | grep -q "Detected a custom API key"; then
-                echo "[entrypoint] Detected API key prompt, selecting 'Yes' to use it"
-                curl -sf -X POST http://localhost:8080/api/v1/input/keys \
-                    -H 'Content-Type: application/json' \
-                    -d '{"keys":["Up","Return"]}' 2>&1 || true
-                sleep 3
-                continue
-            fi
-            # Handle "trust this folder" permission prompt.
-            if echo "${screen}" | grep -q "trust this folder"; then
-                echo "[entrypoint] Auto-accepting trust folder prompt"
-                curl -sf -X POST http://localhost:8080/api/v1/agent/respond \
-                    -H 'Content-Type: application/json' \
-                    -d '{"option":0}' 2>&1 || true
-                sleep 3
-                continue
-            fi
-        fi
-
-        if [ "${prompt_type}" = "setup" ]; then
-            screen=$(curl -sf http://localhost:8080/api/v1/screen 2>/dev/null)
-            if echo "${screen}" | grep -q "No, exit"; then
-                echo "[entrypoint] Auto-accepting setup prompt (subtype: ${subtype})"
-                curl -sf -X POST http://localhost:8080/api/v1/agent/respond \
-                    -H 'Content-Type: application/json' \
-                    -d '{"option":2}' 2>&1 || true
-                false_positive_count=0
-                sleep 5
-                continue
-            else
-                false_positive_count=$((false_positive_count + 1))
-                if [ "${false_positive_count}" -ge 5 ]; then
-                    echo "[entrypoint] Skipping false-positive setup prompt (no dialog after ${false_positive_count} checks)"
-                    return 0
-                fi
-                continue
-            fi
-        fi
-        # If agent is past setup prompts, we're done
-        agent_state=$(echo "${state}" | jq -r '.state // empty' 2>/dev/null)
-        if [ "${agent_state}" = "idle" ] || [ "${agent_state}" = "working" ]; then
-            return 0
-        fi
-    done
-    echo "[entrypoint] WARNING: auto-bypass timed out after 120s"
-}
-
-# ── Inject initial work prompt ────────────────────────────────────────
-
-# ── Standby: wait for pool assignment (prewarmed agents) ─────────────
-# When BOAT_STANDBY=true, Claude is already running and idle. This
-# function polls agent_state until the pool manager changes it from
-# "prewarmed" to "assigning", then hydrates thread/task env vars so
-# the subsequent inject_initial_prompt sends the correct work prompt.
-standby_wait_for_assignment() {
-    # Signal monitor_agent_idle to skip state updates so the pool manager
-    # controls the prewarmed→assigning transition.
-    touch /tmp/standby_active
-
-    echo "[entrypoint] Standby mode: Claude is idle, waiting for assignment (bead: ${BOAT_AGENT_BEAD_ID})"
-    local poll_interval="${BOAT_STANDBY_POLL:-5}"
-    local max_wait="${BOAT_STANDBY_MAX_TTL:-86400}"
-    local elapsed=0
-
-    while true; do
-        if [ "${elapsed}" -ge "${max_wait}" ]; then
-            echo "[entrypoint] Standby safety-net TTL (${max_wait}s) exceeded, shutting down"
-            rm -f /tmp/standby_active
-            touch /tmp/standby_expired
-            curl -sf -X POST http://localhost:8080/api/v1/shutdown 2>/dev/null || true
-            return 1
-        fi
-
-        # Check agent_state via kd (faster than raw curl + jq).
-        local current_state
-        if command -v kd &>/dev/null; then
-            current_state=$(kd show "${BOAT_AGENT_BEAD_ID}" --json 2>/dev/null \
-                | jq -r '.fields.agent_state // "prewarmed"' 2>/dev/null) || current_state="prewarmed"
-        else
-            current_state=$(curl -sf "${BEADS_HTTP_ADDR:-http://localhost:8080}/v1/beads/${BOAT_AGENT_BEAD_ID}" 2>/dev/null \
-                | jq -r '.fields.agent_state // "prewarmed"' 2>/dev/null) || current_state="prewarmed"
-        fi
-
-        if [ "${current_state}" != "prewarmed" ]; then
-            echo "[entrypoint] Assignment received (state: ${current_state}), exiting standby"
-
-            # Hydrate env vars from the assigned bead's fields so the nudge
-            # includes thread context (channel, thread_ts, description).
-            if command -v kd &>/dev/null; then
-                local bead_json
-                bead_json=$(kd show "${BOAT_AGENT_BEAD_ID}" --json 2>/dev/null) || true
-                if [ -n "${bead_json}" ]; then
-                    local assigned_channel assigned_thread_ts assigned_project assigned_task_id
-                    assigned_channel=$(echo "${bead_json}" | jq -r '.fields.slack_thread_channel // empty' 2>/dev/null)
-                    assigned_thread_ts=$(echo "${bead_json}" | jq -r '.fields.slack_thread_ts // empty' 2>/dev/null)
-                    assigned_project=$(echo "${bead_json}" | jq -r '.fields.project // empty' 2>/dev/null)
-                    if [ -n "${assigned_channel}" ]; then
-                        export SLACK_THREAD_CHANNEL="${assigned_channel}"
-                        echo "[entrypoint] Hydrated SLACK_THREAD_CHANNEL=${assigned_channel}"
-                    fi
-                    if [ -n "${assigned_thread_ts}" ]; then
-                        export SLACK_THREAD_TS="${assigned_thread_ts}"
-                        echo "[entrypoint] Hydrated SLACK_THREAD_TS=${assigned_thread_ts}"
-                    fi
-                    if [ -n "${assigned_project}" ] && [ -z "${PROJECT:-}" ]; then
-                        export PROJECT="${assigned_project}"
-                        echo "[entrypoint] Hydrated PROJECT=${assigned_project}"
-                    fi
-                    assigned_task_id=$(echo "${bead_json}" | jq -r '.fields.task_id // empty' 2>/dev/null)
-                    if [ -n "${assigned_task_id}" ]; then
-                        export BOAT_TASK_ID="${assigned_task_id}"
-                        echo "[entrypoint] Hydrated BOAT_TASK_ID=${assigned_task_id}"
-                    fi
-                fi
-            fi
-
-            rm -f /tmp/standby_active
-            return 0
-        fi
-
-        sleep "${poll_interval}"
-        elapsed=$((elapsed + poll_interval))
-    done
-}
-
-inject_initial_prompt() {
-    # Wait for agent to be past setup and idle
-    for i in $(seq 1 60); do
-        sleep 2
-        state=$(curl -sf http://localhost:8080/api/v1/agent 2>/dev/null) || continue
-        agent_state=$(echo "${state}" | jq -r '.state // empty' 2>/dev/null)
-        if [ "${agent_state}" = "idle" ]; then
-            break
-        fi
-        # If agent is already working (hook triggered it), no nudge needed
-        if [ "${agent_state}" = "working" ]; then
-            echo "[entrypoint] Agent already working, skipping initial prompt"
-            return 0
-        fi
-    done
-
-    # Resolve nudge prompt from config beads via gb nudge-prompt.
-    # Task resolution from agent bead dependencies is handled inside gb nudge-prompt.
-    local nudge_msg
-    if command -v gb &>/dev/null; then
-        nudge_msg=$(gb nudge-prompt 2>/dev/null) || nudge_msg=""
-    fi
-
-    if [ -z "${nudge_msg}" ]; then
-        echo "[entrypoint] WARNING: gb nudge-prompt failed — no nudge-prompts config beads found"
-        nudge_msg="Run gb ready to find work."
-    fi
-
-    echo "[entrypoint] Injecting initial work prompt (role: ${ROLE})"
-    response=$(curl -sf -X POST http://localhost:8080/api/v1/agent/nudge \
-        -H 'Content-Type: application/json' \
-        -d "{\"message\": \"${nudge_msg}\"}" 2>&1) || {
-        echo "[entrypoint] WARNING: nudge failed: ${response}"
-        return 0
-    }
-
-    delivered=$(echo "${response}" | jq -r '.delivered // false' 2>/dev/null)
-    if [ "${delivered}" = "true" ]; then
-        echo "[entrypoint] Initial prompt delivered successfully"
-    else
-        reason=$(echo "${response}" | jq -r '.reason // "unknown"' 2>/dev/null)
-        echo "[entrypoint] WARNING: nudge not delivered: ${reason}"
-    fi
-}
-
-# ── OAuth credential refresh ────────────────────────────────────────────
-OAUTH_TOKEN_URL="https://platform.claude.com/v1/oauth/token"
-OAUTH_CLIENT_ID="9d1c250a-e61b-44d9-88ed-5944d1962f5e"
-CREDS_FILE="${CLAUDE_STATE}/.credentials.json"
-
-refresh_credentials() {
-    # Skip refresh in mock mode — claudeless doesn't use OAuth.
-    if [ "${MOCK_MODE}" = "1" ]; then
-        echo "[entrypoint] Mock mode — skipping OAuth refresh loop"
-        return 0
-    fi
-    # Skip refresh entirely when using API key mode — no OAuth credentials to refresh.
-    if [ -n "${ANTHROPIC_API_KEY:-}" ] && [ ! -f "${CREDS_FILE}" ]; then
-        echo "[entrypoint] API key mode — skipping OAuth refresh loop"
-        return 0
-    fi
-    sleep 30  # Let Claude start first
-    local consecutive_failures=0
-    local max_failures=5
-    while true; do
-        sleep 300  # Check every 5 minutes
-
-        if [ ! -f "${CREDS_FILE}" ]; then
-            continue
-        fi
-
-        expires_at=$(jq -r '.claudeAiOauth.expiresAt // 0' "${CREDS_FILE}" 2>/dev/null)
-        refresh_token=$(jq -r '.claudeAiOauth.refreshToken // empty' "${CREDS_FILE}" 2>/dev/null)
-
-        if [ -z "${refresh_token}" ] || [ "${expires_at}" = "0" ]; then
-            continue
-        fi
-
-        # Coop-provisioned credentials use a sentinel expiresAt (>= 10^12 ms).
-        # Skip refresh — these are managed by coop profiles.
-        if [ "${expires_at}" -ge 9999999999000 ] 2>/dev/null; then
-            consecutive_failures=0
-            continue
-        fi
-
-        # Check if within 1 hour of expiry (3600000ms)
-        now_ms=$(date +%s)000
-        remaining_ms=$((expires_at - now_ms))
-        if [ "${remaining_ms}" -gt 3600000 ]; then
-            consecutive_failures=0
-            continue
-        fi
-
-        echo "[entrypoint] OAuth token expires in $((remaining_ms / 60000))m, refreshing..."
-
-        response=$(curl -sf "${OAUTH_TOKEN_URL}" \
-            -H 'Content-Type: application/json' \
-            -d "{\"grant_type\":\"refresh_token\",\"refresh_token\":\"${refresh_token}\",\"client_id\":\"${OAUTH_CLIENT_ID}\"}" 2>/dev/null) || {
-            consecutive_failures=$((consecutive_failures + 1))
-            echo "[entrypoint] WARNING: OAuth refresh request failed (attempt ${consecutive_failures}/${max_failures})"
-            if [ "${consecutive_failures}" -ge "${max_failures}" ]; then
-                agent_state=$(curl -sf http://localhost:8080/api/v1/agent 2>/dev/null | jq -r '.state // empty' 2>/dev/null)
-                if [ "${agent_state}" = "working" ] || [ "${agent_state}" = "idle" ]; then
-                    echo "[entrypoint] WARNING: OAuth refresh failing but agent is ${agent_state}, not terminating"
-                    consecutive_failures=0
-                    continue
-                fi
-                echo "[entrypoint] FATAL: OAuth refresh failed ${max_failures} consecutive times, terminating pod"
-                kill -TERM $$ 2>/dev/null || kill -TERM 1 2>/dev/null
-                exit 1
-            fi
-            continue
-        }
-
-        new_access_token=$(echo "${response}" | jq -r '.access_token // empty' 2>/dev/null)
-        new_refresh_token=$(echo "${response}" | jq -r '.refresh_token // empty' 2>/dev/null)
-        expires_in=$(echo "${response}" | jq -r '.expires_in // 0' 2>/dev/null)
-
-        if [ -z "${new_access_token}" ] || [ -z "${new_refresh_token}" ]; then
-            consecutive_failures=$((consecutive_failures + 1))
-            echo "[entrypoint] WARNING: OAuth refresh returned invalid response (attempt ${consecutive_failures}/${max_failures})"
-            if [ "${consecutive_failures}" -ge "${max_failures}" ]; then
-                agent_state=$(curl -sf http://localhost:8080/api/v1/agent 2>/dev/null | jq -r '.state // empty' 2>/dev/null)
-                if [ "${agent_state}" = "working" ] || [ "${agent_state}" = "idle" ]; then
-                    echo "[entrypoint] WARNING: OAuth refresh failing but agent is ${agent_state}, not terminating"
-                    consecutive_failures=0
-                    continue
-                fi
-                echo "[entrypoint] FATAL: OAuth refresh failed ${max_failures} consecutive times, terminating pod"
-                kill -TERM $$ 2>/dev/null || kill -TERM 1 2>/dev/null
-                exit 1
-            fi
-            continue
-        fi
-
-        consecutive_failures=0
-        new_expires_at=$(( $(date +%s) * 1000 + expires_in * 1000 ))
-
-        jq --arg at "${new_access_token}" \
-           --arg rt "${new_refresh_token}" \
-           --argjson ea "${new_expires_at}" \
-           '.claudeAiOauth.accessToken = $at | .claudeAiOauth.refreshToken = $rt | .claudeAiOauth.expiresAt = $ea' \
-           "${CREDS_FILE}" > "${CREDS_FILE}.tmp" && mv "${CREDS_FILE}.tmp" "${CREDS_FILE}"
-
-        echo "[entrypoint] OAuth credentials refreshed (expires in $((expires_in / 3600))h)"
-    done
-}
-
-# ── Monitor agent exit and shut down coop ──────────────────────────────
-monitor_agent_idle() {
-    [ -z "${KD_AGENT_ID:-}" ] && return 0
-    command -v kd &>/dev/null || return 0
-    local prev_state=""
-    sleep 15
-    while true; do
-        sleep 10
-        state=$(curl -sf http://localhost:8080/api/v1/agent 2>/dev/null) || break
-        agent_state=$(echo "${state}" | jq -r '.state // empty' 2>/dev/null)
-        if [ "${agent_state}" != "${prev_state}" ] && [ -n "${agent_state}" ]; then
-            # Skip state updates while in standby — the pool manager controls
-            # the prewarmed→assigning transition. Writing "idle" here would
-            # remove the agent from the prewarmed pool prematurely.
-            if [ ! -f /tmp/standby_active ]; then
-                case "${agent_state}" in
-                    idle|working)
-                        kd update "${KD_AGENT_ID}" -f agent_state="${agent_state}" 2>/dev/null || true
-                        ;;
-                esac
-            fi
-            prev_state="${agent_state}"
-        fi
-        # Stop polling once the agent exits.
-        [ "${agent_state}" = "exited" ] && break
-    done
-}
-
-monitor_agent_exit() {
-    sleep 10
-    while true; do
-        sleep 5
-        state=$(curl -sf http://localhost:8080/api/v1/agent 2>/dev/null) || break
-        agent_state=$(echo "${state}" | jq -r '.state // empty' 2>/dev/null)
-        error_category=$(echo "${state}" | jq -r '.error_category // empty' 2>/dev/null)
-        if [ "${agent_state}" = "exited" ]; then
-            echo "[entrypoint] Agent exited, requesting coop shutdown"
-            curl -sf -X POST http://localhost:8080/api/v1/shutdown 2>/dev/null || true
-            return 0
-        fi
-        # Detect rate-limited state and park the pod.
-        error_cat=$(echo "${state}" | jq -r '.error_category // empty' 2>/dev/null)
-        if [ "${error_cat}" = "rate_limited" ]; then
-            echo "[entrypoint] Agent rate-limited, dismissing prompt"
-            # Send Enter to select "Stop and wait" from /rate-limit-options.
-            curl -sf -X POST http://localhost:8080/api/v1/input/keys \
-                -H 'Content-Type: application/json' \
-                -d '{"keys":["Return"]}' 2>/dev/null || true
-            last_msg=$(echo "${state}" | jq -r '.last_message // empty' 2>/dev/null)
-            echo "[entrypoint] Rate limit info: ${last_msg}"
-            # Report rate_limited status to the agent bead.
-            if [ -n "${KD_AGENT_ID:-}" ] && command -v kd &>/dev/null; then
-                kd update "${KD_AGENT_ID}" -f agent_state=rate_limited 2>/dev/null || true
-            fi
-            # Write sentinel so the restart loop knows to sleep until reset.
-            echo "${last_msg}" > /tmp/rate_limit_reset
-            sleep 2
-            echo "[entrypoint] Requesting coop shutdown (rate-limited)"
-            curl -sf -X POST http://localhost:8080/api/v1/shutdown 2>/dev/null || true
-            return 0
-        fi
-    done
-}
-
 # ── Signal forwarding ─────────────────────────────────────────────────────
+# gb init handles the coop API calls (Escape + shutdown). The entrypoint
+# only needs to forward SIGTERM to the coop process for hard-kill fallback.
 COOP_PID=""
+GB_INIT_PID=""
 forward_signal() {
-    if [ -n "${COOP_PID}" ]; then
-        echo "[entrypoint] Graceful shutdown: interrupting Claude before forwarding $1"
-        # Send Escape to interrupt Claude mid-generation.
-        curl -sf -X POST http://localhost:8080/api/v1/input/keys \
-            -H 'Content-Type: application/json' \
-            -d '{"keys":["Escape"]}' 2>/dev/null || true
-        sleep 2
-        # Request graceful coop shutdown via API.
-        curl -sf -X POST http://localhost:8080/api/v1/shutdown 2>/dev/null || true
-        sleep 3
-        # If coop is still running, send SIGTERM.
-        if kill -0 "${COOP_PID}" 2>/dev/null; then
-            echo "[entrypoint] Forwarding $1 to coop (pid ${COOP_PID})"
-            kill -"$1" "${COOP_PID}" 2>/dev/null || true
-        fi
+    if [ -n "${GB_INIT_PID}" ]; then
+        # gb init handles graceful shutdown via coop API (Escape + shutdown).
+        # Give it time to complete, then fall back to SIGTERM on coop PID.
+        kill -"$1" "${GB_INIT_PID}" 2>/dev/null || true
+        sleep 5
+    fi
+    if [ -n "${COOP_PID}" ] && kill -0 "${COOP_PID}" 2>/dev/null; then
+        echo "[entrypoint] Forwarding $1 to coop (pid ${COOP_PID})"
+        kill -"$1" "${COOP_PID}" 2>/dev/null || true
         wait "${COOP_PID}" 2>/dev/null || true
     fi
     exit 0
 }
 trap 'forward_signal TERM' TERM
 trap 'forward_signal INT' INT
-
-# Start credential refresh in background (survives coop restarts).
-# Skip for mock agent commands — claudeless needs no OAuth credentials.
-if [ "${MOCK_MODE}" != "1" ]; then
-    refresh_credentials &
-fi
 
 # Clean up stale standby flags from previous runs.
 rm -f /tmp/standby_active /tmp/standby_expired /tmp/standby_done
@@ -867,24 +487,27 @@ while true; do
 
     start_time=$(date +%s)
 
-    # Build the injection chain: bypass prompts → [standby wait] → inject prompt.
-    # For prewarmed agents on first start, Claude idles in standby until the
-    # pool manager assigns work — then the work prompt is injected instantly.
+    # Build gb init flags.
+    GB_INIT_FLAGS=""
     if [ "${BOAT_STANDBY:-}" = "true" ] && [ -n "${BOAT_AGENT_BEAD_ID:-}" ] && [ ! -f /tmp/standby_done ]; then
-        INJECT_CHAIN="auto_bypass_startup && standby_wait_for_assignment && inject_initial_prompt; touch /tmp/standby_done"
-    else
-        INJECT_CHAIN="auto_bypass_startup && inject_initial_prompt"
+        GB_INIT_FLAGS="--standby"
+    fi
+    if [ "${MOCK_MODE}" = "1" ]; then
+        GB_INIT_FLAGS="${GB_INIT_FLAGS} --mock"
     fi
 
     if [ -n "${RESUME_FLAG}" ]; then
         echo "[entrypoint] Starting coop + ${AGENT_CMD%% *} (${ROLE}/${AGENT}) with resume"
         ${COOP_CMD} ${RESUME_FLAG} -- ${AGENT_CMD} &
         COOP_PID=$!
-        (eval "${INJECT_CHAIN}") &
-        monitor_agent_exit &
-        monitor_agent_idle &
+        gb init ${GB_INIT_FLAGS} &
+        GB_INIT_PID=$!
         wait "${COOP_PID}" 2>/dev/null && exit_code=0 || exit_code=$?
         COOP_PID=""
+        # Stop gb init when coop exits.
+        kill "${GB_INIT_PID}" 2>/dev/null || true
+        wait "${GB_INIT_PID}" 2>/dev/null || true
+        GB_INIT_PID=""
 
         if [ "${exit_code}" -ne 0 ] && [ -n "${LATEST_LOG}" ] && [ -f "${LATEST_LOG}" ]; then
             echo "[entrypoint] Resume failed (exit ${exit_code}), retiring stale session log"
@@ -895,11 +518,19 @@ while true; do
         echo "[entrypoint] Starting coop + ${AGENT_CMD%% *} (${ROLE}/${AGENT})"
         ${COOP_CMD} -- ${AGENT_CMD} &
         COOP_PID=$!
-        (eval "${INJECT_CHAIN}") &
-        monitor_agent_exit &
-        monitor_agent_idle &
+        gb init ${GB_INIT_FLAGS} &
+        GB_INIT_PID=$!
         wait "${COOP_PID}" 2>/dev/null && exit_code=0 || exit_code=$?
         COOP_PID=""
+        # Stop gb init when coop exits.
+        kill "${GB_INIT_PID}" 2>/dev/null || true
+        wait "${GB_INIT_PID}" 2>/dev/null || true
+        GB_INIT_PID=""
+    fi
+
+    # Mark standby done after first successful gb init cycle.
+    if [ "${BOAT_STANDBY:-}" = "true" ] && [ ! -f /tmp/standby_done ]; then
+        touch /tmp/standby_done
     fi
 
     elapsed=$(( $(date +%s) - start_time ))


### PR DESCRIPTION
## Summary

- Add `internal/coopapi/` package — thin HTTP client for the coop REST API (localhost:8080)
- Add `gb init` command that orchestrates the agent lifecycle alongside coop
- Replace 6 bash functions (~25 curl calls) in entrypoint.sh with `gb init &`
- Simplify signal forwarding in entrypoint (coop API calls now in Go)

## What `gb init` replaces

| Bash function | Go goroutine | Curl calls removed |
|---|---|---|
| `auto_bypass_startup()` | `bypassStartup()` | 8 |
| `inject_initial_prompt()` | `injectPrompt()` | 2 |
| `standby_wait_for_assignment()` | `standbyWait()` | 2 |
| `monitor_agent_exit()` | `monitorExit()` | 5 |
| `monitor_agent_idle()` | `monitorIdle()` | 1 |
| `refresh_credentials()` | `refreshCredentials()` | 3 |
| `forward_signal()` (coop API part) | `handleSignals()` | 2 |

## Why

The agent entrypoint relied on curl for all coop API calls. When `libgssapi_krb5.so.2` went missing from the container image, curl broke and agents couldn't start. `gb init` uses Go's `net/http` — no shared library dependencies.

## Test plan

- [x] `go build ./cmd/gb/` passes
- [x] `go test ./internal/coopapi/` — 9 tests pass (all API endpoints)
- [x] `go test ./cmd/gb/` — full suite passes including new init tests
- [x] `bash -n entrypoint.sh` — syntax validation passes
- [ ] Deploy to dev pod and verify startup → bypass → nudge → monitor cycle

Closes kd-e8kvj7oprN

🤖 Generated with [Claude Code](https://claude.com/claude-code)