### PR TITLE
feat(gasboat/bridge): forward agent squawk to GitLab MR notes

### DIFF
--- a/gasboat/controller/cmd/gitlab-bridge/main.go
+++ b/gasboat/controller/cmd/gitlab-bridge/main.go
@@ -127,10 +127,10 @@ func main() {
 	// Create event deduplicator.
 	dedup := bridge.NewDedup(logger)
 
-	// Create SSE event stream for MR status checking on bead updates.
+	// Create SSE event stream for MR status checking and squawk forwarding.
 	sseStream := bridge.NewSSEStream(bridge.SSEStreamConfig{
 		BeadsHTTPAddr: cfg.beadsHTTPAddr,
-		Topics:        []string{"beads.bead.updated"},
+		Topics:        []string{"beads.bead.updated", "beads.bead.closed"},
 		Token:         os.Getenv("BEADS_DAEMON_TOKEN"),
 		Logger:        logger,
 		Dedup:         dedup,
@@ -148,6 +148,14 @@ func main() {
 		},
 	})
 	gitlabSync.RegisterHandlers(sseStream)
+
+	// Register GitLab squawk forwarder — posts agent squawk messages as MR notes.
+	squawkFwd := bridge.NewGitLabSquawkForwarder(bridge.GitLabSquawkForwarderConfig{
+		Daemon: daemon,
+		GitLab: gitlabClient,
+		Logger: logger,
+	})
+	squawkFwd.RegisterHandlers(sseStream)
 
 	// Start the SSE stream.
 	go func() {

--- a/gasboat/controller/internal/bridge/gitlab_squawk_forward.go
+++ b/gasboat/controller/internal/bridge/gitlab_squawk_forward.go
@@ -1,0 +1,184 @@
+// Package bridge provides the GitLab MR squawk forwarder.
+//
+// GitLabSquawkForwarder watches for closed squawk message beads from agents
+// that are bound to a GitLab MR (have gitlab_mr_url metadata) and posts the
+// squawk text as MR notes. This gives agents a way to communicate with MR
+// reviewers without direct GitLab API access.
+package bridge
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strconv"
+	"sync"
+
+	"gasboat/controller/internal/beadsapi"
+)
+
+// GitLabSquawkClient is the subset of beadsapi.Client used by GitLabSquawkForwarder.
+type GitLabSquawkClient interface {
+	FindAgentBead(ctx context.Context, agentName string) (*beadsapi.BeadDetail, error)
+}
+
+// GitLabSquawkForwarder watches for squawk beads from MR-bound agents and
+// posts them as GitLab MR notes.
+type GitLabSquawkForwarder struct {
+	daemon GitLabSquawkClient
+	gitlab *GitLabClient
+	logger *slog.Logger
+
+	mu   sync.Mutex
+	seen map[string]bool // dedup on SSE reconnect
+}
+
+// GitLabSquawkForwarderConfig holds configuration for the forwarder.
+type GitLabSquawkForwarderConfig struct {
+	Daemon GitLabSquawkClient
+	GitLab *GitLabClient
+	Logger *slog.Logger
+}
+
+// NewGitLabSquawkForwarder creates a new GitLab squawk forwarder.
+func NewGitLabSquawkForwarder(cfg GitLabSquawkForwarderConfig) *GitLabSquawkForwarder {
+	return &GitLabSquawkForwarder{
+		daemon: cfg.Daemon,
+		gitlab: cfg.GitLab,
+		logger: cfg.Logger,
+		seen:   make(map[string]bool),
+	}
+}
+
+// RegisterHandlers registers SSE event handlers on the given stream for
+// closed message beads (squawk events).
+func (f *GitLabSquawkForwarder) RegisterHandlers(stream *SSEStream) {
+	stream.On("beads.bead.closed", f.handleClosed)
+	f.logger.Info("GitLab squawk forwarder registered SSE handlers",
+		"topics", []string{"beads.bead.closed"})
+}
+
+func (f *GitLabSquawkForwarder) handleClosed(ctx context.Context, data []byte) {
+	bead := ParseBeadEvent(data)
+	if bead == nil {
+		return
+	}
+
+	// Only handle message beads with the "squawk" or "say" label.
+	if bead.Type != "message" || (!hasLabel(bead.Labels, "squawk") && !hasLabel(bead.Labels, "say")) {
+		return
+	}
+
+	// Dedup on SSE reconnect.
+	if f.alreadySeen(bead.ID) {
+		return
+	}
+
+	// Extract the source agent.
+	agent := extractSquawkAgent(*bead)
+	if agent == "" {
+		return
+	}
+
+	// Look up the agent bead to find MR binding metadata.
+	agentBead, err := f.daemon.FindAgentBead(ctx, agent)
+	if err != nil {
+		// Agent not found — not MR-bound, skip silently.
+		f.logger.Debug("gitlab-squawk: agent bead not found, skipping",
+			"agent", agent, "squawk_id", bead.ID)
+		return
+	}
+
+	// Check if the agent has MR binding metadata.
+	mrURL := agentBead.Fields["gitlab_mr_url"]
+	if mrURL == "" {
+		// Also check notes for gitlab_mr_url (runtime state).
+		if notes := beadsapi.ParseNotes(agentBead.Notes); notes != nil {
+			mrURL = notes["gitlab_mr_url"]
+		}
+	}
+	if mrURL == "" {
+		// Agent is not bound to a GitLab MR, skip.
+		return
+	}
+
+	// Get the message text.
+	text := bead.Fields["text"]
+	if text == "" {
+		text = bead.Title
+	}
+
+	// Resolve MR project path and IID.
+	projectPath, mrIID, err := f.resolveMR(agentBead, mrURL)
+	if err != nil {
+		f.logger.Warn("gitlab-squawk: failed to resolve MR",
+			"agent", agent, "mr_url", mrURL, "error", err)
+		return
+	}
+
+	// Format the message for GitLab.
+	body := fmt.Sprintf("**gasboat agent** `%s`:\n\n%s", agent, text)
+
+	// Check if there's a discussion ID to reply to.
+	discussionID := agentBead.Fields["gitlab_discussion_id"]
+	if discussionID == "" {
+		if notes := beadsapi.ParseNotes(agentBead.Notes); notes != nil {
+			discussionID = notes["gitlab_discussion_id"]
+		}
+	}
+
+	if discussionID != "" {
+		// Reply to the specific discussion thread.
+		if _, err := f.gitlab.PostMRDiscussionReply(ctx, projectPath, mrIID, discussionID, body); err != nil {
+			f.logger.Error("gitlab-squawk: failed to reply to MR discussion",
+				"agent", agent, "mr_url", mrURL, "discussion", discussionID, "error", err)
+			// Fall through to post as a new note.
+		} else {
+			f.logger.Info("gitlab-squawk: posted discussion reply",
+				"agent", agent, "mr_url", mrURL, "discussion", discussionID)
+			return
+		}
+	}
+
+	// Post as a new MR note.
+	if _, err := f.gitlab.PostMRNote(ctx, projectPath, mrIID, body); err != nil {
+		f.logger.Error("gitlab-squawk: failed to post MR note",
+			"agent", agent, "mr_url", mrURL, "error", err)
+	} else {
+		f.logger.Info("gitlab-squawk: posted MR note",
+			"agent", agent, "mr_url", mrURL, "text_length", len(text))
+	}
+}
+
+// resolveMR extracts the GitLab project path and MR IID from agent bead
+// metadata, falling back to parsing the MR URL.
+func (f *GitLabSquawkForwarder) resolveMR(agentBead *beadsapi.BeadDetail, mrURL string) (string, int, error) {
+	// Try agent bead fields first.
+	if iidStr := agentBead.Fields["gitlab_mr_iid"]; iidStr != "" {
+		iid, err := strconv.Atoi(iidStr)
+		if err == nil {
+			// Parse the project path from the MR URL.
+			ref := ParseMRURL(mrURL)
+			if ref != nil {
+				return ref.ProjectPath, iid, nil
+			}
+		}
+	}
+
+	// Fall back to parsing the MR URL.
+	ref := ParseMRURL(mrURL)
+	if ref == nil {
+		return "", 0, fmt.Errorf("cannot parse MR URL: %s", mrURL)
+	}
+	return ref.ProjectPath, ref.IID, nil
+}
+
+// alreadySeen returns true if this bead has already been processed.
+func (f *GitLabSquawkForwarder) alreadySeen(beadID string) bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.seen[beadID] {
+		return true
+	}
+	f.seen[beadID] = true
+	return false
+}

