### PR TITLE
fix(gasboat/bridge): preserve slack_user_id across agent respawn and restart

### DIFF
--- a/gasboat/controller/internal/bridge/bot_agent_kill.go
+++ b/gasboat/controller/internal/bridge/bot_agent_kill.go
@@ -87,7 +87,7 @@ func (b *Bot) killAgent(ctx context.Context, agentName string, force bool) error
 // --resume to coop for session continuity. Used when a thread reply arrives
 // for a dead/completed agent. The triggerText is included in the description
 // so the agent knows why it was woken up.
-func (b *Bot) respawnThreadAgent(ctx context.Context, channel, threadTS, agentName, triggerText string) {
+func (b *Bot) respawnThreadAgent(ctx context.Context, channel, threadTS, agentName, triggerText, userID string) {
 	agentName = extractAgentName(agentName)
 
 	// Snapshot the listen-thread flag before it gets cleaned up by killAgent
@@ -125,6 +125,9 @@ func (b *Bot) respawnThreadAgent(ctx context.Context, channel, threadTS, agentNa
 		"slack_thread_channel": channel,
 		"slack_thread_ts":      threadTS,
 		"spawn_source":         "slack-thread-resume",
+	}
+	if userID != "" {
+		fields["slack_user_id"] = userID
 	}
 	fieldsJSON, err := json.Marshal(fields)
 	if err != nil {
@@ -368,6 +371,7 @@ func (b *Bot) handleRestartThreadAgent(ctx context.Context, agentName string, ca
 			return
 		}
 		project := bead.Fields["project"]
+		slackUserID := bead.Fields["slack_user_id"]
 
 		// Snapshot the listen-thread flag before killAgent clears it.
 		wasListenThread := b.state != nil && b.state.IsListenThread(channelID, threadTS)
@@ -392,6 +396,9 @@ func (b *Bot) handleRestartThreadAgent(ctx context.Context, agentName string, ca
 			"slack_thread_channel": channelID,
 			"slack_thread_ts":      threadTS,
 			"spawn_source":         "slack-thread",
+		}
+		if slackUserID != "" {
+			fields["slack_user_id"] = slackUserID
 		}
 		fieldsJSON, err := json.Marshal(fields)
 		if err != nil {

--- a/gasboat/controller/internal/bridge/bot_commands.go
+++ b/gasboat/controller/internal/bridge/bot_commands.go
@@ -748,7 +748,7 @@ func (b *Bot) handleKillThreadCommand(_ context.Context, cmd slack.SlashCommand)
 
 		if restart && threadChannel != "" && threadTS != "" {
 			b.respawnThreadAgent(context.Background(), threadChannel, threadTS, agentName,
-				"Restarted via /kill-thread --restart")
+				"Restarted via /kill-thread --restart", cmd.UserID)
 			_, _ = b.api.PostEphemeral(cmd.ChannelID, cmd.UserID,
 				slack.MsgOptionText(fmt.Sprintf(":arrows_counterclockwise: Thread agent *%s* restarted with session resume.", agentName), false))
 		} else {

--- a/gasboat/controller/internal/bridge/bot_mentions.go
+++ b/gasboat/controller/internal/bridge/bot_mentions.go
@@ -132,7 +132,7 @@ func (b *Bot) handleAppMention(ctx context.Context, ev *slackevents.AppMentionEv
 				"agent", agent, "channel", ev.Channel, "thread_ts", ev.ThreadTimeStamp, "error", err)
 			// Agent is gone — respawn the SAME agent name so the entrypoint
 			// finds the existing session JSONL and PVC for session continuity.
-			b.respawnThreadAgent(ctx, ev.Channel, ev.ThreadTimeStamp, agent, text)
+			b.respawnThreadAgent(ctx, ev.Channel, ev.ThreadTimeStamp, agent, text, ev.User)
 			return
 		}
 		agentPodName = beadsapi.ParseNotes(agentBead.Notes)["pod_name"]
@@ -937,7 +937,7 @@ func (b *Bot) handleMentionThreadCommand(_ context.Context, ev *slackevents.AppM
 		}
 		go func() {
 			b.respawnThreadAgent(context.Background(), channelID, threadTS, agent,
-				"Restarted via @mention command")
+				"Restarted via @mention command", userID)
 		}()
 		return true
 	}

--- a/gasboat/controller/internal/bridge/bot_thread_forward.go
+++ b/gasboat/controller/internal/bridge/bot_thread_forward.go
@@ -33,7 +33,7 @@ func (b *Bot) handleThreadForward(ctx context.Context, ev *slackevents.MessageEv
 			"agent", agentName, "channel", ev.Channel, "thread_ts", ev.ThreadTimeStamp)
 		// Agent is gone — respawn the SAME agent name so the entrypoint
 		// finds the existing session JSONL and PVC for session continuity.
-		b.respawnThreadAgent(ctx, ev.Channel, ev.ThreadTimeStamp, agentName, ev.Text)
+		b.respawnThreadAgent(ctx, ev.Channel, ev.ThreadTimeStamp, agentName, ev.Text, ev.User)
 		return
 	}
 

