### PR TITLE
feat(gasboat/bridge): add agent lookup/reuse for MR review comments

### DIFF
--- a/gasboat/controller/cmd/gitlab-bridge/main.go
+++ b/gasboat/controller/cmd/gitlab-bridge/main.go
@@ -145,11 +145,18 @@ func main() {
 	})
 
 	// Register GitLab sync handler on the SSE stream.
-	gitlabSync := bridge.NewGitLabSync(bridge.GitLabSyncConfig{
-		GitLab: gitlabClient,
+	agentResolver := bridge.NewAgentResolver(bridge.AgentResolverConfig{
 		Daemon: daemon,
+		GitLab: gitlabClient,
+		Client: nudgeClient,
 		Logger: logger,
-		Nudge:  nudgeFunc,
+	})
+	gitlabSync := bridge.NewGitLabSync(bridge.GitLabSyncConfig{
+		GitLab:   gitlabClient,
+		Daemon:   daemon,
+		Logger:   logger,
+		Resolver: agentResolver,
+		Nudge:    nudgeFunc,
 	})
 	gitlabSync.RegisterHandlers(sseStream)
 

--- a/gasboat/controller/internal/bridge/gitlab_agent_resolver.go
+++ b/gasboat/controller/internal/bridge/gitlab_agent_resolver.go
@@ -1,0 +1,179 @@
+// Package bridge provides the GitLab MR agent resolver.
+//
+// AgentResolver handles agent lookup and reuse for MR review comments.
+// When a review comment arrives on an agent-authored MR, it finds the original
+// agent (or spawns a new one) and delivers the review context.
+package bridge
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strconv"
+
+	"gasboat/controller/internal/beadsapi"
+)
+
+// AgentResolverClient is the subset of beadsapi.Client used by AgentResolver.
+type AgentResolverClient interface {
+	FindAgentBead(ctx context.Context, agentName string) (*beadsapi.BeadDetail, error)
+	SpawnAgent(ctx context.Context, agentName, project, taskID, role, customPrompt string, extraFields ...map[string]string) (string, error)
+	UpdateBeadFields(ctx context.Context, beadID string, fields map[string]string) error
+}
+
+// AgentResolver looks up or spawns agents for MR review comment handling.
+type AgentResolver struct {
+	daemon AgentResolverClient
+	gitlab *GitLabClient
+	client *http.Client
+	logger *slog.Logger
+}
+
+// AgentResolverConfig holds configuration for the AgentResolver.
+type AgentResolverConfig struct {
+	Daemon AgentResolverClient
+	GitLab *GitLabClient
+	Client *http.Client // HTTP client for nudge delivery
+	Logger *slog.Logger
+}
+
+// NewAgentResolver creates a new AgentResolver.
+func NewAgentResolver(cfg AgentResolverConfig) *AgentResolver {
+	return &AgentResolver{
+		daemon: cfg.Daemon,
+		gitlab: cfg.GitLab,
+		client: cfg.Client,
+		logger: cfg.Logger,
+	}
+}
+
+// ResolveAndNudge finds the agent assigned to the given task bead and delivers
+// a nudge with the review comment context. If the agent is dead (no active
+// agent bead found), it spawns a new agent pre-assigned to the task with the
+// MR branch context.
+//
+// The taskBead must have a non-empty Assignee field (the agent name) and an
+// mr_url field pointing to the GitLab MR.
+func (r *AgentResolver) ResolveAndNudge(ctx context.Context, taskBead BeadEvent, message string) error {
+	agentName := taskBead.Assignee
+	if agentName == "" {
+		return fmt.Errorf("task bead %s has no assignee", taskBead.ID)
+	}
+
+	mrURL := taskBead.Fields["mr_url"]
+
+	// Try to find the existing agent bead.
+	agentBead, err := r.daemon.FindAgentBead(ctx, agentName)
+	if err == nil && agentBead != nil {
+		// Agent exists — check if it has a coop_url (alive).
+		coopURL := beadsapi.ParseNotes(agentBead.Notes)["coop_url"]
+		if coopURL == "" {
+			// Also check fields (coop_url may be stored as a field).
+			coopURL = agentBead.Fields["coop_url"]
+		}
+		if coopURL != "" {
+			r.logger.Info("agent alive, nudging for MR review",
+				"agent", agentName, "task", taskBead.ID, "mr_url", mrURL)
+
+			// Store MR binding metadata on the agent bead (best-effort).
+			r.setMRBindingFields(ctx, agentBead.ID, taskBead)
+
+			return nudgeCoop(ctx, r.client, coopURL, message)
+		}
+		r.logger.Info("agent bead exists but has no coop_url, treating as dead",
+			"agent", agentName, "task", taskBead.ID)
+	}
+
+	// Agent is dead or not found — spawn a new one.
+	r.logger.Info("spawning new agent for MR review comment",
+		"agent", agentName, "task", taskBead.ID, "mr_url", mrURL)
+
+	return r.spawnAgentForMR(ctx, agentName, taskBead)
+}
+
+// spawnAgentForMR creates a new agent bead pre-assigned to the task with MR
+// context. The agent is spawned with the same name so the entrypoint can find
+// existing session data (PVC, JSONL) for session continuity.
+func (r *AgentResolver) spawnAgentForMR(ctx context.Context, agentName string, taskBead BeadEvent) error {
+	// Resolve project from task bead labels.
+	project := projectFromLabels(taskBead.Labels)
+
+	// Build the custom prompt with MR context.
+	mrURL := taskBead.Fields["mr_url"]
+	prompt := fmt.Sprintf(
+		"You have been respawned to address review comments on MR %s (task %s: %s). "+
+			"Check out the MR branch, read the review comments, and address the feedback. "+
+			"Use `kd show %s` to see the full task context and comments.",
+		mrURL, taskBead.ID, taskBead.Title, taskBead.ID)
+
+	// Build extra fields with MR binding metadata.
+	extraFields := r.buildMRFields(taskBead)
+	extraFields["spawn_source"] = "gitlab-mr-review"
+
+	agentBeadID, err := r.daemon.SpawnAgent(ctx, agentName, project, taskBead.ID, "crew", prompt, extraFields)
+	if err != nil {
+		return fmt.Errorf("spawn agent %q for MR review: %w", agentName, err)
+	}
+
+	r.logger.Info("spawned agent for MR review",
+		"agent", agentName, "agent_bead", agentBeadID,
+		"task", taskBead.ID, "mr_url", mrURL, "project", project)
+	return nil
+}
+
+// setMRBindingFields stores GitLab MR metadata on the agent bead so the agent
+// knows which MR/branch to work on. Best-effort: errors are logged but not
+// returned.
+func (r *AgentResolver) setMRBindingFields(ctx context.Context, agentBeadID string, taskBead BeadEvent) {
+	fields := r.buildMRFields(taskBead)
+	if len(fields) == 0 {
+		return
+	}
+	if err := r.daemon.UpdateBeadFields(ctx, agentBeadID, fields); err != nil {
+		r.logger.Warn("failed to set MR binding fields on agent bead",
+			"agent_bead", agentBeadID, "error", err)
+	}
+}
+
+// buildMRFields extracts GitLab MR metadata from a task bead into a field map
+// suitable for storing on the agent bead.
+func (r *AgentResolver) buildMRFields(taskBead BeadEvent) map[string]string {
+	fields := make(map[string]string)
+
+	if mrURL := taskBead.Fields["mr_url"]; mrURL != "" {
+		fields["gitlab_mr_url"] = mrURL
+	}
+	if pid := taskBead.Fields["gitlab_project_id"]; pid != "" {
+		fields["gitlab_project_id"] = pid
+	}
+	if iid := taskBead.Fields["gitlab_mr_iid"]; iid != "" {
+		fields["gitlab_mr_iid"] = iid
+	}
+
+	// Fetch MR details from GitLab to get the source branch.
+	if r.gitlab != nil {
+		if mrURL := taskBead.Fields["mr_url"]; mrURL != "" {
+			ref := ParseMRURL(mrURL)
+			if ref != nil {
+				mr, err := r.gitlab.GetMergeRequestByPath(context.Background(), ref.ProjectPath, ref.IID)
+				if err == nil && mr != nil {
+					fields["gitlab_mr_source_branch"] = mr.SourceBranch
+					// Backfill project_id and iid if not already set.
+					if fields["gitlab_project_id"] == "" {
+						fields["gitlab_project_id"] = strconv.Itoa(mr.ProjectID)
+					}
+					if fields["gitlab_mr_iid"] == "" {
+						fields["gitlab_mr_iid"] = strconv.Itoa(mr.IID)
+					}
+				} else if err != nil {
+					r.logger.Warn("failed to fetch MR details for source branch",
+						"mr_url", mrURL, "error", err)
+				}
+			}
+		}
+	}
+
+	return fields
+}
+

--- a/gasboat/controller/internal/bridge/gitlab_agent_resolver_test.go
+++ b/gasboat/controller/internal/bridge/gitlab_agent_resolver_test.go
@@ -1,0 +1,493 @@
+package bridge
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"gasboat/controller/internal/beadsapi"
+)
+
+// mockResolverDaemon implements AgentResolverClient for testing.
+type mockResolverDaemon struct {
+	mu           sync.Mutex
+	agentBeads   map[string]*beadsapi.BeadDetail // agent name → bead
+	spawnedBeads []*beadsapi.BeadDetail
+	updatedBeads map[string]map[string]string // bead ID → fields
+	spawnErr     error
+}
+
+func newMockResolverDaemon() *mockResolverDaemon {
+	return &mockResolverDaemon{
+		agentBeads:   make(map[string]*beadsapi.BeadDetail),
+		updatedBeads: make(map[string]map[string]string),
+	}
+}
+
+func (m *mockResolverDaemon) FindAgentBead(_ context.Context, agentName string) (*beadsapi.BeadDetail, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if b, ok := m.agentBeads[agentName]; ok {
+		return b, nil
+	}
+	return nil, &beadsapi.APIError{StatusCode: 404, Message: "not found"}
+}
+
+func (m *mockResolverDaemon) SpawnAgent(_ context.Context, agentName, project, taskID, role, customPrompt string, extraFields ...map[string]string) (string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.spawnErr != nil {
+		return "", m.spawnErr
+	}
+	id := "bd-spawned-" + agentName
+	fields := map[string]string{
+		"agent":   agentName,
+		"project": project,
+		"mode":    "crew",
+		"role":    role,
+		"prompt":  customPrompt,
+	}
+	if taskID != "" {
+		fields["task_id"] = taskID
+	}
+	for _, extra := range extraFields {
+		for k, v := range extra {
+			fields[k] = v
+		}
+	}
+	bead := &beadsapi.BeadDetail{
+		ID:     id,
+		Title:  agentName,
+		Type:   "agent",
+		Fields: fields,
+	}
+	m.spawnedBeads = append(m.spawnedBeads, bead)
+	return id, nil
+}
+
+func (m *mockResolverDaemon) UpdateBeadFields(_ context.Context, beadID string, fields map[string]string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.updatedBeads[beadID] = fields
+	return nil
+}
+
+func (m *mockResolverDaemon) getSpawned() []*beadsapi.BeadDetail {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]*beadsapi.BeadDetail{}, m.spawnedBeads...)
+}
+
+func (m *mockResolverDaemon) getUpdated(beadID string) map[string]string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.updatedBeads[beadID]
+}
+
+// newTestAgentResolver creates an AgentResolver with a mock daemon and a GitLab
+// test server that returns MR details.
+func newTestAgentResolver(daemon *mockResolverDaemon, gitlabServer *httptest.Server) *AgentResolver {
+	var gitlab *GitLabClient
+	if gitlabServer != nil {
+		gitlab = newTestGitLabClient(gitlabServer.URL)
+	}
+	return NewAgentResolver(AgentResolverConfig{
+		Daemon: daemon,
+		GitLab: gitlab,
+		Client: &http.Client{},
+		Logger: slog.Default(),
+	})
+}
+
+func TestResolveAndNudge_AgentAlive_Nudges(t *testing.T) {
+	// Set up a coop server that accepts nudges.
+	var nudgeReceived string
+	coopServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/agent/nudge" {
+			var body map[string]string
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			nudgeReceived = body["message"]
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]bool{"delivered": true})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer coopServer.Close()
+
+	daemon := newMockResolverDaemon()
+	daemon.agentBeads["test-agent"] = &beadsapi.BeadDetail{
+		ID:    "bd-agent-1",
+		Title: "test-agent",
+		Type:  "agent",
+		Notes: "coop_url: " + coopServer.URL,
+		Fields: map[string]string{
+			"agent":   "test-agent",
+			"project": "gasboat",
+		},
+	}
+
+	resolver := newTestAgentResolver(daemon, nil)
+
+	taskBead := BeadEvent{
+		ID:       "kd-task-1",
+		Type:     "task",
+		Title:    "Fix auth bug",
+		Assignee: "test-agent",
+		Labels:   []string{"project:gasboat"},
+		Fields: map[string]string{
+			"mr_url":            "https://gitlab.com/org/repo/-/merge_requests/42",
+			"gitlab_project_id": "99",
+			"gitlab_mr_iid":     "42",
+		},
+	}
+
+	err := resolver.ResolveAndNudge(context.Background(), taskBead, "Review comment: fix the bug")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if nudgeReceived != "Review comment: fix the bug" {
+		t.Errorf("nudge message = %q, want %q", nudgeReceived, "Review comment: fix the bug")
+	}
+
+	// Verify MR binding fields were set on agent bead.
+	updated := daemon.getUpdated("bd-agent-1")
+	if updated["gitlab_mr_url"] != "https://gitlab.com/org/repo/-/merge_requests/42" {
+		t.Errorf("gitlab_mr_url = %q, want MR URL", updated["gitlab_mr_url"])
+	}
+	if updated["gitlab_project_id"] != "99" {
+		t.Errorf("gitlab_project_id = %q, want 99", updated["gitlab_project_id"])
+	}
+	if updated["gitlab_mr_iid"] != "42" {
+		t.Errorf("gitlab_mr_iid = %q, want 42", updated["gitlab_mr_iid"])
+	}
+}
+
+func TestResolveAndNudge_AgentAlive_CoopURLInFields(t *testing.T) {
+	// Agent has coop_url as a field instead of in notes.
+	var nudgeReceived bool
+	coopServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/agent/nudge" {
+			nudgeReceived = true
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]bool{"delivered": true})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer coopServer.Close()
+
+	daemon := newMockResolverDaemon()
+	daemon.agentBeads["test-agent"] = &beadsapi.BeadDetail{
+		ID:    "bd-agent-1",
+		Title: "test-agent",
+		Type:  "agent",
+		Fields: map[string]string{
+			"agent":    "test-agent",
+			"coop_url": coopServer.URL,
+		},
+	}
+
+	resolver := newTestAgentResolver(daemon, nil)
+
+	taskBead := BeadEvent{
+		ID:       "kd-task-1",
+		Type:     "task",
+		Assignee: "test-agent",
+		Fields: map[string]string{
+			"mr_url": "https://gitlab.com/org/repo/-/merge_requests/42",
+		},
+	}
+
+	err := resolver.ResolveAndNudge(context.Background(), taskBead, "test message")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !nudgeReceived {
+		t.Error("expected nudge to be delivered via coop")
+	}
+}
+
+func TestResolveAndNudge_AgentDead_SpawnsNew(t *testing.T) {
+	daemon := newMockResolverDaemon()
+	// No agent bead → agent is dead.
+
+	// GitLab server returns MR details with source branch.
+	gitlabServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := GitLabMR{
+			IID:          42,
+			State:        "opened",
+			ProjectID:    99,
+			SourceBranch: "fix/auth-bug",
+			TargetBranch: "main",
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer gitlabServer.Close()
+
+	resolver := newTestAgentResolver(daemon, gitlabServer)
+
+	taskBead := BeadEvent{
+		ID:       "kd-task-1",
+		Type:     "task",
+		Title:    "Fix auth bug",
+		Assignee: "test-agent",
+		Labels:   []string{"project:gasboat"},
+		Fields: map[string]string{
+			"mr_url": "https://gitlab.com/org/repo/-/merge_requests/42",
+		},
+	}
+
+	err := resolver.ResolveAndNudge(context.Background(), taskBead, "Review comment")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify agent was spawned.
+	spawned := daemon.getSpawned()
+	if len(spawned) != 1 {
+		t.Fatalf("expected 1 spawned agent, got %d", len(spawned))
+	}
+
+	agent := spawned[0]
+	if agent.Fields["agent"] != "test-agent" {
+		t.Errorf("agent name = %q, want test-agent", agent.Fields["agent"])
+	}
+	if agent.Fields["project"] != "gasboat" {
+		t.Errorf("project = %q, want gasboat", agent.Fields["project"])
+	}
+	if agent.Fields["task_id"] != "kd-task-1" {
+		t.Errorf("task_id = %q, want kd-task-1", agent.Fields["task_id"])
+	}
+	if agent.Fields["spawn_source"] != "gitlab-mr-review" {
+		t.Errorf("spawn_source = %q, want gitlab-mr-review", agent.Fields["spawn_source"])
+	}
+	if agent.Fields["gitlab_mr_url"] != "https://gitlab.com/org/repo/-/merge_requests/42" {
+		t.Errorf("gitlab_mr_url = %q, want MR URL", agent.Fields["gitlab_mr_url"])
+	}
+	if agent.Fields["gitlab_mr_source_branch"] != "fix/auth-bug" {
+		t.Errorf("gitlab_mr_source_branch = %q, want fix/auth-bug", agent.Fields["gitlab_mr_source_branch"])
+	}
+	if agent.Fields["gitlab_project_id"] != "99" {
+		t.Errorf("gitlab_project_id = %q, want 99", agent.Fields["gitlab_project_id"])
+	}
+	if agent.Fields["gitlab_mr_iid"] != "42" {
+		t.Errorf("gitlab_mr_iid = %q, want 42", agent.Fields["gitlab_mr_iid"])
+	}
+}
+
+func TestResolveAndNudge_AgentExistsButNoCoopURL_SpawnsNew(t *testing.T) {
+	daemon := newMockResolverDaemon()
+	// Agent bead exists but has no coop_url (not running).
+	daemon.agentBeads["test-agent"] = &beadsapi.BeadDetail{
+		ID:    "bd-agent-old",
+		Title: "test-agent",
+		Type:  "agent",
+		Fields: map[string]string{
+			"agent":   "test-agent",
+			"project": "gasboat",
+		},
+	}
+
+	resolver := newTestAgentResolver(daemon, nil)
+
+	taskBead := BeadEvent{
+		ID:       "kd-task-1",
+		Type:     "task",
+		Title:    "Fix it",
+		Assignee: "test-agent",
+		Labels:   []string{"project:gasboat"},
+		Fields: map[string]string{
+			"mr_url": "https://gitlab.com/org/repo/-/merge_requests/5",
+		},
+	}
+
+	err := resolver.ResolveAndNudge(context.Background(), taskBead, "Review comment")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	spawned := daemon.getSpawned()
+	if len(spawned) != 1 {
+		t.Fatalf("expected 1 spawned agent, got %d", len(spawned))
+	}
+	if spawned[0].Fields["agent"] != "test-agent" {
+		t.Errorf("spawned agent name = %q, want test-agent", spawned[0].Fields["agent"])
+	}
+}
+
+func TestResolveAndNudge_NoAssignee_ReturnsError(t *testing.T) {
+	daemon := newMockResolverDaemon()
+	resolver := newTestAgentResolver(daemon, nil)
+
+	taskBead := BeadEvent{
+		ID:       "kd-task-1",
+		Type:     "task",
+		Assignee: "", // no assignee
+		Fields:   map[string]string{"mr_url": "https://gitlab.com/org/repo/-/merge_requests/1"},
+	}
+
+	err := resolver.ResolveAndNudge(context.Background(), taskBead, "msg")
+	if err == nil {
+		t.Fatal("expected error for empty assignee")
+	}
+}
+
+func TestBuildMRFields_PopulatesFromTaskBead(t *testing.T) {
+	resolver := newTestAgentResolver(newMockResolverDaemon(), nil)
+
+	taskBead := BeadEvent{
+		Fields: map[string]string{
+			"mr_url":            "https://gitlab.com/org/repo/-/merge_requests/42",
+			"gitlab_project_id": "99",
+			"gitlab_mr_iid":     "42",
+		},
+	}
+
+	fields := resolver.buildMRFields(taskBead)
+	if fields["gitlab_mr_url"] != "https://gitlab.com/org/repo/-/merge_requests/42" {
+		t.Errorf("gitlab_mr_url = %q", fields["gitlab_mr_url"])
+	}
+	if fields["gitlab_project_id"] != "99" {
+		t.Errorf("gitlab_project_id = %q", fields["gitlab_project_id"])
+	}
+	if fields["gitlab_mr_iid"] != "42" {
+		t.Errorf("gitlab_mr_iid = %q", fields["gitlab_mr_iid"])
+	}
+}
+
+func TestBuildMRFields_FetchesSourceBranch(t *testing.T) {
+	gitlabServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := GitLabMR{
+			IID:          42,
+			ProjectID:    99,
+			SourceBranch: "feature/new-thing",
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer gitlabServer.Close()
+
+	resolver := newTestAgentResolver(newMockResolverDaemon(), gitlabServer)
+
+	taskBead := BeadEvent{
+		Fields: map[string]string{
+			"mr_url": "https://gitlab.com/org/repo/-/merge_requests/42",
+		},
+	}
+
+	fields := resolver.buildMRFields(taskBead)
+	if fields["gitlab_mr_source_branch"] != "feature/new-thing" {
+		t.Errorf("gitlab_mr_source_branch = %q, want feature/new-thing", fields["gitlab_mr_source_branch"])
+	}
+	// Should backfill project_id and iid from the GitLab response.
+	if fields["gitlab_project_id"] != "99" {
+		t.Errorf("gitlab_project_id = %q, want 99", fields["gitlab_project_id"])
+	}
+	if fields["gitlab_mr_iid"] != "42" {
+		t.Errorf("gitlab_mr_iid = %q, want 42", fields["gitlab_mr_iid"])
+	}
+}
+
+func TestBuildMRFields_NoMRURL_ReturnsEmpty(t *testing.T) {
+	resolver := newTestAgentResolver(newMockResolverDaemon(), nil)
+
+	taskBead := BeadEvent{
+		Fields: map[string]string{}, // no mr_url
+	}
+
+	fields := resolver.buildMRFields(taskBead)
+	if len(fields) != 0 {
+		t.Errorf("expected empty fields, got %v", fields)
+	}
+}
+
+func TestHandleReviewNudge_WithResolver(t *testing.T) {
+	// Test that handleReviewNudge uses the resolver when configured.
+	var nudgeReceived string
+	coopServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/agent/nudge" {
+			var body map[string]string
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			nudgeReceived = body["message"]
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]bool{"delivered": true})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer coopServer.Close()
+
+	resolverDaemon := newMockResolverDaemon()
+	resolverDaemon.agentBeads["my-agent"] = &beadsapi.BeadDetail{
+		ID:    "bd-agent-1",
+		Title: "my-agent",
+		Type:  "agent",
+		Notes: "coop_url: " + coopServer.URL,
+		Fields: map[string]string{
+			"agent": "my-agent",
+		},
+	}
+
+	resolver := newTestAgentResolver(resolverDaemon, nil)
+
+	// Build a mock GitLabBeadClient that returns the task bead.
+	syncDaemon := &mockGitLabBeadClient{
+		beads: []*beadsapi.BeadDetail{},
+	}
+
+	sync := NewGitLabSync(GitLabSyncConfig{
+		Daemon:   syncDaemon,
+		Logger:   slog.Default(),
+		Resolver: resolver,
+	})
+
+	// Simulate a bead update event with mr_has_review_comments changed.
+	// Changes are at the wrapper level in SSE format, not inside the bead.
+	data, _ := json.Marshal(map[string]any{
+		"bead": map[string]any{
+			"id":       "kd-task-1",
+			"type":     "task",
+			"title":    "Fix bug",
+			"assignee": "my-agent",
+			"fields": map[string]string{
+				"mr_has_review_comments": "true",
+				"mr_url":                "https://gitlab.com/org/repo/-/merge_requests/42",
+			},
+		},
+		"changes": map[string]any{
+			"mr_has_review_comments": "true",
+		},
+	})
+	sync.handleReviewNudge(context.Background(), data)
+
+	if nudgeReceived == "" {
+		t.Error("expected nudge to be delivered via resolver")
+	}
+	if nudgeReceived != "MR has new review comments — address them: https://gitlab.com/org/repo/-/merge_requests/42" {
+		t.Errorf("unexpected nudge message: %q", nudgeReceived)
+	}
+}
+
+// mockGitLabBeadClient implements GitLabBeadClient for sync tests.
+type mockGitLabBeadClient struct {
+	beads []*beadsapi.BeadDetail
+}
+
+func (m *mockGitLabBeadClient) ListTaskBeads(_ context.Context) ([]*beadsapi.BeadDetail, error) {
+	return m.beads, nil
+}
+
+func (m *mockGitLabBeadClient) UpdateBeadFields(_ context.Context, _ string, _ map[string]string) error {
+	return nil
+}
+
+func (m *mockGitLabBeadClient) AddComment(_ context.Context, _, _, _ string) error {
+	return nil
+}