--- a/gasboat/controller/internal/bridge/gitlab_squawk_forward_test.go
+++ b/gasboat/controller/internal/bridge/gitlab_squawk_forward_test.go
@@ -1,0 +1,235 @@
+package bridge
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"gasboat/controller/internal/beadsapi"
+)
+
+func TestGitLabSquawkForwarder_IgnoresNonMessageBeads(t *testing.T) {
+	f := &GitLabSquawkForwarder{
+		daemon: newMockDaemon(),
+		gitlab: NewGitLabClient(GitLabClientConfig{Logger: slog.Default()}),
+		logger: slog.Default(),
+		seen:   make(map[string]bool),
+	}
+
+	data := marshalSSEBeadPayload(BeadEvent{
+		ID:     "bd-task1",
+		Type:   "task",
+		Labels: []string{"bug"},
+	})
+	f.handleClosed(context.Background(), data)
+
+	if f.alreadySeen("bd-task1") {
+		t.Error("expected task bead to be ignored, not marked as seen")
+	}
+}
+
+func TestGitLabSquawkForwarder_IgnoresMessageWithoutSquawkLabel(t *testing.T) {
+	f := &GitLabSquawkForwarder{
+		daemon: newMockDaemon(),
+		gitlab: NewGitLabClient(GitLabClientConfig{Logger: slog.Default()}),
+		logger: slog.Default(),
+		seen:   make(map[string]bool),
+	}
+
+	data := marshalSSEBeadPayload(BeadEvent{
+		ID:     "bd-msg1",
+		Type:   "message",
+		Labels: []string{"from:test-agent"},
+	})
+	f.handleClosed(context.Background(), data)
+
+	if f.alreadySeen("bd-msg1") {
+		t.Error("expected non-squawk message bead to be ignored")
+	}
+}
+
+func TestGitLabSquawkForwarder_SkipsAgentWithoutMRBinding(t *testing.T) {
+	mock := newMockDaemon()
+	// Agent exists but has no gitlab_mr_url metadata.
+	mock.mu.Lock()
+	bd := beadsapiBeadDetail("test-agent", "agent", nil)
+	mock.beads["test-agent"] = &bd
+	mock.mu.Unlock()
+
+	f := &GitLabSquawkForwarder{
+		daemon: mock,
+		gitlab: NewGitLabClient(GitLabClientConfig{Logger: slog.Default()}),
+		logger: slog.Default(),
+		seen:   make(map[string]bool),
+	}
+
+	data := marshalSSEBeadPayload(BeadEvent{
+		ID:     "bd-squawk1",
+		Type:   "message",
+		Labels: []string{"squawk", "from:test-agent"},
+		Fields: map[string]string{
+			"source_agent": "test-agent",
+			"text":         "Build complete",
+		},
+	})
+	f.handleClosed(context.Background(), data)
+
+	// Should be marked as seen (was processed) but no MR post attempted.
+	if !f.alreadySeen("bd-squawk1") {
+		t.Error("expected bead to be marked as seen after processing")
+	}
+}
+
+func TestGitLabSquawkForwarder_SkipsUnknownAgent(t *testing.T) {
+	mock := newMockDaemon()
+	// No agent seeded — FindAgentBead will return error.
+
+	f := &GitLabSquawkForwarder{
+		daemon: mock,
+		gitlab: NewGitLabClient(GitLabClientConfig{Logger: slog.Default()}),
+		logger: slog.Default(),
+		seen:   make(map[string]bool),
+	}
+
+	data := marshalSSEBeadPayload(BeadEvent{
+		ID:     "bd-squawk2",
+		Type:   "message",
+		Labels: []string{"squawk", "from:unknown-agent"},
+		Fields: map[string]string{
+			"source_agent": "unknown-agent",
+			"text":         "Hello",
+		},
+	})
+	f.handleClosed(context.Background(), data)
+
+	// Agent not found → silently skipped, bead still marked seen.
+	if !f.alreadySeen("bd-squawk2") {
+		t.Error("expected bead to be marked as seen")
+	}
+}
+
+func TestGitLabSquawkForwarder_Dedup(t *testing.T) {
+	f := &GitLabSquawkForwarder{
+		daemon: newMockDaemon(),
+		gitlab: NewGitLabClient(GitLabClientConfig{Logger: slog.Default()}),
+		logger: slog.Default(),
+		seen:   make(map[string]bool),
+	}
+
+	data := marshalSSEBeadPayload(BeadEvent{
+		ID:     "bd-squawk-dup",
+		Type:   "message",
+		Labels: []string{"squawk", "from:agent-1"},
+		Fields: map[string]string{
+			"source_agent": "agent-1",
+			"text":         "First call",
+		},
+	})
+
+	f.handleClosed(context.Background(), data)
+	if !f.alreadySeen("bd-squawk-dup") {
+		t.Error("expected bead to be seen after first call")
+	}
+
+	// Second call should be deduped — no panic, no double processing.
+	f.handleClosed(context.Background(), data)
+}
+
+func TestGitLabSquawkForwarder_AcceptsSayLabel(t *testing.T) {
+	mock := newMockDaemon()
+	// No agent bead seeded, so FindAgentBead will fail — that's fine,
+	// we just verify the "say" label passes the filter.
+
+	f := &GitLabSquawkForwarder{
+		daemon: mock,
+		gitlab: NewGitLabClient(GitLabClientConfig{Logger: slog.Default()}),
+		logger: slog.Default(),
+		seen:   make(map[string]bool),
+	}
+
+	data := marshalSSEBeadPayload(BeadEvent{
+		ID:     "bd-say1",
+		Type:   "message",
+		Labels: []string{"say", "from:test-agent"},
+		Fields: map[string]string{
+			"source_agent": "test-agent",
+			"text":         "Legacy say message",
+		},
+	})
+	f.handleClosed(context.Background(), data)
+
+	if !f.alreadySeen("bd-say1") {
+		t.Error("expected legacy 'say' label to be accepted")
+	}
+}
+
+func TestGitLabSquawkForwarder_ResolveMR_FromURL(t *testing.T) {
+	f := &GitLabSquawkForwarder{
+		logger: slog.Default(),
+	}
+
+	agentBead := &beadsapi.BeadDetail{
+		Fields: map[string]string{},
+	}
+	mrURL := "https://gitlab.com/PiHealth/CoreFICS/monorepo/-/merge_requests/42"
+
+	projectPath, iid, err := f.resolveMR(agentBead, mrURL)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if projectPath != "PiHealth/CoreFICS/monorepo" {
+		t.Errorf("projectPath = %q, want %q", projectPath, "PiHealth/CoreFICS/monorepo")
+	}
+	if iid != 42 {
+		t.Errorf("iid = %d, want 42", iid)
+	}
+}
+
+func TestGitLabSquawkForwarder_ResolveMR_FromBeadFieldIID(t *testing.T) {
+	f := &GitLabSquawkForwarder{
+		logger: slog.Default(),
+	}
+
+	agentBead := &beadsapi.BeadDetail{
+		Fields: map[string]string{
+			"gitlab_mr_iid": "99",
+		},
+	}
+	mrURL := "https://gitlab.com/PiHealth/CoreFICS/monorepo/-/merge_requests/42"
+
+	// Should prefer the bead field IID over the URL IID.
+	projectPath, iid, err := f.resolveMR(agentBead, mrURL)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if projectPath != "PiHealth/CoreFICS/monorepo" {
+		t.Errorf("projectPath = %q, want %q", projectPath, "PiHealth/CoreFICS/monorepo")
+	}
+	if iid != 99 {
+		t.Errorf("iid = %d, want 99 (from bead field)", iid)
+	}
+}
+
+func TestGitLabSquawkForwarder_ResolveMR_InvalidURL(t *testing.T) {
+	f := &GitLabSquawkForwarder{
+		logger: slog.Default(),
+	}
+
+	agentBead := &beadsapi.BeadDetail{
+		Fields: map[string]string{},
+	}
+	_, _, err := f.resolveMR(agentBead, "not-a-valid-url")
+	if err == nil {
+		t.Error("expected error for invalid MR URL")
+	}
+}
+
+// beadsapiBeadDetail is a test helper to create a BeadDetail with optional fields.
+func beadsapiBeadDetail(name, beadType string, fields map[string]string) beadsapi.BeadDetail {
+	return beadsapi.BeadDetail{
+		ID:     "bd-" + name,
+		Title:  name,
+		Type:   beadType,
+		Fields: fields,
+	}
+}


### PR DESCRIPTION
## Summary
- Add `GitLabSquawkForwarder` that watches `beads.bead.closed` SSE events for squawk/say message beads from MR-bound agents
- Posts agent squawk text as GitLab MR notes via `PostMRNote()`, or as discussion replies via `PostMRDiscussionReply()` when `gitlab_discussion_id` is available
- Wires the forwarder into `gitlab-bridge/main.go` with the new `beads.bead.closed` SSE topic

## Test plan
- [x] 9 unit tests covering: non-message bead filtering, missing squawk label, unknown agent, agent without MR binding, dedup, legacy "say" label, MR URL resolution, bead field IID override, invalid URL error
- [x] Full controller test suite passes (`go test ./...`)
- [x] All three binaries build clean (controller, slack-bridge, gitlab-bridge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)