### PR TITLE
feat(gasboat/bridge): add periodic thread binding validation

### DIFF
--- a/gasboat/controller/internal/bridge/bot.go
+++ b/gasboat/controller/internal/bridge/bot.go
@@ -277,6 +277,10 @@ func (b *Bot) Run(ctx context.Context) error {
 		}
 	}()
 
+	// Periodically validate thread-agent bindings against Slack API
+	// to remove entries for deleted threads or archived channels.
+	go b.startPeriodicThreadValidation(ctx)
+
 	go b.handleEvents(ctx)
 
 	err = b.socket.RunContext(ctx)

--- a/gasboat/controller/internal/bridge/bot_thread_validate.go
+++ b/gasboat/controller/internal/bridge/bot_thread_validate.go
@@ -1,0 +1,112 @@
+package bridge
+
+import (
+	"context"
+	"time"
+
+	"github.com/slack-go/slack"
+)
+
+// threadValidationInterval is how often thread bindings are validated.
+const threadValidationInterval = 6 * time.Hour
+
+// startPeriodicThreadValidation runs ValidateThreadBindings at a fixed interval
+// until ctx is cancelled. Invalid bindings (deleted threads, archived channels)
+// are removed from state to prevent unbounded growth.
+func (b *Bot) startPeriodicThreadValidation(ctx context.Context) {
+	ticker := time.NewTicker(threadValidationInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			b.validateThreadBindings(ctx)
+		}
+	}
+}
+
+// validateThreadBindings checks all thread-agent mappings against the Slack API
+// and removes entries where the thread no longer exists (channel archived,
+// thread deleted, or API returns an error indicating inaccessibility).
+func (b *Bot) validateThreadBindings(ctx context.Context) {
+	if b.state == nil || b.api == nil {
+		return
+	}
+
+	bindings := b.state.AllThreadAgents()
+	if len(bindings) == 0 {
+		return
+	}
+
+	b.logger.Info("thread-validate: starting scan", "bindings", len(bindings))
+
+	removed := 0
+	errors := 0
+	for key := range bindings {
+		// Parse "channel:thread_ts" key.
+		channel, threadTS := parseThreadAgentKey(key)
+		if channel == "" || threadTS == "" {
+			continue
+		}
+
+		// Probe the thread with a minimal API call.
+		if !b.isThreadAccessible(ctx, channel, threadTS) {
+			// Remove the stale binding and its listen flag.
+			if err := b.state.RemoveThreadAgent(channel, threadTS); err != nil {
+				b.logger.Warn("thread-validate: failed to remove stale binding",
+					"channel", channel, "thread_ts", threadTS, "error", err)
+				errors++
+				continue
+			}
+			_ = b.state.RemoveListenThread(channel, threadTS)
+			removed++
+		}
+	}
+
+	if removed > 0 || errors > 0 {
+		b.logger.Info("thread-validate: scan complete",
+			"checked", len(bindings), "removed", removed, "errors", errors)
+	} else {
+		b.logger.Info("thread-validate: all bindings valid", "checked", len(bindings))
+	}
+}
+
+// parseThreadAgentKey splits a "channel:thread_ts" key into its components.
+func parseThreadAgentKey(key string) (channel, threadTS string) {
+	for i := 0; i < len(key); i++ {
+		if key[i] == ':' {
+			return key[:i], key[i+1:]
+		}
+	}
+	return "", ""
+}
+
+// isThreadAccessible checks if a Slack thread is still accessible by fetching
+// exactly one reply. Returns false if the channel is archived, the thread is
+// deleted, or the API returns channel_not_found / thread_not_found.
+func (b *Bot) isThreadAccessible(ctx context.Context, channel, threadTS string) bool {
+	_, _, _, err := b.api.GetConversationRepliesContext(ctx, &slack.GetConversationRepliesParameters{
+		ChannelID: channel,
+		Timestamp: threadTS,
+		Limit:     1,
+		Inclusive:  true,
+	})
+	if err == nil {
+		return true
+	}
+
+	// Slack API errors that indicate the thread/channel is gone.
+	errStr := err.Error()
+	switch errStr {
+	case "channel_not_found", "thread_not_found", "is_archived",
+		"not_in_channel", "missing_scope":
+		return false
+	}
+
+	// Treat other errors (rate limit, network) as "accessible" to avoid
+	// false-positive removals. We'll catch them on the next cycle.
+	b.logger.Debug("thread-validate: API error treated as accessible",
+		"channel", channel, "thread_ts", threadTS, "error", err)
+	return true
+}

