### PR TITLE
fix(gasboat/bridge): add random suffix to concierge agent names

### DIFF
--- a/gasboat/controller/internal/bridge/bot_concierge.go
+++ b/gasboat/controller/internal/bridge/bot_concierge.go
@@ -2,6 +2,8 @@ package bridge
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"fmt"
 	"strings"
 	"sync"
@@ -248,7 +250,9 @@ func (b *Bot) fetchMessageText(ctx context.Context, channel, messageTS string) s
 // generateAgentName creates a unique agent name for a concierge-spawned agent.
 func (b *Bot) generateAgentName(project string) string {
 	ts := time.Now().UnixMilli()
-	return fmt.Sprintf("concierge-%s-%d", project, ts)
+	var suffix [3]byte
+	_, _ = rand.Read(suffix[:])
+	return fmt.Sprintf("concierge-%s-%d-%s", project, ts, hex.EncodeToString(suffix[:]))
 }
 
 // parseConciergeValue parses the encoded button value: "project|channel|message_ts|user_id".

--- a/gasboat/controller/internal/bridge/bot_concierge_test.go
+++ b/gasboat/controller/internal/bridge/bot_concierge_test.go
@@ -300,3 +300,15 @@ func TestHandleMessageEvent_ConciergeDebounce(t *testing.T) {
 		TimeStamp: "1111.7777",
 	})
 }
+
+func TestGenerateConciergeAgentName_UniquePerCall(t *testing.T) {
+	b := &Bot{}
+	seen := make(map[string]bool)
+	for i := 0; i < 100; i++ {
+		name := b.generateAgentName("myproject")
+		if seen[name] {
+			t.Fatalf("duplicate agent name on iteration %d: %s", i, name)
+		}
+		seen[name] = true
+	}
+}


### PR DESCRIPTION
## Summary
- Adds 3-byte random hex suffix to concierge agent names to prevent collisions when two spawns for the same project happen in the same millisecond
- Name format changes from `concierge-{project}-{ms}` to `concierge-{project}-{ms}-{hex}`

## Test plan
- [x] `TestGenerateConciergeAgentName_UniquePerCall` — verifies 100 sequential calls produce unique names
- [x] All existing bridge tests pass

Closes kd-YSb7GXazH7 (child of epic kd-acfghTNV0j)

🤖 Generated with [Claude Code](https://claude.com/claude-code)