### PR TITLE
feat(gasboat/bridge): filter bot comments in GitLab webhook

### DIFF
--- a/gasboat/controller/cmd/gitlab-bridge/main.go
+++ b/gasboat/controller/cmd/gitlab-bridge/main.go
@@ -90,9 +90,13 @@ func main() {
 	})
 
 	// Webhook endpoint for GitLab MR events.
-	mux.Handle("/webhook", bridge.GitLabWebhookHandler(
-		gitlabClient, daemon, cfg.gitlabWebhookSecret, logger,
-	))
+	mux.Handle("/webhook", bridge.GitLabWebhookHandlerWithConfig(bridge.GitLabWebhookConfig{
+		GitLab:        gitlabClient,
+		Daemon:        daemon,
+		WebhookSecret: cfg.gitlabWebhookSecret,
+		BotUsername:   cfg.gitlabBotUsername,
+		Logger:        logger,
+	}))
 
 	srv := &http.Server{
 		Addr:              cfg.listenAddr,
@@ -174,6 +178,7 @@ type config struct {
 	gitlabBaseURL        string
 	gitlabAPIToken       string
 	gitlabWebhookSecret  string
+	gitlabBotUsername    string // GitLab username of bot; notes from this user are ignored
 	gitlabGroupID        int
 	pollInterval         time.Duration
 	listenAddr           string
@@ -201,6 +206,7 @@ func parseConfig() *config {
 		gitlabBaseURL:       os.Getenv("GITLAB_BASE_URL"),
 		gitlabAPIToken:      os.Getenv("GITLAB_API_TOKEN"),
 		gitlabWebhookSecret: os.Getenv("GITLAB_WEBHOOK_SECRET"),
+		gitlabBotUsername:   os.Getenv("GITLAB_BOT_USERNAME"),
 		gitlabGroupID:       groupID,
 		pollInterval:        pollInterval,
 		listenAddr:          envOrDefault("LISTEN_ADDR", ":8092"),

--- a/gasboat/controller/internal/bridge/gitlab_sync.go
+++ b/gasboat/controller/internal/bridge/gitlab_sync.go
@@ -389,9 +389,32 @@ func (p *GitLabPoller) poll(ctx context.Context) {
 	}
 }
 
+// GitLabWebhookConfig holds configuration for the GitLab webhook handler.
+type GitLabWebhookConfig struct {
+	GitLab        *GitLabClient
+	Daemon        GitLabBeadClient
+	WebhookSecret string
+	BotUsername   string // GitLab username of the bot; notes from this user are ignored to prevent loops
+	Logger        *slog.Logger
+}
+
 // GitLabWebhookHandler returns an http.Handler that processes GitLab webhook
 // events for merge request merges.
 func GitLabWebhookHandler(gitlab *GitLabClient, daemon GitLabBeadClient, webhookSecret string, logger *slog.Logger) http.Handler {
+	return GitLabWebhookHandlerWithConfig(GitLabWebhookConfig{
+		GitLab:        gitlab,
+		Daemon:        daemon,
+		WebhookSecret: webhookSecret,
+		Logger:        logger,
+	})
+}
+
+// GitLabWebhookHandlerWithConfig returns an http.Handler using the full config.
+func GitLabWebhookHandlerWithConfig(cfg GitLabWebhookConfig) http.Handler {
+	daemon := cfg.Daemon
+	logger := cfg.Logger
+	webhookSecret := cfg.WebhookSecret
+	botUsername := cfg.BotUsername
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Verify webhook secret.
 		if r.Header.Get("X-Gitlab-Token") != webhookSecret {
@@ -454,7 +477,7 @@ func GitLabWebhookHandler(gitlab *GitLabClient, daemon GitLabBeadClient, webhook
 				}
 			}
 			handleNoteWebhook(r.Context(), event.ObjectAttr.NoteableType, event.ObjectAttr.Note,
-				event.ObjectAttr.System, event.User.Username, pos,
+				event.ObjectAttr.System, event.User.Username, botUsername, pos,
 				event.MergeRequest, daemon, logger)
 			w.WriteHeader(http.StatusOK)
 			fmt.Fprintf(w, `{"status":"processed","kind":"note"}`)
@@ -630,7 +653,8 @@ type notePosition struct {
 
 // handleNoteWebhook processes a GitLab note webhook event. It matches
 // MR review comments to beads and creates bead comments with the review feedback.
-func handleNoteWebhook(ctx context.Context, noteableType, note string, system bool, author string, position *notePosition, mr *struct {
+// Notes from the bot user (botUsername) are skipped to prevent feedback loops.
+func handleNoteWebhook(ctx context.Context, noteableType, note string, system bool, author, botUsername string, position *notePosition, mr *struct {
 	IID int    `json:"iid"`
 	URL string `json:"url"`
 }, daemon GitLabBeadClient, logger *slog.Logger) {
@@ -644,6 +668,16 @@ func handleNoteWebhook(ctx context.Context, noteableType, note string, system bo
 	// Skip system-generated notes (merge status changes, etc.).
 	if system {
 		logger.Debug("webhook: skipping system note")
+		return
+	}
+
+	// Skip notes from the bot user to prevent feedback loops.
+	// When the bridge posts MR comments on behalf of agents, GitLab fires
+	// a webhook for that note. Without this filter, the bridge would
+	// re-process its own comments endlessly.
+	if botUsername != "" && author == botUsername {
+		logger.Debug("webhook: skipping note from bot user",
+			"author", author, "bot_username", botUsername)
 		return
 	}
 

--- a/gasboat/controller/internal/bridge/gitlab_sync_test.go
+++ b/gasboat/controller/internal/bridge/gitlab_sync_test.go
@@ -481,6 +481,57 @@ func TestGitLabWebhookHandler_NoteEvent_SystemNote(t *testing.T) {
 	}
 }
 
+func TestGitLabWebhookHandler_NoteEvent_BotUsername(t *testing.T) {
+	daemon := newMockGitLabDaemon()
+	daemon.beads["bead-1"] = &beadsapi.BeadDetail{
+		ID:     "bead-1",
+		Type:   "task",
+		Fields: map[string]string{"mr_url": "https://gitlab.com/org/repo/-/merge_requests/42"},
+	}
+
+	handler := GitLabWebhookHandlerWithConfig(GitLabWebhookConfig{
+		Daemon:        daemon,
+		WebhookSecret: "secret",
+		BotUsername:   "gasboat-bot",
+		Logger:        slog.Default(),
+	})
+
+	event := map[string]any{
+		"object_kind": "note",
+		"user":        map[string]any{"username": "gasboat-bot"},
+		"object_attributes": map[string]any{
+			"note":          "I've addressed this in the latest commit.",
+			"noteable_type": "MergeRequest",
+			"system":        false,
+		},
+		"merge_request": map[string]any{
+			"iid": 42,
+			"url": "https://gitlab.com/org/repo/-/merge_requests/42",
+		},
+	}
+	body, _ := json.Marshal(event)
+
+	req := httptest.NewRequest(http.MethodPost, "/webhook", bytes.NewReader(body))
+	req.Header.Set("X-Gitlab-Token", "secret")
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	// Bot comments should be ignored — no comments or field updates.
+	comments := daemon.getComments()
+	if len(comments) != 0 {
+		t.Errorf("expected 0 comments for bot user, got %d", len(comments))
+	}
+	bead := daemon.getBead("bead-1")
+	if bead.Fields["mr_has_review_comments"] != "" {
+		t.Errorf("mr_has_review_comments should be empty for bot note, got %s", bead.Fields["mr_has_review_comments"])
+	}
+}
+
 func TestGitLabWebhookHandler_NoteEvent_NoMatchingBead(t *testing.T) {
 	daemon := newMockGitLabDaemon()
 	daemon.beads["bead-1"] = &beadsapi.BeadDetail{


### PR DESCRIPTION
## Summary
- Add `GitLabWebhookConfig` struct with `BotUsername` field for configurable bot comment filtering
- Add `GitLabWebhookHandlerWithConfig()` as the primary webhook handler; keep `GitLabWebhookHandler()` as backward-compatible wrapper
- Filter note webhook events authored by the configured bot username to prevent feedback loops when the bridge posts MR comments
- Wire `GITLAB_BOT_USERNAME` env var into gitlab-bridge main.go config

## Test plan
- [x] `TestGitLabWebhookHandler_NoteEvent_BotUsername` — verifies bot-authored notes are silently dropped
- [x] Existing webhook handler tests continue to pass (backward compatibility)
- [x] `go test ./internal/bridge/` passes (22.9s)

Bead: kd-bB5Z5c4S6Q
Epic: kd-BTpx0lhBSJ

🤖 Generated with [Claude Code](https://claude.com/claude-code)