### PR TITLE
fix(bridge): include prompt and reason in decision resolved nudge

### DIFF
--- a/gasboat/controller/internal/bridge/bot_decisions_modal.go
+++ b/gasboat/controller/internal/bridge/bot_decisions_modal.go
@@ -451,8 +451,27 @@ func (b *Bot) nudgeDecisionRequestingAgent(ctx context.Context, decisionBeadID s
 		return
 	}
 
+	// Build a nudge message with full decision context so the agent
+	// knows which decision was resolved, what was chosen, and why.
+	chosen := dec.Fields["chosen"]
+	rationale := dec.Fields["rationale"]
+	prompt := decisionQuestion(dec.Fields)
+
+	message := fmt.Sprintf("Decision %s resolved", decisionBeadID)
+	if prompt != "" {
+		message += fmt.Sprintf(": %s", prompt)
+	}
+	if chosen != "" {
+		message += fmt.Sprintf("\nChosen: %s", chosen)
+	}
+	if rationale != "" {
+		message += fmt.Sprintf("\nRationale: %s", rationale)
+	}
+	if ra := dec.Fields["required_artifact"]; ra != "" {
+		message += fmt.Sprintf("\nArtifact required (%s). Use `gb decision report %s` to submit.", ra, decisionBeadID)
+	}
+
 	client := &http.Client{Timeout: 10 * time.Second}
