### PR TITLE
fix(gasboat/bridge): fix thread interaction bugs in slack-bridge

### DIFF
--- a/gasboat/controller/internal/bridge/bot_agent_kill.go
+++ b/gasboat/controller/internal/bridge/bot_agent_kill.go
@@ -90,6 +90,11 @@ func (b *Bot) killAgent(ctx context.Context, agentName string, force bool) error
 func (b *Bot) respawnThreadAgent(ctx context.Context, channel, threadTS, agentName, triggerText string) {
 	agentName = extractAgentName(agentName)
 
+	// Snapshot the listen-thread flag before it gets cleaned up by killAgent
+	// (which calls RemoveThreadAgentByAgent, clearing both thread mapping and
+	// listen flag). We restore it after re-establishing the thread binding.
+	wasListenThread := b.state != nil && b.state.IsListenThread(channel, threadTS)
+
 	// Infer project from channel (same logic as handleThreadSpawn).
 	project := b.projectFromChannel(ctx, channel)
 	if project == "" && b.router != nil {
@@ -148,13 +153,17 @@ func (b *Bot) respawnThreadAgent(ctx context.Context, channel, threadTS, agentNa
 		return
 	}
 
-	// Re-establish thread→agent mapping.
+	// Re-establish thread→agent mapping and restore listen-thread flag.
 	if b.state != nil {
 		_ = b.state.SetThreadAgent(channel, threadTS, agentName)
+		if wasListenThread {
+			_ = b.state.SetListenThread(channel, threadTS)
+		}
 	}
 
 	b.logger.Info("respawned thread agent with session resume",
-		"agent", agentName, "bead", beadID, "channel", channel, "thread_ts", threadTS)
+		"agent", agentName, "bead", beadID, "channel", channel, "thread_ts", threadTS,
+		"listen", wasListenThread)
 
 	// Post confirmation in thread.
 	if b.api != nil {
@@ -354,6 +363,9 @@ func (b *Bot) handleRestartThreadAgent(ctx context.Context, agentName string, ca
 		}
 		project := bead.Fields["project"]
 
+		// Snapshot the listen-thread flag before killAgent clears it.
+		wasListenThread := b.state != nil && b.state.IsListenThread(channelID, threadTS)
+
 		// Kill the agent (graceful shutdown + close bead + clean up state).
 		if err := b.killAgent(bgCtx, agentName, false); err != nil {
 			b.logger.Error("restart-thread-agent: kill failed", "agent", agentName, "error", err)
@@ -402,13 +414,17 @@ func (b *Bot) handleRestartThreadAgent(ctx context.Context, agentName string, ca
 			return
 		}
 
-		// Re-establish thread→agent mapping.
+		// Re-establish thread→agent mapping and restore listen-thread flag.
 		if b.state != nil {
 			_ = b.state.SetThreadAgent(channelID, threadTS, agentName)
+			if wasListenThread {
+				_ = b.state.SetListenThread(channelID, threadTS)
+			}
 		}
 
 		b.logger.Info("restarted thread agent", "agent", agentName, "new_bead", newBeadID,
-			"user", userID, "channel", channelID, "thread_ts", threadTS)
+			"user", userID, "channel", channelID, "thread_ts", threadTS,
+			"listen", wasListenThread)
 
 		if b.api != nil {
 			msg := fmt.Sprintf(":arrows_counterclockwise: Agent *%s* restarted with session resume. (tracking: `%s`)", agentName, newBeadID)

--- a/gasboat/controller/internal/bridge/bot_agents.go
+++ b/gasboat/controller/internal/bridge/bot_agents.go
@@ -59,6 +59,17 @@ func (b *Bot) pruneStaleAgentCards(ctx context.Context) {
 	}
 	b.mu.Unlock()
 
+	// Compact stale state entries alongside the card prune to prevent
+	// unbounded growth of decision/chat message refs in the state file.
+	if b.state != nil {
+		removed, err := b.state.CompactStaleEntries(active)
+		if err != nil {
+			b.logger.Warn("prune: state compaction failed", "error", err)
+		} else if removed > 0 {
+			b.logger.Info("prune: compacted stale state entries", "removed", removed)
+		}
+	}
+
 	if len(stale) == 0 {
 		b.logger.Info("prune agent cards: all cards are current", "total", cardCount)
 		return

--- a/gasboat/controller/internal/bridge/bot_thread_forward.go
+++ b/gasboat/controller/internal/bridge/bot_thread_forward.go
@@ -19,6 +19,11 @@ const threadNudgeInterval = 30 * time.Second
 
 // handleThreadForward creates a tracking bead and nudges the bound agent when
 // a non-mention message is posted in an agent thread.
+//
+// To avoid bead pollution in busy threads, a tracking bead is only created when
+// the nudge is NOT throttled. Throttled messages are still visible in the Slack
+// thread — the agent can read them via `gb slack thread`. The agent always sees
+// the full thread context on its next interaction.
 func (b *Bot) handleThreadForward(ctx context.Context, ev *slackevents.MessageEvent, agent string) {
 	agentName := extractAgentName(agent)
 
@@ -29,6 +34,14 @@ func (b *Bot) handleThreadForward(ctx context.Context, ev *slackevents.MessageEv
 		// Agent is gone — respawn the SAME agent name so the entrypoint
 		// finds the existing session JSONL and PVC for session continuity.
 		b.respawnThreadAgent(ctx, ev.Channel, ev.ThreadTimeStamp, agentName, ev.Text)
+		return
+	}
+
+	// Throttle check first — skip bead creation for rapid-fire thread replies
+	// to avoid creating dozens of orphaned task beads in active threads.
+	if b.shouldThrottleNudge(agentName, ev.ThreadTimeStamp) {
+		b.logger.Debug("thread-forward: skipping bead creation (throttled)",
+			"agent", agentName, "channel", ev.Channel)
 		return
 	}
 
@@ -80,21 +93,22 @@ func (b *Bot) handleThreadForward(ctx context.Context, ev *slackevents.MessageEv
 
 	// Persist message ref for response relay.
 	if b.state != nil {
-		_ = b.state.SetChatMessage(beadID, MessageRef{
+		if err := b.state.SetChatMessage(beadID, MessageRef{
 			ChannelID: ev.Channel,
 			Timestamp: ev.ThreadTimeStamp,
 			Agent:     agent,
-		})
+		}); err != nil {
+			b.logger.Warn("thread-forward: failed to persist chat message ref",
+				"bead", beadID, "error", err)
+		}
 	}
 
-	// Nudge with throttling — avoid flooding the agent in active threads.
-	if !b.shouldThrottleNudge(agentName, ev.ThreadTimeStamp) {
-		message := fmt.Sprintf("Slack thread reply (bead %s): %s", beadID, truncateText(ev.Text, 200))
-		client := &http.Client{Timeout: 10 * time.Second}
-		if err := NudgeAgent(ctx, b.daemon, client, b.logger, agentName, message); err != nil {
-			b.logger.Error("failed to nudge agent for thread forward",
-				"agent", agentName, "bead", beadID, "error", err)
-		}
+	// Nudge the agent with the thread reply.
+	message := fmt.Sprintf("Slack thread reply (bead %s): %s", beadID, truncateText(ev.Text, 200))
+	client := &http.Client{Timeout: 10 * time.Second}
+	if err := NudgeAgent(ctx, b.daemon, client, b.logger, agentName, message); err != nil {
+		b.logger.Error("failed to nudge agent for thread forward",
+			"agent", agentName, "bead", beadID, "error", err)
 	}
 }
 

--- a/gasboat/controller/internal/bridge/bot_thread_forward_test.go
+++ b/gasboat/controller/internal/bridge/bot_thread_forward_test.go
@@ -389,7 +389,7 @@ func TestNudgeThrottling_Expiry(t *testing.T) {
 	}
 }
 
-func TestHandleThreadForward_BeadAlwaysCreated(t *testing.T) {
+func TestHandleThreadForward_ThrottledMessagesSkipBeadCreation(t *testing.T) {
 	daemon := newMockDaemon()
 	daemon.beads["hq"] = &beadsapi.BeadDetail{
 		ID:    "bd-agent-hq",
@@ -420,7 +420,8 @@ func TestHandleThreadForward_BeadAlwaysCreated(t *testing.T) {
 
 	ctx := context.Background()
 
-	// Send two messages in quick succession — both should create beads.
+	// Send two messages in quick succession — only the first should create a bead.
+	// The second is throttled (within threadNudgeInterval) to prevent bead pollution.
 	for i, text := range []string{"first message", "second message"} {
 		ev := &slackevents.MessageEvent{
 			User:            "U-HUMAN",
@@ -439,8 +440,8 @@ func TestHandleThreadForward_BeadAlwaysCreated(t *testing.T) {
 			count++
 		}
 	}
-	if count != 2 {
-		t.Errorf("expected 2 thread-reply beads, got %d", count)
+	if count != 1 {
+		t.Errorf("expected 1 thread-reply bead (second throttled), got %d", count)
 	}
 }
 

--- a/gasboat/controller/internal/bridge/state.go
+++ b/gasboat/controller/internal/bridge/state.go
@@ -319,6 +319,59 @@ func (sm *StateManager) SetLastEventID(id string) error {
 	return sm.saveLocked()
 }
 
+// --- Compaction ---
+
+// CompactStaleEntries removes decision/chat messages and agent cards for
+// agents that are no longer active. This prevents unbounded growth of the
+// state file over weeks of operation. Returns the number of entries removed.
+// The activeAgents set should contain short agent names of currently active agents.
+func (sm *StateManager) CompactStaleEntries(activeAgents map[string]bool) (int, error) {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+
+	removed := 0
+
+	// Compact decision messages for agents that are no longer active.
+	for id, ref := range sm.data.DecisionMessages {
+		if ref.Agent != "" && !activeAgents[ref.Agent] {
+			delete(sm.data.DecisionMessages, id)
+			removed++
+		}
+	}
+
+	// Compact chat messages for agents that are no longer active.
+	for id, ref := range sm.data.ChatMessages {
+		if ref.Agent != "" && !activeAgents[ref.Agent] {
+			delete(sm.data.ChatMessages, id)
+			removed++
+		}
+	}
+
+	// Compact agent cards for agents that are no longer active.
+	for agent := range sm.data.AgentCards {
+		if !activeAgents[agent] {
+			delete(sm.data.AgentCards, agent)
+			removed++
+		}
+	}
+
+	if removed > 0 {
+		return removed, sm.saveLocked()
+	}
+	return 0, nil
+}
+
+// Stats returns counts of all tracked state entries (for observability).
+func (sm *StateManager) Stats() (decisions, chats, cards, threads, listens int) {
+	sm.mu.RLock()
+	defer sm.mu.RUnlock()
+	return len(sm.data.DecisionMessages),
+		len(sm.data.ChatMessages),
+		len(sm.data.AgentCards),
+		len(sm.data.ThreadAgents),
+		len(sm.data.ListenThreads)
+}
+
 // --- Persistence ---
 
 func (sm *StateManager) load() error {


### PR DESCRIPTION
## Summary
- **Listen-thread flag lost on respawn/restart**: `RemoveThreadAgentByAgent` clears both thread mapping and listen flag during kill. Now snapshots `wasListenThread` before kill and restores it after re-establishing the thread binding in both `respawnThreadAgent` and `handleRestartThreadAgent`.
- **Thread-forward bead pollution**: Throttle check was positioned after bead creation, causing orphaned task beads for rapid-fire thread messages. Moved throttle check before bead creation so throttled messages skip entirely (agent can still read them via `gb slack thread`).
- **State file unbounded growth**: Added `CompactStaleEntries()` to prune decision/chat/card refs for agents that are no longer active. Integrated into the existing 5-minute `pruneStaleAgentCards` cycle. Added `Stats()` method for observability.

## Test plan
- [x] Updated `TestHandleThreadForward_ThrottledMessagesSkipBeadCreation` — verifies second rapid message is throttled (1 bead, not 2)
- [x] All existing bridge tests pass (`go test ./internal/bridge/`)
- [x] `go build ./cmd/controller/` and `go build ./cmd/slack-bridge/` compile cleanly
- [ ] CI validation (GHA)

🤖 Generated with [Claude Code](https://claude.com/claude-code)