### PR TITLE
test(gasboat/bridge): add concurrent scenario tests for thread agent interactions

### DIFF
--- a/gasboat/controller/internal/bridge/bot_agent_kill.go
+++ b/gasboat/controller/internal/bridge/bot_agent_kill.go
@@ -90,6 +90,28 @@ func (b *Bot) killAgent(ctx context.Context, agentName string, force bool) error
 func (b *Bot) respawnThreadAgent(ctx context.Context, channel, threadTS, agentName, triggerText string) {
 	agentName = extractAgentName(agentName)
 
+	// Atomic check-and-set: prevent concurrent respawn attempts for the same thread.
+	// Multiple thread replies arriving for a dead agent can all call respawnThreadAgent
+	// concurrently — this guard ensures only one respawn proceeds.
+	spawnKey := channel + ":" + threadTS
+	b.mu.Lock()
+	if b.spawnInFlight == nil {
+		b.spawnInFlight = make(map[string]bool)
+	}
+	if b.spawnInFlight[spawnKey] {
+		b.mu.Unlock()
+		b.logger.Info("respawn-thread-agent: spawn already in flight, skipping",
+			"channel", channel, "thread_ts", threadTS, "agent", agentName)
+		return
+	}
+	b.spawnInFlight[spawnKey] = true
+	b.mu.Unlock()
+	defer func() {
+		b.mu.Lock()
+		delete(b.spawnInFlight, spawnKey)
+		b.mu.Unlock()
+	}()
+
 	// Snapshot the listen-thread flag before it gets cleaned up by killAgent
 	// (which calls RemoveThreadAgentByAgent, clearing both thread mapping and
 	// listen flag). We restore it after re-establishing the thread binding.

--- a/gasboat/controller/internal/bridge/bot_thread_concurrent_test.go
+++ b/gasboat/controller/internal/bridge/bot_thread_concurrent_test.go
@@ -1,0 +1,364 @@
+package bridge
+
+import (
+	"context"
+	"log/slog"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"gasboat/controller/internal/beadsapi"
+
+	"github.com/slack-go/slack/slackevents"
+)
+
+// TestConcurrentThreadForwardDuringSpawn fires concurrent handleThreadForward
+// calls for the same thread while a spawn is still in-flight. The forward
+// path should detect the dead agent and attempt respawn, but the spawnInFlight
+// guard must prevent duplicate agent beads.
+func TestConcurrentThreadForwardDuringSpawn(t *testing.T) {
+	daemon := newMockDaemon()
+	// Project bead for channel→project resolution during respawn.
+	daemon.seedProjectWithChannel("testproj", "C-fwd-race")
+
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+
+	bot := newTestBot(daemon, slackSrv)
+
+	dir := t.TempDir()
+	state, err := NewStateManager(filepath.Join(dir, "state.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	bot.state = state
+	bot.lastThreadNudge = make(map[string]time.Time)
+
+	channel := "C-fwd-race"
+	threadTS := "7777.1111"
+	agentName := "thread-7777-1111"
+
+	// Pre-bind thread to an agent that is NOT in the daemon (dead).
+	// handleThreadForward will see the agent in state, call FindAgentBead,
+	// get an error, and attempt respawnThreadAgent.
+	_ = state.SetThreadAgent(channel, threadTS, agentName)
+	_ = state.SetListenThread(channel, threadTS)
+
+	// Fire 5 concurrent thread-forward calls.
+	var wg sync.WaitGroup
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			ev := &slackevents.MessageEvent{
+				User:            "U-HUMAN",
+				Channel:         channel,
+				Text:            "concurrent forward message",
+				TimeStamp:       "7777.2222",
+				ThreadTimeStamp: threadTS,
+			}
+			bot.handleThreadForward(context.Background(), ev, agentName)
+		}(i)
+	}
+	wg.Wait()
+
+	// Count how many agent beads were created. The spawnInFlight guard in
+	// respawnThreadAgent should ensure at most 1 agent bead.
+	daemon.mu.Lock()
+	var agentCount int
+	for _, b := range daemon.beads {
+		if b.Type == "agent" && b.Title == agentName {
+			agentCount++
+		}
+	}
+	daemon.mu.Unlock()
+
+	if agentCount > 1 {
+		t.Errorf("expected at most 1 agent bead from concurrent forwards, got %d", agentCount)
+	}
+
+	// Thread→agent mapping should still be intact.
+	if _, ok := state.GetThreadAgent(channel, threadTS); !ok {
+		t.Error("expected thread→agent mapping to be preserved")
+	}
+}
+
+// TestReconcileThreadAgentsDuringActiveSpawn verifies that ReconcileThreadAgents
+// does not corrupt state when called while a spawn is in-flight for the same thread.
+func TestReconcileThreadAgentsDuringActiveSpawn(t *testing.T) {
+	daemon := newMockDaemon()
+
+	dir := t.TempDir()
+	state, err := NewStateManager(filepath.Join(dir, "state.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	b := &Bot{
+		daemon:        daemon,
+		state:         state,
+		logger:        slog.Default(),
+		agentCards:    make(map[string]MessageRef),
+		spawnInFlight: make(map[string]bool),
+	}
+
+	channel := "C-reconcile-test"
+	threadTS := "5555.1111"
+	agentName := "thread-5555-1111"
+
+	// Simulate an in-flight spawn for this thread.
+	spawnKey := channel + ":" + threadTS
+	b.mu.Lock()
+	b.spawnInFlight[spawnKey] = true
+	b.mu.Unlock()
+
+	// Add an agent bead with thread fields that would normally be reconciled.
+	daemon.mu.Lock()
+	daemon.beads["bd-inflight"] = &beadsapi.BeadDetail{
+		ID:    "bd-inflight",
+		Title: agentName,
+		Type:  "agent",
+		Fields: map[string]string{
+			"agent":                agentName,
+			"slack_thread_channel": channel,
+			"slack_thread_ts":      threadTS,
+		},
+	}
+	daemon.mu.Unlock()
+
+	// Run reconciliation — it should set the mapping since no existing
+	// state-level mapping exists (spawnInFlight is a separate concern;
+	// reconciliation only checks state.GetThreadAgent).
+	b.ReconcileThreadAgents(context.Background())
+
+	// The mapping should be set from the daemon bead.
+	agent, ok := state.GetThreadAgent(channel, threadTS)
+	if !ok {
+		t.Fatal("expected thread→agent mapping to be restored by reconciliation")
+	}
+	if agent != agentName {
+		t.Errorf("reconciled agent = %q, want %q", agent, agentName)
+	}
+
+	// Now simulate a concurrent scenario: set a DIFFERENT mapping (as if
+	// the in-flight spawn completed) and run reconciliation again.
+	_ = state.SetThreadAgent(channel, threadTS, "spawned-agent")
+
+	b.ReconcileThreadAgents(context.Background())
+
+	// Reconciliation must NOT overwrite the existing mapping.
+	agent, _ = state.GetThreadAgent(channel, threadTS)
+	if agent != "spawned-agent" {
+		t.Errorf("expected reconciliation to preserve existing mapping %q, got %q",
+			"spawned-agent", agent)
+	}
+
+	// Clean up spawnInFlight.
+	b.mu.Lock()
+	delete(b.spawnInFlight, spawnKey)
+	b.mu.Unlock()
+}
+
+// TestDecisionNotificationRoutesToThreadBoundAgent verifies that a decision
+// bead created by a thread-bound agent resolves the thread binding and routes
+// the notification correctly. The decision's requesting_agent field should be
+// used to look up thread metadata.
+func TestDecisionNotificationRoutesToThreadBoundAgent(t *testing.T) {
+	daemon := newMockDaemon()
+
+	channel := "C-decision-thread"
+	threadTS := "8888.1111"
+	agentName := "thread-8888-1111"
+
+	// Set up a thread-bound agent bead.
+	daemon.beads[agentName] = &beadsapi.BeadDetail{
+		ID:    "bd-thread-decision-agent",
+		Title: agentName,
+		Type:  "agent",
+		Fields: map[string]string{
+			"agent":                agentName,
+			"slack_thread_channel": channel,
+			"slack_thread_ts":      threadTS,
+			"spawn_source":        "slack-thread",
+			"slack_user_id":       "U-SPAWNER",
+		},
+	}
+
+	dir := t.TempDir()
+	state, err := NewStateManager(filepath.Join(dir, "state.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = state.SetThreadAgent(channel, threadTS, agentName)
+
+	b := &Bot{
+		daemon:     daemon,
+		state:      state,
+		logger:     slog.Default(),
+		botUserID:  "U-BOT",
+		agentCards: make(map[string]MessageRef),
+	}
+
+	// Verify resolveAgentThread returns the correct binding.
+	resolvedChannel, resolvedTS := b.resolveAgentThread(context.Background(), agentName)
+	if resolvedChannel != channel {
+		t.Errorf("resolveAgentThread channel = %q, want %q", resolvedChannel, channel)
+	}
+	if resolvedTS != threadTS {
+		t.Errorf("resolveAgentThread ts = %q, want %q", resolvedTS, threadTS)
+	}
+
+	// Verify the agent is reachable via getAgentByThread (for mention routing).
+	found := b.getAgentByThread(channel, threadTS)
+	if found != agentName {
+		t.Errorf("getAgentByThread = %q, want %q", found, agentName)
+	}
+
+	// Verify resolveDecisionMentionUser finds the slack_user_id on the agent bead.
+	userID := b.resolveDecisionMentionUser(context.Background(), agentName)
+	if userID != "U-SPAWNER" {
+		t.Errorf("resolveDecisionMentionUser = %q, want %q", userID, "U-SPAWNER")
+	}
+}
+
+// TestConciergeDoubleClick verifies that two rapid clicks on the concierge
+// Start button result in only one agent being spawned. The spawnInFlight
+// guard should prevent the second click from creating a duplicate agent.
+//
+// handleConciergeStart uses spawnInFlight as a mutex-guarded check-and-set.
+// This test uses handleThreadSpawn (which has the same guard) to exercise
+// the real code path, since handleConciergeStart requires a full
+// slack.InteractionCallback that is hard to construct in tests.
+func TestConciergeDoubleClick(t *testing.T) {
+	daemon := newMockDaemon()
+	daemon.seedProjectWithChannel("testproj", "C-concierge-test")
+
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+
+	bot := newTestBot(daemon, slackSrv)
+
+	dir := t.TempDir()
+	state, err := NewStateManager(filepath.Join(dir, "state.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	bot.state = state
+	bot.botUserID = "U-BOT"
+	bot.lastThreadNudge = make(map[string]time.Time)
+
+	channel := "C-concierge-test"
+	threadTS := "6666.1111"
+
+	// Fire 5 concurrent spawn attempts for the same thread — simulates
+	// rapid button clicks or multiple @mentions arriving simultaneously.
+	// The spawnInFlight guard in handleThreadSpawn should ensure only 1 spawns.
+	var wg sync.WaitGroup
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			bot.handleThreadSpawn(context.Background(), &slackevents.AppMentionEvent{
+				User:            "U-USER",
+				Text:            "<@U-BOT> help me",
+				TimeStamp:       "6666.2222",
+				ThreadTimeStamp: threadTS,
+				Channel:         channel,
+			}, "help me")
+		}()
+	}
+	wg.Wait()
+
+	// Count agent beads — should be exactly 1.
+	daemon.mu.Lock()
+	var agentCount int
+	for _, b := range daemon.beads {
+		if b.Type == "agent" {
+			agentCount++
+		}
+	}
+	daemon.mu.Unlock()
+
+	if agentCount != 1 {
+		t.Errorf("expected exactly 1 agent bead from double-click, got %d", agentCount)
+	}
+}
+
+// TestConcurrentSpawnAndForwardSameThread verifies that a handleThreadForward
+// arriving concurrently with a handleThreadSpawn for the same thread does not
+// produce duplicate agents. The spawnInFlight guard protects both paths.
+func TestConcurrentSpawnAndForwardSameThread(t *testing.T) {
+	daemon := newMockDaemon()
+	daemon.seedProjectWithChannel("testproj", "C-mixed-race")
+
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+
+	bot := newTestBot(daemon, slackSrv)
+
+	dir := t.TempDir()
+	state, err := NewStateManager(filepath.Join(dir, "state.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	bot.state = state
+	bot.botUserID = "U-BOT"
+	bot.lastThreadNudge = make(map[string]time.Time)
+
+	channel := "C-mixed-race"
+	threadTS := "3333.4444"
+
+	// Fire a spawn and multiple forwards concurrently.
+	var wg sync.WaitGroup
+
+	// Spawn goroutine.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		bot.handleThreadSpawn(context.Background(), &slackevents.AppMentionEvent{
+			User:            "U-USER",
+			Text:            "<@U-BOT> help me",
+			TimeStamp:       "3333.5555",
+			ThreadTimeStamp: threadTS,
+			Channel:         channel,
+		}, "help me")
+	}()
+
+	// Forward goroutines (these will see no agent bound yet and try respawn).
+	for i := 0; i < 3; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			// These will find no agent in state (or a just-set one) and either
+			// forward normally or attempt respawn.
+			agentName := bot.getAgentByThread(channel, threadTS)
+			if agentName == "" {
+				// No agent bound yet — this is expected for the race window.
+				return
+			}
+			bot.handleThreadForward(context.Background(), &slackevents.MessageEvent{
+				User:            "U-USER",
+				Channel:         channel,
+				Text:            "follow up",
+				TimeStamp:       "3333.6666",
+				ThreadTimeStamp: threadTS,
+			}, agentName)
+		}()
+	}
+	wg.Wait()
+
+	// Count agent beads — should be exactly 1.
+	daemon.mu.Lock()
+	var agentCount int
+	for _, b := range daemon.beads {
+		if b.Type == "agent" {
+			agentCount++
+		}
+	}
+	daemon.mu.Unlock()
+
+	if agentCount != 1 {
+		t.Errorf("expected exactly 1 agent bead from concurrent spawn+forward, got %d", agentCount)
+	}
+}


### PR DESCRIPTION
## Summary
- Add 5 concurrent scenario tests covering thread spawn races, reconciliation during active spawns, decision routing to thread-bound agents, concierge double-click prevention, and mixed spawn+forward races
- Fix race condition in `respawnThreadAgent` — concurrent thread replies for a dead agent could spawn duplicate agent beads (missing `spawnInFlight` guard)

## Test plan
- [x] All 5 new tests pass (`TestConcurrentThreadForwardDuringSpawn`, `TestReconcileThreadAgentsDuringActiveSpawn`, `TestDecisionNotificationRoutesToThreadBoundAgent`, `TestConciergeDoubleClick`, `TestConcurrentSpawnAndForwardSameThread`)
- [x] Full bridge test suite passes (22s, 0 failures)
- [x] All controller binaries build (controller, slack-bridge, gitlab-bridge)
- [x] Full `go test ./...` passes across all packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)