### PR TITLE
fix(gasboat/agent): add fontconfig package to RWX CI for font discovery

### DIFF
--- a/.rwx/docker.yml
+++ b/.rwx/docker.yml
@@ -717,14 +717,14 @@ tasks:
         libcairo2 libcups2t64 libdbus-1-3 libdrm2 libgbm1 libglib2.0-0t64 \
         libnspr4 libnss3 libpango-1.0-0 libx11-6 libxcb1 \
         libxcomposite1 libxdamage1 libxext6 libxfixes3 libxkbcommon0 \
-        libxrandr2 fonts-noto-color-emoji fonts-noto-core libfontconfig1 libfreetype6 \
+        libxrandr2 fonts-noto-color-emoji fonts-noto-core fontconfig libfontconfig1 libfreetype6 \
         libsqlite3-0 libavahi-client3
       # Copy dpkg-managed files (use -a to preserve symlinks)
       for pkg in libasound2t64 libatk-bridge2.0-0t64 libatk1.0-0t64 libatspi2.0-0t64 \
           libcairo2 libcups2t64 libdbus-1-3 libdrm2 libgbm1 libglib2.0-0t64 \
           libnspr4 libnss3 libpango-1.0-0 libx11-6 libxcb1 \
           libxcomposite1 libxdamage1 libxext6 libxfixes3 libxkbcommon0 \
-          libxrandr2 libfontconfig1 libfreetype6 fonts-noto-color-emoji fonts-noto-core \
+          libxrandr2 fontconfig libfontconfig1 libfreetype6 fonts-noto-color-emoji fonts-noto-core \
           libsqlite3-0 libavahi-client3; do
         dpkg -L "$pkg" 2>/dev/null | while read -r f; do
           [ -e "$f" ] || continue
@@ -792,6 +792,10 @@ tasks:
           mkdir -p "$OUT$(dirname "$lib")" && cp -L "$lib" "$OUT${lib}" 2>/dev/null || true
         done || true
       done
+
+      # Build fontconfig cache so chromium can discover fonts at runtime.
+      # dpkg -L copies fonts.conf and conf.d/ but not the generated cache.
+      FONTCONFIG_SYSROOT=$OUT fc-cache -f 2>/dev/null || true
 
       tar -cf playwright.tar -C $OUT .
     outputs:

--- a/gasboat/.rwx/agent-playwright.lock
+++ b/gasboat/.rwx/agent-playwright.lock
@@ -1,8 +1,9 @@
 # Cache key for agent-install-playwright task.
 # Touch this file to force a rebuild of Playwright + Chromium + Chrome only.
-cache-epoch=6
+cache-epoch=7
 playwright=1.58.2
 # epoch 3: add Chrome for Testing browser, fix system deps, ldd sweep
 # epoch 4: install Google Chrome Stable via apt, fix usrmerge symlinks in push-agent
 # epoch 5: install MCP's own chromium revision (npx resolves global playwright, not MCP's bundled one)
 # epoch 6: add fonts-noto-core for Playwright text rendering
+# epoch 7: add fontconfig package (fonts.conf + /etc/fonts/conf.d/) — libfontconfig1 alone lacks config


### PR DESCRIPTION
## Summary

- **Root cause**: RWX CI `agent-install-playwright` task installed `libfontconfig1` (shared library only) but not `fontconfig` (which provides `/etc/fonts/fonts.conf`, `/etc/fonts/conf.d/` symlinks, and `fc-*` binaries)
- Without `fonts.conf`, chromium cannot discover Noto font files via fontconfig — text renders at 0px height → Playwright MCP screenshots are blank grey rectangles
- The Dockerfile already installs `fontconfig` correctly; only the RWX CI parallel build was missing it
- Also adds `fc-cache` step to pre-build the fontconfig cache in the layer

## Changes

- `.rwx/docker.yml`: Add `fontconfig` to apt-get install + dpkg copy loop in `agent-install-playwright` task
- `.rwx/docker.yml`: Add `FONTCONFIG_SYSROOT=$OUT fc-cache -f` before tar to pre-build font cache
- `gasboat/.rwx/agent-playwright.lock`: Bump cache epoch 6 → 7

## Test plan

- [ ] RWX CI builds successfully with new epoch
- [ ] Agent pod has `/etc/fonts/fonts.conf` present
- [ ] `fc-list` returns Noto fonts in agent container
- [ ] Playwright MCP screenshots render text correctly (not blank grey)

🤖 Generated with [Claude Code](https://claude.com/claude-code)