### PR TITLE
fix(gasboat/bridge): harden chat/squawk thread routing for thread-bound agents

### DIFF
--- a/gasboat/controller/internal/bridge/bot_mentions.go
+++ b/gasboat/controller/internal/bridge/bot_mentions.go
@@ -142,7 +142,13 @@ func (b *Bot) handleAppMention(ctx context.Context, ev *slackevents.AppMentionEv
 	}
 
 	if replyTS == "" {
-		replyTS = ev.TimeStamp
+		// For thread messages, reply in the parent thread (not under
+		// the individual message which would create a sub-thread).
+		if ev.ThreadTimeStamp != "" {
+			replyTS = ev.ThreadTimeStamp
+		} else {
+			replyTS = ev.TimeStamp
+		}
 	}
 
 	// Canonicalize to short name so map lookups (agentPodName, etc.)

--- a/gasboat/controller/internal/bridge/bot_mentions_test.go
+++ b/gasboat/controller/internal/bridge/bot_mentions_test.go
@@ -1196,3 +1196,75 @@ func TestHandleMentionThreadCommand_CommandDispatch(t *testing.T) {
 		time.Sleep(10 * time.Millisecond)
 	}
 }
+
+func TestHandleAppMention_ThreadMention_UsesParentThreadTS(t *testing.T) {
+	// Verifies that when a mention arrives in a thread, the stored chat
+	// message ref uses the parent thread TS (ThreadTimeStamp) so the
+	// response threads correctly in the same thread, not under the
+	// individual message.
+	daemon := newMockDaemon()
+
+	// Seed an active agent bead for the thread-bound agent.
+	daemon.beads["thread-agent"] = &beadsapi.BeadDetail{
+		ID:    "bd-agent-thread",
+		Title: "crew-gasboat-crew-thread-agent",
+		Type:  "agent",
+		Fields: map[string]string{
+			"agent":   "thread-agent",
+			"project": "gasboat",
+			"role":    "crew",
+		},
+	}
+
+	dir := t.TempDir()
+	state, err := NewStateManager(filepath.Join(dir, "state.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Map the thread to the agent.
+	_ = state.SetThreadAgent("C-test", "1000.0000", "thread-agent")
+
+	slackSrv := newFakeSlackServer(t)
+	defer slackSrv.Close()
+
+	b := newTestBot(daemon, slackSrv)
+	b.state = state
+	b.botUserID = "U-BOT"
+	b.lastThreadNudge = make(map[string]time.Time)
+
+	// Mention @gasboat in a thread — the parent thread TS is 1000.0000,
+	// the individual message TS is 2000.5555.
+	b.handleAppMention(context.Background(), &slackevents.AppMentionEvent{
+		User:            "U-USER",
+		Text:            "<@U-BOT> check the status",
+		TimeStamp:       "2000.5555",
+		ThreadTimeStamp: "1000.0000",
+		Channel:         "C-test",
+	})
+
+	// Find the mention tracking bead created by handleAppMention.
+	taskBeads := filterBeadsByType(daemon.beads, "task")
+	if len(taskBeads) == 0 {
+		t.Fatal("expected a mention tracking bead to be created")
+	}
+
+	// Check the stored chat message ref uses the parent thread TS.
+	for _, tb := range taskBeads {
+		ref, ok := state.GetChatMessage(tb.ID)
+		if !ok {
+			continue
+		}
+		if ref.Timestamp == "2000.5555" {
+			t.Errorf("chat message ref uses individual message TS %q, want parent thread TS %q",
+				ref.Timestamp, "1000.0000")
+		}
+		if ref.Timestamp != "1000.0000" {
+			t.Errorf("chat message ref timestamp = %q, want parent thread TS %q",
+				ref.Timestamp, "1000.0000")
+		}
+		if ref.ChannelID != "C-test" {
+			t.Errorf("chat message ref channel = %q, want %q", ref.ChannelID, "C-test")
+		}
+	}
+}

--- a/gasboat/controller/internal/bridge/chat.go
+++ b/gasboat/controller/internal/bridge/chat.go
@@ -98,12 +98,17 @@ func (c *Chat) handleClosed(ctx context.Context, data []byte) {
 
 	// Post as thread reply.
 	if c.bot != nil && c.bot.api != nil {
-		_, _, _ = c.bot.api.PostMessage(ref.ChannelID,
+		_, _, err = c.bot.api.PostMessageContext(ctx, ref.ChannelID,
 			slack.MsgOptionText(response, false),
 			slack.MsgOptionTS(ref.Timestamp),
 		)
-		c.logger.Info("chat response relayed to Slack",
-			"bead", bead.ID, "channel", ref.ChannelID)
+		if err != nil {
+			c.logger.Error("failed to relay chat response to Slack",
+				"bead", bead.ID, "channel", ref.ChannelID, "error", err)
+		} else {
+			c.logger.Info("chat response relayed to Slack",
+				"bead", bead.ID, "channel", ref.ChannelID)
+		}
 	}
 
 	// Clean up state.


### PR DESCRIPTION
## Summary

- Thread mentions now use `ev.ThreadTimeStamp` (parent thread TS) as the chat response anchor instead of `ev.TimeStamp` (individual message TS), preventing sub-threads under individual messages
- Chat handler now uses `PostMessageContext` for proper context cancellation support
- Chat handler now logs Slack API errors instead of silently swallowing them

## Root cause

When a mention arrived in a thread, the stored chat message ref used the individual message TS. Slack would then create a response threaded under that specific message rather than in the parent thread. The `bot_thread_forward.go` handler already used `ev.ThreadTimeStamp` correctly — the mention handler was inconsistent.

## Test plan

- [x] New test `TestHandleAppMention_ThreadMention_UsesParentThreadTS` verifies parent TS is used
- [x] All existing chat/squawk/mention tests pass
- [x] Full controller test suite passes (`go test ./...`)
- [ ] Verify thread-bound agent responses appear in correct thread after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)