### PR TITLE
feat(gasboat): add S3 session persistence config

### DIFF
--- a/gasboat/controller/cmd/controller/podspec.go
+++ b/gasboat/controller/cmd/controller/podspec.go
@@ -356,6 +356,17 @@ func applyCommonConfig(cfg *config.Config, spec *podmanager.AgentPodSpec) {
 		}
 	}
 
+	// Wire S3 config for session artifact persistence (transcripts, recordings, session logs).
+	if cfg.CoopS3Bucket != "" {
+		spec.Env["COOP_S3_BUCKET"] = cfg.CoopS3Bucket
+	}
+	if cfg.CoopS3Prefix != "" {
+		spec.Env["COOP_S3_PREFIX"] = cfg.CoopS3Prefix
+	}
+	if cfg.CoopS3Region != "" {
+		spec.Env["COOP_S3_REGION"] = cfg.CoopS3Region
+	}
+
 	// Wire NATS config to all agents for beads decisions, coop events, and bus emit.
 	if cfg.NatsURL != "" {
 		spec.Env["BEADS_NATS_URL"] = cfg.NatsURL

--- a/gasboat/controller/cmd/controller/podspec_project_test.go
+++ b/gasboat/controller/cmd/controller/podspec_project_test.go
@@ -495,3 +495,45 @@ func TestApplyCommonConfig_TeamsPartialResourceOverride(t *testing.T) {
 		t.Errorf("expected default cpu request %s, got %s", podmanager.DefaultCPURequest, cpuReq.String())
 	}
 }
+
+func TestApplyCommonConfig_S3EnvVars(t *testing.T) {
+	cfg := &config.Config{
+		CoopS3Bucket: "gasboat-sessions",
+		CoopS3Prefix: "prod/sessions",
+		CoopS3Region: "us-west-2",
+	}
+	spec := &podmanager.AgentPodSpec{
+		Project: "testproj",
+		Env:     map[string]string{},
+	}
+	applyCommonConfig(cfg, spec)
+
+	if spec.Env["COOP_S3_BUCKET"] != "gasboat-sessions" {
+		t.Errorf("COOP_S3_BUCKET = %q, want gasboat-sessions", spec.Env["COOP_S3_BUCKET"])
+	}
+	if spec.Env["COOP_S3_PREFIX"] != "prod/sessions" {
+		t.Errorf("COOP_S3_PREFIX = %q, want prod/sessions", spec.Env["COOP_S3_PREFIX"])
+	}
+	if spec.Env["COOP_S3_REGION"] != "us-west-2" {
+		t.Errorf("COOP_S3_REGION = %q, want us-west-2", spec.Env["COOP_S3_REGION"])
+	}
+}
+
+func TestApplyCommonConfig_S3EnvVars_Empty(t *testing.T) {
+	cfg := &config.Config{}
+	spec := &podmanager.AgentPodSpec{
+		Project: "testproj",
+		Env:     map[string]string{},
+	}
+	applyCommonConfig(cfg, spec)
+
+	if _, ok := spec.Env["COOP_S3_BUCKET"]; ok {
+		t.Error("COOP_S3_BUCKET should not be set when CoopS3Bucket is empty")
+	}
+	if _, ok := spec.Env["COOP_S3_PREFIX"]; ok {
+		t.Error("COOP_S3_PREFIX should not be set when CoopS3Prefix is empty")
+	}
+	if _, ok := spec.Env["COOP_S3_REGION"]; ok {
+		t.Error("COOP_S3_REGION should not be set when CoopS3Region is empty")
+	}
+}

