### PR TITLE
fix(gasboat/bridge): prevent duplicate Jira comments on bridge restart

### DIFF
--- a/gasboat/controller/cmd/jira-bridge/main.go
+++ b/gasboat/controller/cmd/jira-bridge/main.go
@@ -142,6 +142,10 @@ func main() {
 	})
 	jiraSync.RegisterHandlers(sseStream)
 
+	// Pre-populate dedup map with existing Jira beads to prevent duplicate
+	// comments/transitions on SSE replay after restart.
+	jiraSync.CatchUp(ctx, daemon)
+
 	// Start the SSE stream.
 	go func() {
 		if err := sseStream.Start(ctx); err != nil && ctx.Err() == nil {

--- a/gasboat/controller/internal/bridge/jira_sync.go
+++ b/gasboat/controller/internal/bridge/jira_sync.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"gasboat/controller/internal/beadsapi"
 )
 
 // syncTTL is the dedup window for sync-back operations.
@@ -56,6 +58,77 @@ func (s *JiraSync) RegisterHandlers(stream *SSEStream) {
 	stream.On("beads.bead.closed", s.handleClosed)
 	s.logger.Info("JIRA sync watcher registered SSE handlers",
 		"topics", []string{"beads.bead.updated", "beads.bead.closed"})
+}
+
+// JiraSyncCatchUpClient is the subset of beadsapi.Client needed for catch-up.
+type JiraSyncCatchUpClient interface {
+	ListBeadsFiltered(ctx context.Context, q beadsapi.ListBeadsQuery) (*beadsapi.ListBeadsResult, error)
+}
+
+// CatchUp fetches existing Jira-sourced beads from the daemon and pre-populates
+// the dedup map so that SSE replay after a restart does not re-post comments,
+// links, or transitions that were already synced.
+func (s *JiraSync) CatchUp(ctx context.Context, client JiraSyncCatchUpClient) {
+	if client == nil {
+		return
+	}
+
+	// Fetch all active issue-kind beads with source:jira label.
+	result, err := client.ListBeadsFiltered(ctx, beadsapi.ListBeadsQuery{
+		Kinds:    []string{"issue"},
+		Statuses: []string{"open", "in_progress"},
+		Labels:   []string{"source:jira"},
+		Limit:    500,
+	})
+	if err != nil {
+		s.logger.Warn("jira catch-up: failed to list beads", "error", err)
+		return
+	}
+
+	marked := 0
+	for _, bead := range result.Beads {
+		jiraKey := bead.Fields["jira_key"]
+		if jiraKey == "" {
+			// Fallback: check labels.
+			for _, label := range bead.Labels {
+				if strings.HasPrefix(label, "jira:") && !strings.HasPrefix(label, "jira-label:") {
+					jiraKey = strings.TrimPrefix(label, "jira:")
+					break
+				}
+			}
+		}
+		if jiraKey == "" {
+			continue
+		}
+
+		// Pre-mark claimed beads.
+		if bead.Status == "in_progress" && bead.Assignee != "" {
+			s.mark("claimed:" + bead.ID + ":" + bead.Assignee)
+			marked++
+		}
+
+		// Pre-mark MR links.
+		if mrURL := bead.Fields["mr_url"]; mrURL != "" {
+			s.mark("mr:" + bead.ID + ":" + mrURL)
+			marked++
+		}
+
+		// Pre-mark MR merged.
+		if bead.Fields["mr_merged"] == "true" {
+			s.mark("merged:" + bead.ID)
+			marked++
+		}
+	}
+
+	s.logger.Info("jira catch-up complete",
+		"beads", len(result.Beads), "marked", marked)
+}
+
+// mark records a dedup key as seen without returning whether it was already present.
+func (s *JiraSync) mark(key string) {
+	s.mu.Lock()
+	s.seen[key] = time.Now()
+	s.mu.Unlock()
 }
 
 func (s *JiraSync) handleUpdated(ctx context.Context, data []byte) {

--- a/gasboat/controller/internal/bridge/jira_sync_test.go
+++ b/gasboat/controller/internal/bridge/jira_sync_test.go
@@ -9,6 +9,8 @@ import (
 	"net/http/httptest"
 	"sync"
 	"testing"
+
+	"gasboat/controller/internal/beadsapi"
 )
 
 func TestJiraSync_MRLink(t *testing.T) {
@@ -546,4 +548,86 @@ func TestAdfToMarkdown(t *testing.T) {
 			}
 		})
 	}