--- a/gasboat/controller/internal/bridge/bot_thread_validate_test.go
+++ b/gasboat/controller/internal/bridge/bot_thread_validate_test.go
@@ -1,0 +1,112 @@
+package bridge
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+)
+
+func TestParseThreadAgentKey(t *testing.T) {
+	tests := []struct {
+		key    string
+		wantCh string
+		wantTS string
+	}{
+		{"C123:1111.2222", "C123", "1111.2222"},
+		{"C-general:3333.4444", "C-general", "3333.4444"},
+		{"", "", ""},
+		{"nocolon", "", ""},
+		{"C123:", "C123", ""},
+		{":1111.2222", "", "1111.2222"},
+	}
+
+	for _, tt := range tests {
+		ch, ts := parseThreadAgentKey(tt.key)
+		if ch != tt.wantCh || ts != tt.wantTS {
+			t.Errorf("parseThreadAgentKey(%q) = (%q, %q), want (%q, %q)",
+				tt.key, ch, ts, tt.wantCh, tt.wantTS)
+		}
+	}
+}
+
+func TestValidateThreadBindings_NilState(t *testing.T) {
+	daemon := newMockDaemon()
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+	b := newTestBot(daemon, slackSrv)
+	b.state = nil
+
+	// Should not panic.
+	b.validateThreadBindings(context.Background())
+}
+
+func TestValidateThreadBindings_NilAPI(t *testing.T) {
+	dir := t.TempDir()
+	state, err := NewStateManager(filepath.Join(dir, "state.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_ = state.SetThreadAgent("C-good", "1111.2222", "agent-a")
+	_ = state.SetListenThread("C-good", "1111.2222")
+	_ = state.SetThreadAgent("C-archived", "3333.4444", "agent-b")
+
+	daemon := newMockDaemon()
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+	b := newTestBot(daemon, slackSrv)
+	b.state = state
+	b.api = nil // nil API = skip validation
+
+	b.validateThreadBindings(context.Background())
+
+	// Both bindings should survive since API is nil.
+	if _, ok := state.GetThreadAgent("C-good", "1111.2222"); !ok {
+		t.Error("C-good binding should survive when API is nil")
+	}
+	if _, ok := state.GetThreadAgent("C-archived", "3333.4444"); !ok {
+		t.Error("C-archived binding should survive when API is nil")
+	}
+}
+
+func TestValidateThreadBindings_EmptyBindings(t *testing.T) {
+	dir := t.TempDir()
+	state, err := NewStateManager(filepath.Join(dir, "state.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	daemon := newMockDaemon()
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+	b := newTestBot(daemon, slackSrv)
+	b.state = state
+
+	// Should not panic with zero bindings.
+	b.validateThreadBindings(context.Background())
+}
+
+func TestValidateThreadBindings_AccessibleThreadsSurvive(t *testing.T) {
+	dir := t.TempDir()
+	state, err := NewStateManager(filepath.Join(dir, "state.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_ = state.SetThreadAgent("C-test", "1111.2222", "agent-a")
+
+	daemon := newMockDaemon()
+	// The fake Slack server returns OK for all API calls,
+	// so GetConversationReplies will succeed — threads are "accessible".
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+	b := newTestBot(daemon, slackSrv)
+	b.state = state
+
+	b.validateThreadBindings(context.Background())
+
+	// Thread should survive since the API returns success.
+	if _, ok := state.GetThreadAgent("C-test", "1111.2222"); !ok {
+		t.Error("accessible thread binding should survive validation")
+	}
+}


### PR DESCRIPTION
## Summary

- Thread-to-agent mappings in StateManager were never cleaned up when Slack threads were deleted or channels archived, causing unbounded state growth
- Added a 6-hour periodic scan that validates each thread binding via Slack API (GetConversationReplies) and removes stale entries
- Transient errors (rate limits, network) are treated as "accessible" to prevent false-positive removals — stale entries are caught on the next cycle

## Test plan

- [x] `TestParseThreadAgentKey` — verifies key parsing for various formats
- [x] `TestValidateThreadBindings_NilState` — safe with nil state
- [x] `TestValidateThreadBindings_NilAPI` — skips validation when Slack API is unavailable
- [x] `TestValidateThreadBindings_EmptyBindings` — no-op with zero bindings
- [x] `TestValidateThreadBindings_AccessibleThreadsSurvive` — accessible threads preserved
- [x] All existing bridge tests pass (23s suite)
- [x] Both binaries build (`controller`, `slack-bridge`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)