### PR TITLE
feat(gasboat): add autodestruct permission for matthew.baker

### DIFF
--- a/gasboat/helm/gasboat/values.yaml
+++ b/gasboat/helm/gasboat/values.yaml
@@ -215,7 +215,7 @@ agents:
     tokenSecret: ""
     # Comma-separated Slack user IDs allowed to trigger autodestruct via the
     # bridge's Slack command. Passed as AUTODESTRUCT_ALLOWED_USERS env var.
-    allowedSlackUsers: ""
+    allowedSlackUsers: "U07K1RLQAKF"
 
   # --- Secrets & credentials ---
   #


### PR DESCRIPTION
## Summary
- Adds Slack user ID `U07K1RLQAKF` (@matthew.baker) to `agents.autodestruct.allowedSlackUsers` in Helm values
- This authorizes the user to trigger `/autodestruct`, `/autodestruct clear`, and `/autodestruct status` via Slack

## Important Note
The `autodestruct.tokenSecret` (or `token`) is still empty. A K8s secret containing a bearer token must also be created and referenced in the Helm values for the autodestruct HTTP endpoints to function. Without the token, the bridge will return "AUTODESTRUCT_TOKEN not configured" when calling the controller.

To complete setup:
```bash
kubectl create secret generic gasboat-autodestruct-token --from-literal=token=$(openssl rand -hex 32) -n gasboat
```
Then set `agents.autodestruct.tokenSecret: "gasboat-autodestruct-token"` in the deployment values.

## Test plan
- [ ] `helm lint gasboat/helm/gasboat/` passes
- [ ] After deploy, verify `AUTODESTRUCT_ALLOWED_USERS` env var is set on controller pod
- [ ] Verify `/autodestruct status` works from Slack (requires token to also be configured)

Closes kd-YUcJWgT5eH

🤖 Generated with [Claude Code](https://claude.com/claude-code)