--- a/gasboat/controller/internal/bridge/gitlab_sync.go
+++ b/gasboat/controller/internal/bridge/gitlab_sync.go
@@ -28,10 +28,11 @@ type GitLabBeadClient interface {
 
 // GitLabSync watches for MR merges and updates bead fields.
 type GitLabSync struct {
-	gitlab *GitLabClient
-	daemon GitLabBeadClient
-	logger *slog.Logger
-	nudge  NudgeFunc
+	gitlab   *GitLabClient
+	daemon   GitLabBeadClient
+	logger   *slog.Logger
+	nudge    NudgeFunc
+	resolver *AgentResolver // optional; when set, handles agent lookup/reuse for review nudges
 
 	mu   sync.Mutex
 	seen map[string]time.Time // dedup key → last check time
@@ -42,20 +43,22 @@ type NudgeFunc func(ctx context.Context, agentName, message string) error
 
 // GitLabSyncConfig holds configuration for the GitLab sync watcher.
 type GitLabSyncConfig struct {
-	GitLab *GitLabClient
-	Daemon GitLabBeadClient
-	Logger *slog.Logger
-	Nudge  NudgeFunc // optional; if nil, nudges are skipped
+	GitLab   *GitLabClient
+	Daemon   GitLabBeadClient
+	Logger   *slog.Logger
+	Nudge    NudgeFunc      // optional; if nil, nudges are skipped
+	Resolver *AgentResolver // optional; when set, handles agent lookup/reuse for review nudges
 }
 
 // NewGitLabSync creates a new GitLab MR sync watcher.
 func NewGitLabSync(cfg GitLabSyncConfig) *GitLabSync {
 	return &GitLabSync{
-		gitlab: cfg.GitLab,
-		daemon: cfg.Daemon,
-		logger: cfg.Logger,
-		nudge:  cfg.Nudge,
-		seen:   make(map[string]time.Time),
+		gitlab:   cfg.GitLab,
+		daemon:   cfg.Daemon,
+		logger:   cfg.Logger,
+		nudge:    cfg.Nudge,
+		resolver: cfg.Resolver,
+		seen:     make(map[string]time.Time),
 	}
 }
 
@@ -205,9 +208,11 @@ func (s *GitLabSync) handleDescriptionSync(ctx context.Context, data []byte) {
 }
 
 // handleReviewNudge nudges the assigned agent when mr_has_review_comments
-// changes to true on a bead.
+// changes to true on a bead. When an AgentResolver is configured, it handles
+// agent lookup/reuse: if the original agent is alive it gets nudged; if dead,
+// a new agent is spawned with the MR context.
 func (s *GitLabSync) handleReviewNudge(ctx context.Context, data []byte) {
-	if s.nudge == nil {
+	if s.nudge == nil && s.resolver == nil {
 		return
 	}
 
@@ -239,6 +244,21 @@ func (s *GitLabSync) handleReviewNudge(ctx context.Context, data []byte) {
 	}
 
 	message := fmt.Sprintf("MR has new review comments — address them: %s", bead.Fields["mr_url"])
+
+	// When the resolver is available, use it for agent lookup/reuse.
+	// This handles dead agents by spawning new ones with MR context.
+	if s.resolver != nil {
+		if err := s.resolver.ResolveAndNudge(ctx, *bead, message); err != nil {
+			s.logger.Error("failed to resolve/nudge agent for review comments",
+				"bead", bead.ID, "agent", assignee, "error", err)
+		} else {
+			s.logger.Info("resolved and nudged agent for MR review comments",
+				"bead", bead.ID, "agent", assignee)
+		}
+		return
+	}
+
+	// Fallback: simple nudge by agent name (no agent reuse).
 	if err := s.nudge(ctx, assignee, message); err != nil {
 		s.logger.Error("failed to nudge agent for review comments",
 			"bead", bead.ID, "agent", assignee, "error", err)

--- a/gasboat/controller/internal/bridge/init.go
+++ b/gasboat/controller/internal/bridge/init.go
@@ -108,6 +108,11 @@ func configs() map[string]any {
 				{Name: "prompt", Type: "string"},
 				// Pre-assigned task ID (set by /spawn with ticket or task-first flow).
 				{Name: "task_id", Type: "string"},
+				// GitLab MR binding metadata (set by gitlab-bridge agent resolver).
+				{Name: "gitlab_mr_url", Type: "string"},
+				{Name: "gitlab_project_id", Type: "string"},
+				{Name: "gitlab_mr_iid", Type: "string"},
+				{Name: "gitlab_mr_source_branch", Type: "string"},
 			},
 		},
 		"type:mail": TypeConfig{


### PR DESCRIPTION
## Summary

- Add `AgentResolver` component to gitlab-bridge that handles agent lookup and reuse when MR review comments arrive
- When a review comment webhook fires on an agent-authored MR, the resolver finds the original agent via `FindAgentBead` and checks liveness (coop_url presence)
- If the agent is alive, it gets nudged with the review comment context; if dead, a new agent is spawned with the same name (for session continuity) and MR branch metadata
- Add GitLab MR binding fields (`gitlab_mr_url`, `gitlab_project_id`, `gitlab_mr_iid`, `gitlab_mr_source_branch`) to the agent bead type schema so agents know which MR/branch to work on

## Test plan

- [x] `TestResolveAndNudge_AgentAlive_Nudges` — verifies nudge delivery to alive agent via coop
- [x] `TestResolveAndNudge_AgentAlive_CoopURLInFields` — handles coop_url in fields vs notes
- [x] `TestResolveAndNudge_AgentDead_SpawnsNew` — spawns new agent with MR context when agent is dead
- [x] `TestResolveAndNudge_AgentExistsButNoCoopURL_SpawnsNew` — treats agent without coop_url as dead
- [x] `TestResolveAndNudge_NoAssignee_ReturnsError` — rejects beads with no assignee
- [x] `TestBuildMRFields_*` — verifies MR metadata extraction and GitLab API backfill
- [x] `TestHandleReviewNudge_WithResolver` — integration test through SSE handler
- [x] All existing controller tests pass (`go test ./gasboat/controller/...`)

Closes kd-NgWb01M6Xp

🤖 Generated with [Claude Code](https://claude.com/claude-code)