--- a/gasboat/controller/internal/config/config.go
+++ b/gasboat/controller/internal/config/config.go
@@ -146,6 +146,21 @@ type Config struct {
 	// This is a volume mount (not SecretEnv), so it cannot be handled by config beads.
 	ClaudeOAuthSecret string
 
+	// --- S3 Session Persistence ---
+
+	// CoopS3Bucket is the S3 bucket for coop session artifact persistence
+	// (env: COOP_S3_BUCKET). When set, agent pods upload transcripts,
+	// recordings, and session logs to S3 for cross-pod recall.
+	CoopS3Bucket string
+
+	// CoopS3Prefix is the S3 key prefix for session artifacts (env: COOP_S3_PREFIX).
+	// Default (in coop): "coop/sessions".
+	CoopS3Prefix string
+
+	// CoopS3Region is the AWS region for the S3 bucket (env: COOP_S3_REGION).
+	// When empty, coop uses the default AWS region chain.
+	CoopS3Region string
+
 	// --- Coopmux ---
 
 	// CoopmuxURL is the URL of the coopmux service (env: COOPMUX_URL).
@@ -305,6 +320,11 @@ func Parse() *Config {
 
 		// Secrets & Credentials (only controller-level; per-project secrets via config beads)
 		ClaudeOAuthSecret: os.Getenv("CLAUDE_OAUTH_SECRET"),
+
+		// S3 Session Persistence
+		CoopS3Bucket: os.Getenv("COOP_S3_BUCKET"),
+		CoopS3Prefix: os.Getenv("COOP_S3_PREFIX"),
+		CoopS3Region: os.Getenv("COOP_S3_REGION"),
 
 		// Coopmux
 		CoopmuxURL:         os.Getenv("COOPMUX_URL"),

--- a/gasboat/controller/internal/config/config_test.go
+++ b/gasboat/controller/internal/config/config_test.go
@@ -182,6 +182,42 @@ func TestParse_EnvOverrides(t *testing.T) {
 	}
 }
 
+func TestParse_S3Config(t *testing.T) {
+	t.Setenv("COOP_S3_BUCKET", "gasboat-sessions")
+	t.Setenv("COOP_S3_PREFIX", "prod/sessions")
+	t.Setenv("COOP_S3_REGION", "us-west-2")
+
+	cfg := Parse()
+
+	if cfg.CoopS3Bucket != "gasboat-sessions" {
+		t.Errorf("CoopS3Bucket = %q, want gasboat-sessions", cfg.CoopS3Bucket)
+	}
+	if cfg.CoopS3Prefix != "prod/sessions" {
+		t.Errorf("CoopS3Prefix = %q, want prod/sessions", cfg.CoopS3Prefix)
+	}
+	if cfg.CoopS3Region != "us-west-2" {
+		t.Errorf("CoopS3Region = %q, want us-west-2", cfg.CoopS3Region)
+	}
+}
+
+func TestParse_S3Config_Empty(t *testing.T) {
+	t.Setenv("COOP_S3_BUCKET", "")
+	t.Setenv("COOP_S3_PREFIX", "")
+	t.Setenv("COOP_S3_REGION", "")
+
+	cfg := Parse()
+
+	if cfg.CoopS3Bucket != "" {
+		t.Errorf("CoopS3Bucket = %q, want empty", cfg.CoopS3Bucket)
+	}
+	if cfg.CoopS3Prefix != "" {
+		t.Errorf("CoopS3Prefix = %q, want empty", cfg.CoopS3Prefix)
+	}
+	if cfg.CoopS3Region != "" {
+		t.Errorf("CoopS3Region = %q, want empty", cfg.CoopS3Region)
+	}
+}
+
 func TestParse_SecretEnvVars(t *testing.T) {
 	// Controller-level secrets (not per-project — those come from config beads).
 	t.Setenv("BEADS_TOKEN_SECRET", "beads-token")

--- a/gasboat/helm/gasboat/templates/controller/deployment.yaml
+++ b/gasboat/helm/gasboat/templates/controller/deployment.yaml
@@ -191,6 +191,18 @@ spec:
             - name: SLACK_BRIDGE_URL
               value: {{ .Values.agents.slackBridgeURL | default (include "gasboat.slackBridge.serviceURL" .) }}
             {{- end }}
+            {{- if .Values.agents.s3.bucket }}
+            - name: COOP_S3_BUCKET
+              value: {{ .Values.agents.s3.bucket }}
+            {{- end }}
+            {{- if .Values.agents.s3.prefix }}
+            - name: COOP_S3_PREFIX
+              value: {{ .Values.agents.s3.prefix }}
+            {{- end }}
+            {{- if .Values.agents.s3.region }}
+            - name: COOP_S3_REGION
+              value: {{ .Values.agents.s3.region }}
+            {{- end }}
             {{- if .Values.agents.claudeModel }}
             - name: CLAUDE_MODEL
               value: {{ .Values.agents.claudeModel }}

--- a/gasboat/helm/gasboat/values.yaml
+++ b/gasboat/helm/gasboat/values.yaml
@@ -128,6 +128,17 @@ agents:
   # If empty, Claude Code uses its built-in default (Sonnet).
   claudeModel: ""
 
+  # --- S3 Session Persistence ---
+
+  # S3 bucket for coop session artifact persistence. When set, agent pods
+  # upload transcripts, recordings, and session logs to S3 for cross-pod
+  # recall and durable storage. Requires IRSA on the agent ServiceAccount
+  # (set agentServiceAccount.annotations with eks.amazonaws.com/role-arn).
+  s3:
+    bucket: ""        # e.g., "gasboat-sessions"
+    prefix: ""        # S3 key prefix (default in coop: "coop/sessions")
+    region: ""        # AWS region override (default: AWS SDK region chain)
+
   # --- Claude Agent Teams ---
 
   # Claude Code Agent Teams: allow a team lead session to spawn and coordinate


### PR DESCRIPTION
## Summary
- Wire `COOP_S3_BUCKET`, `COOP_S3_PREFIX`, `COOP_S3_REGION` env vars from controller config to agent pods
- Add `agents.s3` section to Helm values for S3 bucket configuration
- Coop already has full S3 implementation (`s3.rs`) — this connects the plumbing

## Context

Sessions smoke test (kd-DGQI5BcnQG) found that coop's S3 session persistence code is complete but the env vars aren't being passed to agent pods. This PR adds the controller-side plumbing so that setting a bucket in Helm values automatically enables S3 uploads for all agents.

## How to enable

1. Create S3 bucket and IAM role with S3 read/write permissions
2. Add IRSA annotation to agent ServiceAccount:
   ```yaml
   agents:
     agentServiceAccount:
       annotations:
         eks.amazonaws.com/role-arn: arn:aws:iam::ACCOUNT:role/gasboat-agent-s3
     s3:
       bucket: "gasboat-sessions"
   ```
3. Deploy and recreate agent pods

## Test plan
- [x] `go build ./cmd/controller/` compiles
- [x] `go build ./cmd/gb/` compiles
- [x] `go build ./cmd/slack-bridge/` compiles
- [x] `go test ./...` all tests pass (including new S3 config tests)
- [x] `helm lint gasboat/helm/gasboat/` passes
- [ ] Deploy with S3 bucket configured and verify coop uploads artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)