### PR TITLE
feat(gasboat/bridge): persist nudge throttle state across restarts

### DIFF
--- a/gasboat/controller/internal/bridge/bot.go
+++ b/gasboat/controller/internal/bridge/bot.go
@@ -443,15 +443,25 @@ func (b *Bot) handleMessageEvent(ctx context.Context, ev *slackevents.MessageEve
 // per 10 minutes to avoid spam.
 func (b *Bot) hintMentionRequired(ctx context.Context, channel, threadTS, agent string) {
 	key := "hint:" + channel + ":" + threadTS
-	now := time.Now()
+	const hintInterval = 10 * time.Minute
 
-	b.mu.Lock()
-	if last, ok := b.lastThreadNudge[key]; ok && now.Sub(last) < 10*time.Minute {
+	// Use persistent state when available.
+	if b.state != nil {
+		throttled, _ := b.state.CheckAndSetNudgeThrottle(key, hintInterval)
+		if throttled {
+			return
+		}
+	} else {
+		// Fallback to in-memory map when state is nil.
+		now := time.Now()
+		b.mu.Lock()
+		if last, ok := b.lastThreadNudge[key]; ok && now.Sub(last) < hintInterval {
+			b.mu.Unlock()
+			return
+		}
+		b.lastThreadNudge[key] = now
 		b.mu.Unlock()
-		return
 	}
-	b.lastThreadNudge[key] = now
-	b.mu.Unlock()
 
 	hint := fmt.Sprintf(":bulb: _Tip: @mention me so *%s* sees your message._", agent)
 	if b.api != nil {

--- a/gasboat/controller/internal/bridge/bot_thread_forward.go
+++ b/gasboat/controller/internal/bridge/bot_thread_forward.go
@@ -121,9 +121,25 @@ func (b *Bot) handleThreadForward(ctx context.Context, ev *slackevents.MessageEv
 }
 
 // shouldThrottleNudge returns true if a nudge was sent recently for this agent+thread.
-// Updates the last nudge time if not throttled.
+// Uses persistent state if available (survives restarts), falling back to in-memory map.
 func (b *Bot) shouldThrottleNudge(agent, threadTS string) bool {
 	key := agent + ":" + threadTS
+
+	// Use persistent state when available.
+	if b.state != nil {
+		throttled, err := b.state.CheckAndSetNudgeThrottle(key, threadNudgeInterval)
+		if err != nil {
+			b.logger.Warn("thread-forward: failed to persist nudge throttle", "key", key, "error", err)
+		}
+		if throttled {
+			b.logger.Debug("thread-forward: nudge throttled (persisted)",
+				"agent", agent, "thread_ts", threadTS)
+			return true
+		}
+		return false
+	}
+
+	// Fallback to in-memory map when state is nil (tests).
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	if last, ok := b.lastThreadNudge[key]; ok && time.Since(last) < threadNudgeInterval {

--- a/gasboat/controller/internal/bridge/state.go
+++ b/gasboat/controller/internal/bridge/state.go
@@ -64,6 +64,7 @@ type StateData struct {
 	AgentCards       map[string]MessageRef       `json:"agent_cards,omitempty"`       // agent identity → status card message ref
 	ThreadAgents     map[string]ThreadAgentEntry `json:"thread_agents,omitempty"`     // "{channel}:{thread_ts}" → agent entry
 	ListenThreads    map[string]bool             `json:"listen_threads,omitempty"`    // "{channel}:{thread_ts}" → true if --listen mode
+	NudgeThrottles   map[string]time.Time        `json:"nudge_throttles,omitempty"`   // "agent:thread_ts" → last nudge time
 	Dashboard        *DashboardRef               `json:"dashboard,omitempty"`
 	LastEventID      string                      `json:"last_event_id,omitempty"` // SSE event ID for reconnection
 }
@@ -86,6 +87,7 @@ func NewStateManager(path string) (*StateManager, error) {
 			AgentCards:       make(map[string]MessageRef),
 			ThreadAgents:     make(map[string]ThreadAgentEntry),
 			ListenThreads:    make(map[string]bool),
+			NudgeThrottles:   make(map[string]time.Time),
 		},
 	}
 	if err := sm.load(); err != nil && !os.IsNotExist(err) {
@@ -329,6 +331,36 @@ func (sm *StateManager) RemoveListenThread(channel, threadTS string) error {
 	return sm.saveLocked()
 }
 
+// --- Nudge Throttles ---
+
+// CheckAndSetNudgeThrottle atomically checks whether a nudge for the given key
+// is within the throttle interval. If throttled, returns true without modifying
+// state. Otherwise, records the current time and persists.
+// This survives bridge restarts, preventing duplicate bead creation on SSE replay.
+func (sm *StateManager) CheckAndSetNudgeThrottle(key string, interval time.Duration) (bool, error) {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+	if last, ok := sm.data.NudgeThrottles[key]; ok && time.Since(last) < interval {
+		return true, nil // throttled
+	}
+	sm.data.NudgeThrottles[key] = time.Now()
+	return false, sm.saveLocked()
+}
+
+// CleanExpiredNudgeThrottles removes throttle entries older than maxAge.
+// Called during compaction to prevent unbounded growth.
+func (sm *StateManager) CleanExpiredNudgeThrottles(maxAge time.Duration) int {
+	now := time.Now()
+	removed := 0
+	for k, last := range sm.data.NudgeThrottles {
+		if now.Sub(last) > maxAge {
+			delete(sm.data.NudgeThrottles, k)
+			removed++
+		}
+	}
+	return removed
+}
+
 // --- Dashboard ---
 
 // GetDashboard returns the dashboard message ref.
@@ -411,6 +443,10 @@ func (sm *StateManager) CompactStaleEntries(activeAgents map[string]bool) (int, 
 	// Compact thread-agent bindings that have exceeded the TTL.
 	removed += sm.cleanExpiredThreadAgentsLocked(ThreadAgentTTL)
 
+	// Clean up expired nudge throttle entries (anything older than 1h
+	// is well past any throttle interval and safe to remove).
+	removed += sm.CleanExpiredNudgeThrottles(time.Hour)
+
 	if removed > 0 {
 		return removed, sm.saveLocked()
 	}
@@ -481,6 +517,9 @@ func (sm *StateManager) load() error {
 	}
 	if sm.data.ListenThreads == nil {
 		sm.data.ListenThreads = make(map[string]bool)
+	}
+	if sm.data.NudgeThrottles == nil {
+		sm.data.NudgeThrottles = make(map[string]time.Time)
 	}
 	return nil
 }

--- a/gasboat/controller/internal/bridge/state_nudge_throttle_test.go
+++ b/gasboat/controller/internal/bridge/state_nudge_throttle_test.go
@@ -1,0 +1,162 @@
+package bridge
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestCheckAndSetNudgeThrottle_FirstCall(t *testing.T) {
+	sm, err := NewStateManager(filepath.Join(t.TempDir(), "state.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	throttled, err := sm.CheckAndSetNudgeThrottle("agent:1.1", 30*time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if throttled {
+		t.Error("first call should not be throttled")
+	}
+}
+
+func TestCheckAndSetNudgeThrottle_WithinInterval(t *testing.T) {
+	sm, err := NewStateManager(filepath.Join(t.TempDir(), "state.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// First call: not throttled.
+	if throttled, _ := sm.CheckAndSetNudgeThrottle("agent:1.1", 30*time.Second); throttled {
+		t.Fatal("first call should not be throttled")
+	}
+
+	// Second call within interval: throttled.
+	throttled, err := sm.CheckAndSetNudgeThrottle("agent:1.1", 30*time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !throttled {
+		t.Error("second call within interval should be throttled")
+	}
+}
+
+func TestCheckAndSetNudgeThrottle_AfterInterval(t *testing.T) {
+	sm, err := NewStateManager(filepath.Join(t.TempDir(), "state.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Backdate the throttle entry.
+	sm.mu.Lock()
+	sm.data.NudgeThrottles["agent:1.1"] = time.Now().Add(-31 * time.Second)
+	sm.mu.Unlock()
+
+	// Should NOT be throttled (interval expired).
+	throttled, err := sm.CheckAndSetNudgeThrottle("agent:1.1", 30*time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if throttled {
+		t.Error("call after interval should not be throttled")
+	}
+}
+
+func TestCheckAndSetNudgeThrottle_DifferentKeys(t *testing.T) {
+	sm, err := NewStateManager(filepath.Join(t.TempDir(), "state.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Key A: not throttled.
+	if throttled, _ := sm.CheckAndSetNudgeThrottle("agent-a:1.1", 30*time.Second); throttled {
+		t.Error("key A first call should not be throttled")
+	}
+
+	// Key B: not throttled (independent).
+	if throttled, _ := sm.CheckAndSetNudgeThrottle("agent-b:2.2", 30*time.Second); throttled {
+		t.Error("key B should not be throttled by key A")
+	}
+
+	// Key A: throttled (same key, within interval).
+	if throttled, _ := sm.CheckAndSetNudgeThrottle("agent-a:1.1", 30*time.Second); !throttled {
+		t.Error("key A second call should be throttled")
+	}
+}
+
+func TestCheckAndSetNudgeThrottle_SurvivesRestart(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "state.json")
+
+	// Create and set throttle.
+	sm1, err := NewStateManager(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if throttled, _ := sm1.CheckAndSetNudgeThrottle("agent:1.1", 30*time.Second); throttled {
+		t.Fatal("first call should not be throttled")
+	}
+
+	// "Restart": create a new StateManager from the same file.
+	sm2, err := NewStateManager(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Should be throttled — state was persisted.
+	throttled, err := sm2.CheckAndSetNudgeThrottle("agent:1.1", 30*time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !throttled {
+		t.Error("throttle should survive restart")
+	}
+}
+
+func TestCleanExpiredNudgeThrottles(t *testing.T) {
+	sm, err := NewStateManager(filepath.Join(t.TempDir(), "state.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Set up: one recent, one expired.
+	sm.mu.Lock()
+	sm.data.NudgeThrottles["recent"] = time.Now()
+	sm.data.NudgeThrottles["expired"] = time.Now().Add(-2 * time.Hour)
+	sm.mu.Unlock()
+
+	removed := sm.CleanExpiredNudgeThrottles(time.Hour)
+	if removed != 1 {
+		t.Errorf("expected 1 removed, got %d", removed)
+	}
+
+	sm.mu.RLock()
+	if _, ok := sm.data.NudgeThrottles["recent"]; !ok {
+		t.Error("recent entry should survive")
+	}
+	if _, ok := sm.data.NudgeThrottles["expired"]; ok {
+		t.Error("expired entry should be removed")
+	}
+	sm.mu.RUnlock()
+}
+
+func TestCompactStaleEntries_CleansNudgeThrottles(t *testing.T) {
+	sm, err := NewStateManager(filepath.Join(t.TempDir(), "state.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Add an expired nudge throttle entry.
+	sm.mu.Lock()
+	sm.data.NudgeThrottles["old-key"] = time.Now().Add(-2 * time.Hour)
+	sm.mu.Unlock()
+
+	removed, err := sm.CompactStaleEntries(map[string]bool{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if removed != 1 {
+		t.Errorf("expected 1 removed (expired throttle), got %d", removed)
+	}
+}


### PR DESCRIPTION
## Summary

- The `lastThreadNudge` in-memory map was lost on bridge restart, causing duplicate bead creation from SSE replay when rapid-fire thread replies arrived
- Added `NudgeThrottles` map to `StateData` for persistent throttle timestamps that survive crashes and restarts
- Both `shouldThrottleNudge` (30s interval) and `hintMentionRequired` (10m interval) now use persistent state with in-memory fallback for nil state (backward compat with tests)

## Test plan

- [x] `TestCheckAndSetNudgeThrottle_FirstCall` — first call not throttled
- [x] `TestCheckAndSetNudgeThrottle_WithinInterval` — second call within interval is throttled
- [x] `TestCheckAndSetNudgeThrottle_AfterInterval` — call after interval expiry passes
- [x] `TestCheckAndSetNudgeThrottle_DifferentKeys` — independent keys don't interfere
- [x] `TestCheckAndSetNudgeThrottle_SurvivesRestart` — throttle state persists across StateManager reload
- [x] `TestCleanExpiredNudgeThrottles` — expired entries cleaned up
- [x] `TestCompactStaleEntries_CleansNudgeThrottles` — integrated into periodic compaction
- [x] All existing bridge tests pass (23s suite)
- [x] Both binaries build (`controller`, `slack-bridge`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)