### PR TITLE
feat(gasboat/agent): add k6 load testing binary to agent image

### DIFF
--- a/gasboat/.rwx/agent-clis.lock
+++ b/gasboat/.rwx/agent-clis.lock
@@ -1,6 +1,6 @@
 # Cache key for agent-install-clis task.
 # Touch this file to force a rebuild of CLI tools only.
-cache-epoch=5
+cache-epoch=6
 docker-cli=27.5.1
 terraform=1.11.3
 terragrunt=0.77.11
@@ -8,3 +8,4 @@ stern=1.30.0
 claudeless=v0.4.0
 rtk=v0.23.0
 rwx=v3.7.1
+k6=v1.6.1

--- a/gasboat/CLAUDE.md
+++ b/gasboat/CLAUDE.md
@@ -165,7 +165,7 @@ crane export ghcr.io/groblegark/gasboats/agent:<tag> - | tar -tf - | grep <binar
 docker run --rm ghcr.io/groblegark/gasboats/agent:<tag> which <tool-name>
 ```
 
-Key tools to verify: `claude`, `coop`, `kd`, `gb`, `playwright`, `npx`, `ffmpeg`, `tmux`, `whisper-cli`, `go`, `rustc`, `gh`, `glab`, `helm`, `terraform`, `kubectl`, `psql`
+Key tools to verify: `claude`, `coop`, `kd`, `gb`, `playwright`, `npx`, `ffmpeg`, `tmux`, `whisper-cli`, `go`, `rustc`, `gh`, `glab`, `helm`, `terraform`, `kubectl`, `psql`, `k6`
 
 ### Common Pitfalls
 

--- a/gasboat/images/agent/install/clis.sh
+++ b/gasboat/images/agent/install/clis.sh
@@ -140,6 +140,12 @@ mkdir -p "$PREFIX/bin" "$PREFIX/lib/docker/cli-plugins" "$PREFIX/share/helm/plug
 ) &
 
 (
+  # k6 (load testing)
+  curl -fsSL "https://github.com/grafana/k6/releases/download/v${K6_VERSION}/k6-v${K6_VERSION}-linux-${ARCH}.tar.gz" \
+    | tar -xz --strip-components=1 -C "$PREFIX/bin" "k6-v${K6_VERSION}-linux-${ARCH}/k6"
+) &
+
+(
   # whisper-cli (needs cmake, gcc — must be available in PATH)
   curl -fsSL "https://github.com/ggml-org/whisper.cpp/archive/refs/tags/v${WHISPER_CPP_VERSION}.tar.gz" \
     | tar -xz -C /tmp

--- a/gasboat/images/agent/install/versions.env
+++ b/gasboat/images/agent/install/versions.env
@@ -25,6 +25,7 @@ export CLAUDELESS_VERSION=v0.4.0
 export RTK_VERSION=0.23.0
 export RWX_CLI_VERSION=3.7.1
 export WHISPER_CPP_VERSION=1.8.3
+export K6_VERSION=1.6.1
 export PLAYWRIGHT_VERSION=1.58.2
 
 # ── Base apt packages (minimal agent: git, Node.js, Claude Code) ──


### PR DESCRIPTION
## Summary

- Adds k6 v1.6.1 (Grafana load testing tool) to the agent image via shared install scripts
- Version pinned in `versions.env`, install logic in `clis.sh` (parallel download block)
- Cache epoch bumped in `agent-clis.lock` to trigger rebuild
- Verification checklist in CLAUDE.md updated to include `k6`

Stacks on #71 (shared install scripts). Part of epic kd-LwE07hAC1m (k6 load testing onboarding).

## Test plan

- [ ] CI passes on this PR
- [ ] After merge + release, verify: `docker run --rm ghcr.io/groblegark/gasboats/agent:<tag> k6 version`
- [ ] Verify arm64 build also works (k6 provides `linux-arm64` tarball)

🤖 Generated with [Claude Code](https://claude.com/claude-code)