### PR TITLE
feat(bridge): add PostMRNote and PostMRDiscussionReply to GitLabClient

### DIFF
--- a/gasboat/controller/internal/bridge/gitlab.go
+++ b/gasboat/controller/internal/bridge/gitlab.go
@@ -281,6 +281,41 @@ func (c *GitLabClient) UpdateMergeRequestDescription(ctx context.Context, projec
 	return nil
 }
 
+// GitLabNote represents a note (comment) on a GitLab merge request.
+type GitLabNote struct {
+	ID        int        `json:"id"`
+	Body      string     `json:"body"`
+	Author    GitLabUser `json:"author"`
+	CreatedAt string     `json:"created_at"`
+	System    bool       `json:"system"`
+}
+
+// PostMRNote creates a new note (comment) on a merge request.
+// POST /projects/:id/merge_requests/:merge_request_iid/notes
+func (c *GitLabClient) PostMRNote(ctx context.Context, projectPath string, mrIID int, body string) (*GitLabNote, error) {
+	encoded := url.PathEscape(projectPath)
+	path := fmt.Sprintf("/api/v4/projects/%s/merge_requests/%d/notes", encoded, mrIID)
+	reqBody := map[string]string{"body": body}
+	var note GitLabNote
+	if err := c.doJSON(ctx, http.MethodPost, path, reqBody, &note); err != nil {
+		return nil, fmt.Errorf("GitLab post MR note %s!%d: %w", projectPath, mrIID, err)
+	}
+	return &note, nil
+}
+
+// PostMRDiscussionReply adds a reply to an existing discussion thread on a merge request.
+// POST /projects/:id/merge_requests/:merge_request_iid/discussions/:discussion_id/notes
+func (c *GitLabClient) PostMRDiscussionReply(ctx context.Context, projectPath string, mrIID int, discussionID, body string) (*GitLabNote, error) {
+	encoded := url.PathEscape(projectPath)
+	path := fmt.Sprintf("/api/v4/projects/%s/merge_requests/%d/discussions/%s/notes", encoded, mrIID, discussionID)
+	reqBody := map[string]string{"body": body}
+	var note GitLabNote
+	if err := c.doJSON(ctx, http.MethodPost, path, reqBody, &note); err != nil {
+		return nil, fmt.Errorf("GitLab reply to discussion %s on MR %s!%d: %w", discussionID, projectPath, mrIID, err)
+	}
+	return &note, nil
+}
+
 // MRRef holds the parsed components of a GitLab MR URL.
 type MRRef struct {
 	ProjectPath string // e.g., "PiHealth/CoreFICS/fics-helm-chart"

--- a/gasboat/controller/internal/bridge/gitlab_test.go
+++ b/gasboat/controller/internal/bridge/gitlab_test.go
@@ -157,6 +157,101 @@ func TestGitLabClient_ErrorHandling(t *testing.T) {
 	}
 }
 
+func TestGitLabClient_PostMRNote(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Go's net/http decodes %2F, so check both forms.
+		wantPath := "/api/v4/projects/PiHealth/CoreFICS/monorepo/merge_requests/42/notes"
+		if r.URL.Path != wantPath {
+			t.Errorf("unexpected path: %s, want %s", r.URL.Path, wantPath)
+			http.NotFound(w, r)
+			return
+		}
+		if r.Method != http.MethodPost {
+			t.Errorf("unexpected method: %s, want POST", r.Method)
+		}
+		if r.Header.Get("PRIVATE-TOKEN") != "test-token" {
+			t.Error("missing or wrong PRIVATE-TOKEN header")
+		}
+		var body map[string]string
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		if body["body"] != "LGTM with one nit" {
+			t.Errorf("unexpected note body: %q", body["body"])
+		}
+		resp := GitLabNote{
+			ID:        1001,
+			Body:      body["body"],
+			Author:    GitLabUser{ID: 1, Username: "gasboat-bot"},
+			CreatedAt: "2026-03-13T18:00:00Z",
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := newTestGitLabClient(server.URL)
+	note, err := client.PostMRNote(context.Background(), "PiHealth/CoreFICS/monorepo", 42, "LGTM with one nit")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if note.ID != 1001 {
+		t.Errorf("note ID = %d, want 1001", note.ID)
+	}
+	if note.Body != "LGTM with one nit" {
+		t.Errorf("note Body = %q, want %q", note.Body, "LGTM with one nit")
+	}
+}
+
+func TestGitLabClient_PostMRDiscussionReply(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		wantPath := "/api/v4/projects/org/repo/merge_requests/7/discussions/abc123def/notes"
+		if r.URL.Path != wantPath {
+			t.Errorf("unexpected path: %s, want %s", r.URL.Path, wantPath)
+			http.NotFound(w, r)
+			return
+		}
+		if r.Method != http.MethodPost {
+			t.Errorf("unexpected method: %s, want POST", r.Method)
+		}
+		var body map[string]string
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		resp := GitLabNote{
+			ID:        2002,
+			Body:      body["body"],
+			Author:    GitLabUser{ID: 1, Username: "gasboat-bot"},
+			CreatedAt: "2026-03-13T18:05:00Z",
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := newTestGitLabClient(server.URL)
+	note, err := client.PostMRDiscussionReply(context.Background(), "org/repo", 7, "abc123def", "Fixed in latest push")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if note.ID != 2002 {
+		t.Errorf("note ID = %d, want 2002", note.ID)
+	}
+	if note.Body != "Fixed in latest push" {
+		t.Errorf("note Body = %q, want %q", note.Body, "Fixed in latest push")
+	}
+}
+
+func TestGitLabClient_PostMRNote_Error(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"message":"403 Forbidden"}`))
+	}))
+	defer server.Close()
+
+	client := newTestGitLabClient(server.URL)
+	_, err := client.PostMRNote(context.Background(), "org/repo", 42, "test")
+	if err == nil {
+		t.Fatal("expected error for 403 response")
+	}
+}
+
 func TestParseMRURL(t *testing.T) {
 	tests := []struct {
 		name        string


### PR DESCRIPTION
## Summary

- Add `PostMRNote()` — creates a new note (comment) on a GitLab merge request
- Add `PostMRDiscussionReply()` — replies to an existing discussion thread on a merge request
- Add `GitLabNote` struct for the response type
- Add tests for both methods including error handling

## Context

Building blocks for epic kd-BTpx0lhBSJ (GitLab MR comment agent bridge). These API methods will be used by the response forwarding component to post agent replies back to MR discussions.

## Test plan

- [x] `TestGitLabClient_PostMRNote` — verifies correct API path, method, auth header, request body, and response parsing
- [x] `TestGitLabClient_PostMRDiscussionReply` — verifies discussion reply path and response
- [x] `TestGitLabClient_PostMRNote_Error` — verifies error handling for non-2xx responses
- [x] All 19 existing GitLab tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)