### PR TITLE
feat(gasboat/bridge): wire Router in slack-bridge for channel-scoped agents

### DIFF
--- a/gasboat/controller/cmd/slack-bridge/main.go
+++ b/gasboat/controller/cmd/slack-bridge/main.go
@@ -12,6 +12,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -144,6 +145,15 @@ func main() {
 		}
 	}
 
+	// Build channel router if configured.
+	var router *bridge.Router
+	if cfg.routerConfig != nil {
+		router = bridge.NewRouter(*cfg.routerConfig)
+		logger.Info("channel router enabled",
+			"patterns", len(cfg.routerConfig.Channels),
+			"default_channel", cfg.routerConfig.DefaultChannel)
+	}
+
 	if cfg.slackBotToken != "" && cfg.slackAppToken != "" {
 		// Socket Mode: real-time WebSocket connection for events, interactions, slash commands.
 		bot = bridge.NewBot(bridge.BotConfig{
@@ -153,6 +163,7 @@ func main() {
 			ThreadingMode:    cfg.threadingMode,
 			Daemon:           daemon,
 			State:            state,
+			Router:           router,
 			Bouncer:          bouncer,
 			Logger:           logger,
 			Debug:            cfg.debug,
@@ -401,6 +412,9 @@ type config struct {
 	// Coopmux terminal links
 	coopmuxPublicURL string
 
+	// Channel router
+	routerConfig *bridge.RouterConfig
+
 	// Gate (IP whitelist management)
 	bouncerEnabled     bool
 	bouncerNamespace   string
@@ -429,6 +443,15 @@ func parseConfig() *config {
 
 	repos := parseRepoList(envOrDefault("UNRELEASED_REPOS", "groblegark/gasboats"))
 
+	var routerCfg *bridge.RouterConfig
+	if v := os.Getenv("SLACK_ROUTER_CONFIG"); v != "" {
+		routerCfg = &bridge.RouterConfig{}
+		if err := json.Unmarshal([]byte(v), routerCfg); err != nil {
+			fmt.Fprintf(os.Stderr, "WARNING: invalid SLACK_ROUTER_CONFIG JSON: %v\n", err)
+			routerCfg = nil
+		}
+	}
+
 	return &config{
 		beadsHTTPAddr:      envOrDefault("BEADS_HTTP_ADDR", "http://localhost:8080"),
 		slackBotToken:      os.Getenv("SLACK_BOT_TOKEN"),
@@ -451,6 +474,8 @@ func parseConfig() *config {
 		controllerURL: os.Getenv("CONTROLLER_URL"),
 
 		coopmuxPublicURL: os.Getenv("COOPMUX_PUBLIC_URL"),
+
+		routerConfig: routerCfg,
 
 		bouncerEnabled:     os.Getenv("BOUNCER_ENABLED") == "true",
 		bouncerNamespace:   envOrDefault("BOUNCER_NAMESPACE", os.Getenv("POD_NAMESPACE")),

--- a/gasboat/helm/gasboat/templates/slack-bridge/deployment.yaml
+++ b/gasboat/helm/gasboat/templates/slack-bridge/deployment.yaml
@@ -149,6 +149,11 @@ spec:
             - name: COOPMUX_PUBLIC_URL
               value: "https://{{ .Values.coopmux.ingress.host }}/mux"
             {{- end }}
+            # Channel router
+            {{- if .Values.slackBridge.router }}
+            - name: SLACK_ROUTER_CONFIG
+              value: {{ .Values.slackBridge.router | toJson | quote }}
+            {{- end }}
             # Bouncer (IP whitelist management)
             {{- if .Values.slackBridge.bouncer.enabled }}
             - name: BOUNCER_ENABLED

--- a/gasboat/helm/gasboat/values.yaml
+++ b/gasboat/helm/gasboat/values.yaml
@@ -578,6 +578,19 @@ slackBridge:
     # Default: groblegark/gasboats (monorepo)
     repos: ""
 
+  # Channel router — maps agent identity patterns to Slack channels.
+  # Agent identity format: "project/role/name" (e.g., "gasboat/crew/test-bot").
+  # Patterns support wildcards: "*" matches any single segment.
+  # Example:
+  #   router:
+  #     default_channel: "C-DEFAULT"
+  #     channels:
+  #       "gasboat/crew/*": "C-CREW-CHANNEL"
+  #       "gasboat/thread/*": "C-THREAD-CHANNEL"
+  #     overrides:
+  #       "gasboat/crew/hq": "C-HQ-CHANNEL"
+  router: {}
+
   # Bouncer — IP whitelist management via /bouncer Slack command.
   # Patches Traefik Middleware CRs to add/remove IPs from sourceRange.
   bouncer:


### PR DESCRIPTION
## Summary

- Wire `SLACK_ROUTER_CONFIG` env var parsing in `cmd/slack-bridge/main.go` to construct and pass `Router` to `BotConfig`
- Add `slackBridge.router` values section to Helm chart with pattern documentation
- Add `SLACK_ROUTER_CONFIG` env var injection in slack-bridge deployment template

The Router code (`router.go`) and its integration with `resolveChannel()` already existed but were never wired up in production — the `BotConfig.Router` field was always nil. This commit closes that gap.

## How it works

Set `slackBridge.router` in Helm values:

```yaml
slackBridge:
  router:
    default_channel: "C-DEFAULT"
    channels:
      "gasboat/crew/*": "C-CREW-CHANNEL"
      "gasboat/thread/*": "C-THREAD-CHANNEL"
    overrides:
      "gasboat/crew/hq": "C-HQ-CHANNEL"
```

Or set `SLACK_ROUTER_CONFIG` env var directly with JSON:

```json
{"default_channel":"C-DEFAULT","channels":{"gasboat/crew/*":"C-CREW"},"overrides":{}}
```

## Resolution priority (unchanged)

1. Router override (exact agent match)
2. Router pattern match (wildcard patterns sorted by specificity)
3. Agent spawn channel (`slack_spawn_channel`)
4. Project primary channel
5. Router default channel
6. Bot default channel (`SLACK_CHANNEL`)

## Test plan

- [x] `go build ./cmd/slack-bridge/` compiles
- [x] `go build ./cmd/controller/` compiles
- [x] `go test ./internal/bridge/...` passes (existing router tests cover resolution logic)
- [x] `helm lint` passes
- [x] `helm template` with router config renders correct JSON in env var
- [x] `helm template` without router config omits the env var entirely

## Bead

kd-nMwODyiHoc (child of epic kd-ouMgoUyi1f)

🤖 Generated with [Claude Code](https://claude.com/claude-code)