-	message := "Decision resolved: " + decisionBeadID
 	if err := nudgeCoop(ctx, client, coopURL, message); err != nil {
 		b.logger.Warn("nudge: failed to nudge agent for decision response",
 			"agent_bead", agentBeadID, "coop_url", coopURL, "error", err)

--- a/gasboat/controller/internal/bridge/decisions.go
+++ b/gasboat/controller/internal/bridge/decisions.go
@@ -141,7 +141,7 @@ func (d *Decisions) handleClosed(ctx context.Context, data []byte) {
 
 	chosen := bead.Fields["chosen"]
 
-	// SSE close events may not include close-time fields (chosen, rationale).
+	// SSE close events may not include close-time fields (chosen, rationale, prompt).
 	// Fetch the full bead when chosen is missing so nudgeAgent has complete data.
 	if chosen == "" {
 		if detail, err := d.daemon.GetBead(ctx, bead.ID); err == nil {
@@ -154,6 +154,14 @@ func (d *Decisions) handleClosed(ctx context.Context, data []byte) {
 			}
 			if v := detail.Fields["rationale"]; v != "" {
 				bead.Fields["rationale"] = v
+			}
+			// Backfill prompt/question so nudge message includes the decision context.
+			if decisionQuestion(bead.Fields) == "" {
+				if v := detail.Fields["prompt"]; v != "" {
+					bead.Fields["prompt"] = v
+				} else if v := detail.Fields["question"]; v != "" {
+					bead.Fields["question"] = v
+				}
 			}
 			if bead.Assignee == "" {
 				bead.Assignee = detail.Assignee
@@ -261,14 +269,24 @@ func (d *Decisions) nudgeAgent(ctx context.Context, bead BeadEvent) {
 
 	chosen := bead.Fields["chosen"]
 	rationale := bead.Fields["rationale"]
-	message := fmt.Sprintf("Decision resolved: %s", chosen)
+	prompt := decisionQuestion(bead.Fields)
+
+	// Build a nudge message that gives the agent full context about the
+	// resolved decision: the original prompt, the chosen option, and the
+	// rationale. Without the prompt, the agent has no idea which decision
+	// was resolved or why.
+	message := fmt.Sprintf("Decision %s resolved", bead.ID)
+	if prompt != "" {
+		message += fmt.Sprintf(": %s", prompt)
+	}
+	message += fmt.Sprintf("\nChosen: %s", chosen)
 	if rationale != "" {
-		message += fmt.Sprintf(" — %s", rationale)
+		message += fmt.Sprintf("\nRationale: %s", rationale)
 	}
 
 	// If the chosen option requires an artifact, append requirement to nudge.
 	if ra, ok := bead.Fields["required_artifact"]; ok && ra != "" {
-		message += fmt.Sprintf(" — Artifact required (%s). Use `gb decision report %s` to submit.", ra, bead.ID)
+		message += fmt.Sprintf("\nArtifact required (%s). Use `gb decision report %s` to submit.", ra, bead.ID)
 	}
 
 	if err := NudgeAgent(ctx, d.daemon, d.httpClient, d.logger, agentName, message); err != nil {

--- a/gasboat/controller/internal/bridge/decisions_test.go
+++ b/gasboat/controller/internal/bridge/decisions_test.go
@@ -97,6 +97,7 @@ func TestDecisions_HandleClosed_NudgesCoop(t *testing.T) {
 		Type:     "decision",
 		Assignee: "crew-town-crew-hq",
 		Fields: map[string]string{
+			"prompt":    "What color?",
 			"chosen":    "blue",
 			"rationale": "it's calming",
 		},
@@ -112,8 +113,9 @@ func TestDecisions_HandleClosed_NudgesCoop(t *testing.T) {
 	if msg == "" {
 		t.Fatal("expected coop nudge, got none")
 	}
-	if msg != "Decision resolved: blue \u2014 it's calming" {
-		t.Errorf("unexpected nudge message: %s", msg)
+	want := "Decision dec-1 resolved: What color?\nChosen: blue\nRationale: it's calming"
+	if msg != want {
+		t.Errorf("unexpected nudge message:\n got: %s\nwant: %s", msg, want)
 	}
 
 	// Verify notifier.UpdateDecision was called.
@@ -151,10 +153,11 @@ func TestDecisions_HandleClosed_RationaleFromFetch(t *testing.T) {
 		ID:    "agent-x",
 		Notes: "coop_url: " + coopServer.URL,
 	}
-	// Full bead has both chosen and rationale; SSE event only has chosen.
+	// Full bead has chosen, rationale, and prompt; SSE event has none.
 	daemon.beads["dec-rat"] = &beadsapi.BeadDetail{
 		ID: "dec-rat",
 		Fields: map[string]string{
+			"prompt":    "Should we proceed?",
 			"chosen":    "proceed",
 			"rationale": "looks good to me",
 		},
@@ -168,7 +171,7 @@ func TestDecisions_HandleClosed_RationaleFromFetch(t *testing.T) {
 		escalated:  make(map[string]time.Time),
 	}
 
-	// SSE event carries neither chosen nor rationale — both must come from the fetch.
+	// SSE event carries neither chosen nor rationale — all must come from the fetch.
 	closedEvent := marshalSSEBeadPayload(BeadEvent{
 		ID:       "dec-rat",
 		Type:     "decision",
@@ -182,7 +185,7 @@ func TestDecisions_HandleClosed_RationaleFromFetch(t *testing.T) {
 	msg := nudgeMessage
 	nudgeReceived.Unlock()
 
-	want := "Decision resolved: proceed \u2014 looks good to me"
+	want := "Decision dec-rat resolved: Should we proceed?\nChosen: proceed\nRationale: looks good to me"
 	if msg != want {
 		t.Errorf("nudge message = %q, want %q", msg, want)
 	}


### PR DESCRIPTION
## Summary

- Both decision-resolved nudge paths (SSE close event watcher + Slack modal submission) now include the full decision context: bead ID, original prompt/question, chosen option, rationale, and artifact requirements
- Previously the SSE nudge only sent `"Decision resolved: <chosen> — <rationale>"` and the modal nudge only sent `"Decision resolved: <beadID>"` — agents had no idea which decision was resolved or what the question was
- Also backfills the prompt field from the full bead fetch when SSE events omit it

## Test plan

- [x] All existing decision tests pass with updated expectations
- [x] Full controller test suite passes (`go test ./...`)
- [ ] Verify in staging that agents receiving a decision nudge see the prompt, chosen option, and rationale

🤖 Generated with [Claude Code](https://claude.com/claude-code)