### PR TITLE
feat(gasboat/poolmanager): predictive scaling for prewarmed agent pools

### DIFF
--- a/gasboat/controller/internal/poolmanager/poolmanager.go
+++ b/gasboat/controller/internal/poolmanager/poolmanager.go
@@ -22,19 +22,21 @@ import (
 // Manager maintains prewarmed agent pools across multiple projects.
 // Each project with a prewarmed_pool config gets its own independent pool.
 type Manager struct {
-	daemon *beadsapi.Client
-	cfg    *config.Config
-	logger *slog.Logger
-	mu     sync.Mutex
-	seq    int // monotonic counter for unique agent names
+	daemon  *beadsapi.Client
+	cfg     *config.Config
+	logger  *slog.Logger
+	mu      sync.Mutex
+	seq     int            // monotonic counter for unique agent names
+	tracker *spawnTracker  // tracks assignment rate for predictive scaling
 }
 
 // New creates a multi-pool Manager.
 func New(daemon *beadsapi.Client, cfg *config.Config, logger *slog.Logger) *Manager {
 	return &Manager{
-		daemon: daemon,
-		cfg:    cfg,
-		logger: logger,
+		daemon:  daemon,
+		cfg:     cfg,
+		logger:  logger,
+		tracker: newSpawnTracker(),
 	}
 }
 
@@ -108,16 +110,22 @@ func (m *Manager) Reconcile(ctx context.Context) error {
 		return nil
 	}
 
-	// Reconcile each project pool: scale up to min, cap at max.
+	// Reconcile each project pool: scale to target (between min and max),
+	// adjusted by recent spawn rate for predictive scaling.
 	for _, pp := range pools {
 		active := byProject[pp.name]
 
-		// Enforce max_size: close excess agents if pool was shrunk.
-		if len(active) > pp.cfg.MaxSize {
-			excess := len(active) - pp.cfg.MaxSize
-			m.logger.Info("pool exceeds max_size, closing excess agents",
+		// Compute dynamic target based on recent assignment rate.
+		spawnRate := m.tracker.Rate(pp.name)
+		target := targetPoolSize(spawnRate, pp.cfg.MinSize, pp.cfg.MaxSize)
+
+		// Enforce max_size: close excess agents if pool was shrunk or
+		// spawn rate dropped.
+		if len(active) > target {
+			excess := len(active) - target
+			m.logger.Info("pool above target, closing excess agents",
 				"project", pp.name, "current", len(active),
-				"max", pp.cfg.MaxSize, "closing", excess)
+				"target", target, "spawn_rate", spawnRate, "closing", excess)
 			// Close oldest first (FIFO order).
 			sortByAge(active)
 			for i := 0; i < excess; i++ {
@@ -129,11 +137,11 @@ func (m *Manager) Reconcile(ctx context.Context) error {
 			active = active[excess:]
 		}
 
-		deficit := pp.cfg.MinSize - len(active)
+		deficit := target - len(active)
 		if deficit <= 0 {
 			continue
 		}
-		// Cap creation to not exceed max size.
+		// Hard cap at max_size regardless of target calculation.
 		if len(active)+deficit > pp.cfg.MaxSize {
 			deficit = pp.cfg.MaxSize - len(active)
 		}
@@ -141,9 +149,9 @@ func (m *Manager) Reconcile(ctx context.Context) error {
 			continue
 		}
 
-		m.logger.Info("pool below minimum, creating prewarmed agents",
+		m.logger.Info("pool below target, creating prewarmed agents",
 			"project", pp.name, "current", len(active),
-			"min", pp.cfg.MinSize, "creating", deficit)
+			"target", target, "spawn_rate", spawnRate, "creating", deficit)
 
 		for i := 0; i < deficit; i++ {
 			if err := m.createPrewarmedAgent(ctx, pp.name, pp.cfg); err != nil {
@@ -330,6 +338,9 @@ func (m *Manager) AssignPrewarmed(ctx context.Context, req AssignRequest) (*Assi
 	m.logger.Info("assigned prewarmed agent",
 		"bead", pick.ID, "agent", pick.AgentName,
 		"channel", req.Channel, "thread_ts", req.ThreadTS)
+
+	// Record assignment for predictive scaling.
+	m.tracker.Record(pick.Project)
 
 	// Nudge the agent's Claude session with the work description.
 	// The coop_url is stored in the bead notes by the status reporter.

--- a/gasboat/controller/internal/poolmanager/scaling.go
+++ b/gasboat/controller/internal/poolmanager/scaling.go
@@ -1,0 +1,72 @@
+package poolmanager
+
+import (
+	"sync"
+	"time"
+)
+
+// spawnWindow is the sliding window over which spawn rate is measured.
+const spawnWindow = 15 * time.Minute
+
+// spawnTracker records assignment timestamps per project for predictive scaling.
+// Thread-safe: guarded by its own mutex, independent of Manager.mu.
+type spawnTracker struct {
+	mu      sync.Mutex
+	spawns  map[string][]time.Time // project → sorted timestamps
+	nowFunc func() time.Time       // injectable clock for testing
+}
+
+func newSpawnTracker() *spawnTracker {
+	return &spawnTracker{
+		spawns:  make(map[string][]time.Time),
+		nowFunc: time.Now,
+	}
+}
+
+// Record adds a spawn event for a project at the current time.
+func (t *spawnTracker) Record(project string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.spawns[project] = append(t.spawns[project], t.nowFunc())
+}
+
+// Rate returns the number of spawns in the last spawnWindow for a project.
+func (t *spawnTracker) Rate(project string) int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	cutoff := t.nowFunc().Add(-spawnWindow)
+	times := t.spawns[project]
+	// Prune old entries while counting recent ones.
+	recent := times[:0]
+	for _, ts := range times {
+		if !ts.Before(cutoff) {
+			recent = append(recent, ts)
+		}
+	}
+	t.spawns[project] = recent
+	return len(recent)
+}
+
+// targetPoolSize computes the desired pool size based on recent spawn rate.
+// The formula scales linearly between minSize and maxSize:
+//   - 0 spawns in the window → minSize
+//   - spawnsForMax or more → maxSize
+//
+// spawnsForMax is the spawn count at which we want the pool at max capacity.
+// A reasonable default is maxSize itself (1 spawn per slot in the window).
+func targetPoolSize(spawnRate, minSize, maxSize int) int {
+	if maxSize <= minSize {
+		return minSize
+	}
+	// Scale linearly: each spawn in the window adds roughly one extra slot.
+	// spawnsForMax = maxSize: at max capacity when recent spawns equal max pool size.
+	spawnsForMax := maxSize
+	target := minSize + (spawnRate*(maxSize-minSize)+spawnsForMax-1)/spawnsForMax
+	if target > maxSize {
+		target = maxSize
+	}
+	if target < minSize {
+		target = minSize
+	}
+	return target
+}

--- a/gasboat/controller/internal/poolmanager/scaling_test.go
+++ b/gasboat/controller/internal/poolmanager/scaling_test.go
@@ -1,0 +1,108 @@
+package poolmanager
+
+import (
+	"testing"
+	"time"
+)
+
+func TestTargetPoolSize(t *testing.T) {
+	tests := []struct {
+		name      string
+		spawnRate int
+		min       int
+		max       int
+		want      int
+	}{
+		{"zero spawns → min", 0, 2, 10, 2},
+		{"max spawns → max", 10, 2, 10, 10},
+		{"over max spawns → capped at max", 20, 2, 10, 10},
+		{"half max spawns → midpoint", 5, 2, 10, 6},
+		{"one spawn → just above min", 1, 2, 10, 3},
+		{"min equals max → always that value", 3, 5, 5, 5},
+		{"zero min zero max → zero", 0, 0, 0, 0},
+		{"one spawn with small pool", 1, 1, 3, 2},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := targetPoolSize(tt.spawnRate, tt.min, tt.max)
+			if got != tt.want {
+				t.Errorf("targetPoolSize(%d, %d, %d) = %d, want %d",
+					tt.spawnRate, tt.min, tt.max, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSpawnTracker_RecordAndRate(t *testing.T) {
+	now := time.Date(2026, 3, 12, 12, 0, 0, 0, time.UTC)
+	tracker := newSpawnTracker()
+	tracker.nowFunc = func() time.Time { return now }
+
+	// No spawns → rate 0.
+	if rate := tracker.Rate("proj"); rate != 0 {
+		t.Fatalf("expected rate 0, got %d", rate)
+	}
+
+	// Record 3 spawns.
+	tracker.Record("proj")
+	tracker.Record("proj")
+	tracker.Record("proj")
+
+	if rate := tracker.Rate("proj"); rate != 3 {
+		t.Fatalf("expected rate 3, got %d", rate)
+	}
+
+	// Different project has independent rate.
+	if rate := tracker.Rate("other"); rate != 0 {
+		t.Fatalf("expected rate 0 for other project, got %d", rate)
+	}
+}
+
+func TestSpawnTracker_RatePrunesOldEntries(t *testing.T) {
+	now := time.Date(2026, 3, 12, 12, 0, 0, 0, time.UTC)
+	tracker := newSpawnTracker()
+	tracker.nowFunc = func() time.Time { return now }
+
+	// Record spawns.
+	tracker.Record("proj")
+	tracker.Record("proj")
+
+	// Advance time past the window.
+	now = now.Add(spawnWindow + time.Minute)
+	tracker.nowFunc = func() time.Time { return now }
+
+	// Old spawns should be pruned.
+	if rate := tracker.Rate("proj"); rate != 0 {
+		t.Fatalf("expected rate 0 after window expired, got %d", rate)
+	}
+}
+
+func TestSpawnTracker_MixedAges(t *testing.T) {
+	now := time.Date(2026, 3, 12, 12, 0, 0, 0, time.UTC)
+	tracker := newSpawnTracker()
+	tracker.nowFunc = func() time.Time { return now }
+
+	// Record 2 spawns in the past.
+	tracker.Record("proj")
+	tracker.Record("proj")
+
+	// Advance time so the first 2 are old but still within window.
+	now = now.Add(10 * time.Minute)
+	tracker.nowFunc = func() time.Time { return now }
+
+	// Record 1 more recent spawn.
+	tracker.Record("proj")
+
+	// All 3 should still be in window (10min < 15min window).
+	if rate := tracker.Rate("proj"); rate != 3 {
+		t.Fatalf("expected rate 3, got %d", rate)
+	}
+
+	// Advance past window for the first 2 but not the last.
+	now = now.Add(6 * time.Minute) // 16min total for first 2, 6min for last
+	tracker.nowFunc = func() time.Time { return now }
+
+	if rate := tracker.Rate("proj"); rate != 1 {
+		t.Fatalf("expected rate 1 (only recent spawn), got %d", rate)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds spawn rate tracking per project over a 15-minute sliding window
- Pool target dynamically scales between `min_size` and `max_size` based on recent assignment rate
- Zero config change needed — works automatically with existing `prewarmed_pool` project bead settings
- When activity is high, pool preemptively scales up; when quiet, it shrinks to `min_size`

## How it works
- `spawnTracker` records assignment timestamps per project (thread-safe, independent of pool mutex)
- On each 30s reconcile pass, `Rate(project)` counts spawns in the last 15 minutes
- `targetPoolSize()` linearly interpolates between min and max based on spawn rate
- Pool creates/closes agents to match the dynamic target instead of the static `min_size`

## Test plan
- [x] `TestTargetPoolSize` — 8 cases covering edge conditions (zero, max, over-max, equal min/max)
- [x] `TestSpawnTracker_RecordAndRate` — basic recording and rate counting
- [x] `TestSpawnTracker_RatePrunesOldEntries` — entries expire after window
- [x] `TestSpawnTracker_MixedAges` — partial expiry (old entries pruned, recent kept)
- [x] All existing poolmanager tests pass (14 total)
- [x] `go build ./cmd/controller/` compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)