--- a/gasboat/controller/internal/bridge/bot_thread_test.go
+++ b/gasboat/controller/internal/bridge/bot_thread_test.go
@@ -273,7 +273,7 @@ func TestRespawnThreadAgent_CreatesSameNameBead(t *testing.T) {
 		threadSpawnMsgs: make(map[string]MessageRef),
 	}
 
-	b.respawnThreadAgent(context.Background(), channel, threadTS, agentName, "wake up please")
+	b.respawnThreadAgent(context.Background(), channel, threadTS, agentName, "wake up please", "U-SPAWNER")
 
 	// Thread→agent mapping should still exist.
 	agent, ok := state.GetThreadAgent(channel, threadTS)
@@ -334,7 +334,7 @@ func TestRespawnThreadAgent_RejectsNoProject(t *testing.T) {
 		threadSpawnMsgs: make(map[string]MessageRef),
 	}
 
-	b.respawnThreadAgent(context.Background(), "C-unmapped", "1111.2222", "thread-1111-2222", "wake up")
+	b.respawnThreadAgent(context.Background(), "C-unmapped", "1111.2222", "thread-1111-2222", "wake up", "")
 
 	// Should NOT have created any agent bead.
 	for _, bead := range daemon.beads {
@@ -363,7 +363,7 @@ func TestRespawnThreadAgent_InfersProjectFromChannel(t *testing.T) {
 		threadSpawnMsgs: make(map[string]MessageRef),
 	}
 
-	b.respawnThreadAgent(context.Background(), "C-gasboat", "2222.3333", "my-agent", "do the thing")
+	b.respawnThreadAgent(context.Background(), "C-gasboat", "2222.3333", "my-agent", "do the thing", "U-ORIGINAL")
 
 	// Find the created agent bead.
 	var found *beadsapi.BeadDetail
@@ -380,8 +380,68 @@ func TestRespawnThreadAgent_InfersProjectFromChannel(t *testing.T) {
 	if found.Fields["project"] != "gasboat" {
 		t.Errorf("project = %q, want gasboat", found.Fields["project"])
 	}
+	if found.Fields["slack_user_id"] != "U-ORIGINAL" {
+		t.Errorf("slack_user_id = %q, want U-ORIGINAL", found.Fields["slack_user_id"])
+	}
 	if !hasLabel(found.Labels, "project:gasboat") {
 		t.Errorf("expected project:gasboat label, got %v", found.Labels)
+	}
+}
+
+// TestHandleThreadForward_RespawnPreservesUserID verifies that when
+// handleThreadForward triggers a respawn (agent is dead), the poster's
+// user ID is carried forward as slack_user_id on the new agent bead.
+func TestHandleThreadForward_RespawnPreservesUserID(t *testing.T) {
+	daemon := newMockDaemon()
+	daemon.seedProjectWithChannel("testproj", "C-uid-test")
+
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+
+	bot := newTestBot(daemon, slackSrv)
+
+	dir := t.TempDir()
+	state, err := NewStateManager(filepath.Join(dir, "state.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	bot.state = state
+	bot.lastThreadNudge = make(map[string]time.Time)
+
+	channel := "C-uid-test"
+	threadTS := "9999.1111"
+	agentName := "thread-9999-1111"
+
+	// Pre-bind thread to an agent that is NOT in the daemon (dead).
+	_ = state.SetThreadAgent(channel, threadTS, agentName)
+	_ = state.SetListenThread(channel, threadTS)
+
+	// Forward a message — triggers respawn because agent is dead.
+	ev := &slackevents.MessageEvent{
+		User:            "U-POSTER",
+		Channel:         channel,
+		Text:            "follow up message",
+		TimeStamp:       "9999.2222",
+		ThreadTimeStamp: threadTS,
+	}
+	bot.handleThreadForward(context.Background(), ev, agentName)
+
+	// Find the respawned agent bead.
+	daemon.mu.Lock()
+	var found *beadsapi.BeadDetail
+	for _, b := range daemon.beads {
+		if b.Type == "agent" && b.Title == agentName {
+			found = b
+			break
+		}
+	}
+	daemon.mu.Unlock()
+
+	if found == nil {
+		t.Fatal("expected agent bead to be created by respawn")
+	}
+	if found.Fields["slack_user_id"] != "U-POSTER" {
+		t.Errorf("slack_user_id = %q, want U-POSTER", found.Fields["slack_user_id"])
 	}
 }
 


### PR DESCRIPTION
## Summary
- Adds `userID` parameter to `respawnThreadAgent` so all callers pass the Slack user ID to the new agent bead
- Copies `slack_user_id` from the old bead in `handleRestartThreadAgent` before killing the agent
- Fixes decision mention routing (`resolveDecisionMentionUser`) returning empty for respawned agents

## Test plan
- [x] `TestRespawnThreadAgent_InfersProjectFromChannel` — verifies `slack_user_id` on respawned bead
- [x] `TestHandleThreadForward_RespawnPreservesUserID` — new test: verifies full respawn path carries user ID
- [x] All existing bridge tests pass

Closes kd-8jPpFbS50P (child of epic kd-acfghTNV0j)

🤖 Generated with [Claude Code](https://claude.com/claude-code)