+}
+
+// mockCatchUpClient implements JiraSyncCatchUpClient for testing.
+type mockCatchUpClient struct {
+	beads []*beadsapi.BeadDetail
+	err   error
+}
+
+func (m *mockCatchUpClient) ListBeadsFiltered(_ context.Context, _ beadsapi.ListBeadsQuery) (*beadsapi.ListBeadsResult, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return &beadsapi.ListBeadsResult{Beads: m.beads, Total: len(m.beads)}, nil
+}
+
+func TestJiraSync_CatchUp_PreventsReplay(t *testing.T) {
+	var (
+		mu           sync.Mutex
+		commentCount int
+	)
+
+	jiraServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
+		switch {
+		case r.Method == "POST" && r.URL.Path == "/rest/api/3/issue/PE-900/comment":
+			commentCount++
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprint(w, `{"id":"1"}`)
+		case r.Method == "PUT" && r.URL.Path == "/rest/api/3/issue/PE-900":
+			w.WriteHeader(http.StatusNoContent)
+		case r.Method == "GET" && r.URL.Path == "/rest/api/3/issue/PE-900/transitions":
+			resp := map[string]any{"transitions": []map[string]any{
+				{"id": "21", "name": "In Progress", "to": map[string]string{"name": "In Progress"}},
+			}}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(resp)
+		case r.Method == "POST" && r.URL.Path == "/rest/api/3/issue/PE-900/transitions":
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer jiraServer.Close()
+
+	s := NewJiraSync(JiraSyncConfig{Jira: newTestJiraClient(jiraServer.URL), Logger: slog.Default()})
+
+	// Simulate restart catch-up: bead is already in_progress with an assignee.
+	client := &mockCatchUpClient{
+		beads: []*beadsapi.BeadDetail{
+			{
+				ID:       "bd-task-20",
+				Status:   "in_progress",
+				Assignee: "agent-old",
+				Labels:   []string{"source:jira", "jira:PE-900"},
+				Fields:   map[string]string{"jira_key": "PE-900", "mr_url": "https://gitlab.com/mr/1"},
+			},
+		},
+	}
+	s.CatchUp(context.Background(), client)
+
+	// SSE replays the same event after restart — should be deduped.
+	event := marshalSSEBeadPayload(BeadEvent{
+		ID: "bd-task-20", Type: "task", Title: "[PE-900] Fix auth",
+		Status:   "in_progress",
+		Assignee: "agent-old",
+		Labels:   []string{"source:jira", "jira:PE-900"},
+		Fields:   map[string]string{"jira_key": "PE-900", "mr_url": "https://gitlab.com/mr/1"},
+	})
+	s.handleUpdated(context.Background(), event)
+
+	mu.Lock()
+	defer mu.Unlock()
+	if commentCount != 0 {
+		t.Errorf("expected 0 comments after catch-up (deduped), got %d", commentCount)
+	}
+}
+
+func TestJiraSync_CatchUp_NilClient(t *testing.T) {
+	s := NewJiraSync(JiraSyncConfig{Jira: newTestJiraClient("https://example.com"), Logger: slog.Default()})
+	// Should not panic.
+	s.CatchUp(context.Background(), nil)
 }


### PR DESCRIPTION
## Summary
- Add `CatchUp()` method to `JiraSync` that pre-populates the dedup map with existing in-progress Jira beads before the SSE stream starts
- On restart, the SSE stream replays events from the persisted `Last-Event-ID`, but the in-memory dedup map is empty — causing duplicate "Gasboat agent X is working on this issue" comments, MR link posts, and transition attempts
- The catch-up fetches all active `source:jira` beads and marks their claimed, mr_url, and mr_merged dedup keys as already seen
- Wire the catch-up call in `jira-bridge/main.go` between handler registration and SSE stream start

## Root cause
The Jira bridge's `JiraSync` uses an in-memory dedup map with 10-minute TTL. On pod restart, this map is cleared. When the SSE stream reconnects with the persisted `Last-Event-ID`, it replays all events since that ID. Without catch-up pre-population, every replayed `in_progress` event re-triggers Jira comments and transitions.

The Slack bridge already had this pattern (`CatchUpDecisions`, `CatchUpAgents`), but the Jira bridge was missing it.

## Test plan
- [x] `TestJiraSync_CatchUp_PreventsReplay` — verifies SSE replay after catch-up produces zero duplicate comments
- [x] `TestJiraSync_CatchUp_NilClient` — verifies nil client is safe (no panic)
- [x] All existing JiraSync tests pass (dedup, claim, MR link, closed, merged, transitions)
- [x] `go build ./cmd/jira-bridge/` succeeds
- [x] Full bridge test suite passes (22.9s)

Bead: kd-bs9y1Y5r0j

🤖 Generated with [Claude Code](https://claude.com/claude-code)