### PR TITLE
fix(ci): upgrade Actions to Node.js 24 and make release idempotent

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       helm: ${{ steps.filter.outputs.helm }}
       is_tag: ${{ startsWith(github.ref, 'refs/tags/20') }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dorny/paths-filter@v3
         id: filter
         with:
@@ -49,8 +49,8 @@ jobs:
     if: needs.changes.outputs.gasboat == 'true' || needs.changes.outputs.is_tag == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: gasboat/controller/go.mod
       - run: go test ./gasboat/controller/...
@@ -61,8 +61,8 @@ jobs:
     if: needs.changes.outputs.kbeads == 'true' || needs.changes.outputs.is_tag == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: kbeads/go.mod
       - run: go test ./kbeads/...
@@ -73,8 +73,8 @@ jobs:
     if: needs.changes.outputs.gasboat == 'true' || needs.changes.outputs.kbeads == 'true' || needs.changes.outputs.is_tag == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: gasboat/controller/go.mod
       - uses: golangci/golangci-lint-action@v7
@@ -92,7 +92,7 @@ jobs:
     if: needs.changes.outputs.coop == 'true' || needs.changes.outputs.is_tag == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
       - run: sudo apt-get install -y protobuf-compiler
       - run: cd coop && RUSTC_WRAPPER="" cargo test --workspace --lib
@@ -103,8 +103,8 @@ jobs:
     if: needs.changes.outputs.beads3d == 'true' || needs.changes.outputs.is_tag == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
       - run: cd beads3d && npm ci && npm run build
@@ -115,6 +115,6 @@ jobs:
     if: needs.changes.outputs.helm == 'true' || needs.changes.outputs.is_tag == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: azure/setup-helm@v4
       - run: helm lint gasboat/helm/gasboat/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,13 +18,19 @@ jobs:
   github-release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release create "${{ github.ref_name }}" --generate-notes
+          TAG: ${{ github.ref_name }}
+        run: |
+          if gh release view "$TAG" &>/dev/null; then
+            echo "Release $TAG already exists, skipping creation"
+          else
+            gh release create "$TAG" --generate-notes
+          fi
 
   trigger-deploy:
     name: Trigger fics-helm-chart deploy


### PR DESCRIPTION
## Summary
- Upgrade `actions/checkout` v4→v5, `actions/setup-go` v5→v6, `actions/setup-node` v4→v5 for Node.js 24 runtime (ahead of June 2026 forced migration)
- Make release workflow idempotent: check if release exists before `gh release create`, preventing HTTP 422 "already exists" failures on re-runs (fixes issue seen on 2026.71.2)
- `dorny/paths-filter@v3` and `azure/setup-helm@v4` kept as-is — no Node.js 24 versions available upstream yet

## Test plan
- [ ] CI passes on this PR (validates updated action versions work)
- [ ] Verify no regressions in path-filtered job triggers
- [ ] Next release tag push validates idempotent release creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)