### PR TITLE
fix(gasboat/bridge): prevent bridge duplicate comments on restart

### DIFF
--- a/gasboat/controller/internal/bridge/jira_sync.go
+++ b/gasboat/controller/internal/bridge/jira_sync.go
@@ -68,17 +68,25 @@ type JiraSyncCatchUpClient interface {
 // CatchUp fetches existing Jira-sourced beads from the daemon and pre-populates
 // the dedup map so that SSE replay after a restart does not re-post comments,
 // links, or transitions that were already synced.
+//
+// This includes closed beads because the bridge state volume may be ephemeral
+// (emptyDir), causing the SSE last-event-ID to be lost on restart. Without
+// covering closed beads, ancient claim/close events would be replayed and
+// re-posted to Jira every time the bridge restarts.
 func (s *JiraSync) CatchUp(ctx context.Context, client JiraSyncCatchUpClient) {
 	if client == nil {
 		return
 	}
 
-	// Fetch all active issue-kind beads with source:jira label.
+	// Fetch all Jira-sourced beads including closed ones. The bridge state
+	// volume may be ephemeral (emptyDir), so SSE may replay from the
+	// beginning on restart. We must pre-mark all historical sync operations
+	// to prevent duplicate Jira comments.
 	result, err := client.ListBeadsFiltered(ctx, beadsapi.ListBeadsQuery{
 		Kinds:    []string{"issue"},
-		Statuses: []string{"open", "in_progress"},
+		Statuses: []string{"open", "in_progress", "closed"},
 		Labels:   []string{"source:jira"},
-		Limit:    500,
+		Limit:    1000,
 	})
 	if err != nil {
 		s.logger.Warn("jira catch-up: failed to list beads", "error", err)
@@ -101,8 +109,10 @@ func (s *JiraSync) CatchUp(ctx context.Context, client JiraSyncCatchUpClient) {
 			continue
 		}
 
-		// Pre-mark claimed beads.
-		if bead.Status == "in_progress" && bead.Assignee != "" {
+		// Pre-mark claimed beads. Any bead with an assignee was claimed
+		// at some point — mark regardless of current status so that
+		// replayed "updated" events for closed beads don't re-post.
+		if bead.Assignee != "" {
 			s.mark("claimed:" + bead.ID + ":" + bead.Assignee)
 			marked++
 		}
@@ -116,6 +126,12 @@ func (s *JiraSync) CatchUp(ctx context.Context, client JiraSyncCatchUpClient) {
 		// Pre-mark MR merged.
 		if bead.Fields["mr_merged"] == "true" {
 			s.mark("merged:" + bead.ID)
+			marked++
+		}
+
+		// Pre-mark closed beads so replayed close events don't re-post.
+		if bead.Status == "closed" {
+			s.mark("close:" + bead.ID)
 			marked++
 		}
 	}

--- a/gasboat/controller/internal/bridge/jira_sync_test.go
+++ b/gasboat/controller/internal/bridge/jira_sync_test.go
@@ -631,3 +631,126 @@ func TestJiraSync_CatchUp_NilClient(t *testing.T) {
 	// Should not panic.
 	s.CatchUp(context.Background(), nil)
 }
+
+// TestJiraSync_CatchUp_ClosedBeadPreventsReplay verifies that CatchUp marks
+// closed beads so that SSE replay of historical "updated" events for
+// long-gone agents doesn't re-post "working on this issue" comments.
+// This is the fix for the bug where the jira bridge repeated itself on restart
+// because closed beads were not included in the CatchUp query.
+func TestJiraSync_CatchUp_ClosedBeadPreventsReplay(t *testing.T) {
+	var (
+		mu           sync.Mutex
+		commentCount int
+	)
+
+	jiraServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
+		switch {
+		case r.Method == "POST" && r.URL.Path == "/rest/api/3/issue/PE-950/comment":
+			commentCount++
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprint(w, `{"id":"1"}`)
+		case r.Method == "PUT" && r.URL.Path == "/rest/api/3/issue/PE-950":
+			w.WriteHeader(http.StatusNoContent)
+		case r.Method == "GET" && r.URL.Path == "/rest/api/3/issue/PE-950/transitions":
+			resp := map[string]any{"transitions": []map[string]any{
+				{"id": "21", "name": "In Progress", "to": map[string]string{"name": "In Progress"}},
+			}}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(resp)
+		case r.Method == "POST" && r.URL.Path == "/rest/api/3/issue/PE-950/transitions":
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer jiraServer.Close()
+
+	s := NewJiraSync(JiraSyncConfig{Jira: newTestJiraClient(jiraServer.URL), Logger: slog.Default()})
+
+	// Simulate restart catch-up: bead was claimed by an agent that is now
+	// long gone — the bead is closed.
+	client := &mockCatchUpClient{
+		beads: []*beadsapi.BeadDetail{
+			{
+				ID:       "bd-task-closed",
+				Status:   "closed",
+				Assignee: "jira-fixer99",
+				Labels:   []string{"source:jira"},
+				Fields:   map[string]string{"jira_key": "PE-950"},
+			},
+		},
+	}
+	s.CatchUp(context.Background(), client)
+
+	// SSE replays the historical "updated" event (the claim from before
+	// the bead was closed). Without the fix, this would re-post the
+	// "working on this issue" comment to Jira.
+	event := marshalSSEBeadPayload(BeadEvent{
+		ID: "bd-task-closed", Type: "task", Title: "[PE-950] Fix something",
+		Status:   "in_progress",
+		Assignee: "jira-fixer99",
+		Labels:   []string{"source:jira"},
+		Fields:   map[string]string{"jira_key": "PE-950"},
+	})
+	s.handleUpdated(context.Background(), event)
+
+	mu.Lock()
+	defer mu.Unlock()
+	if commentCount != 0 {
+		t.Errorf("expected 0 comments for closed bead (deduped), got %d", commentCount)
+	}
+}
+
+// TestJiraSync_CatchUp_ClosedBeadPreventsCloseReplay verifies that CatchUp
+// also marks close events for closed beads.
+func TestJiraSync_CatchUp_ClosedBeadPreventsCloseReplay(t *testing.T) {
+	var (
+		mu           sync.Mutex
+		commentCount int
+	)
+
+	jiraServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
+		if r.Method == "POST" && r.URL.Path == "/rest/api/3/issue/PE-960/comment" {
+			commentCount++
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprint(w, `{"id":"1"}`)
+		} else {
+			w.WriteHeader(http.StatusNoContent)
+		}
+	}))
+	defer jiraServer.Close()
+
+	s := NewJiraSync(JiraSyncConfig{Jira: newTestJiraClient(jiraServer.URL), Logger: slog.Default()})
+
+	client := &mockCatchUpClient{
+		beads: []*beadsapi.BeadDetail{
+			{
+				ID:       "bd-task-closed2",
+				Status:   "closed",
+				Assignee: "agent-old",
+				Labels:   []string{"source:jira"},
+				Fields:   map[string]string{"jira_key": "PE-960"},
+			},
+		},
+	}
+	s.CatchUp(context.Background(), client)
+
+	// Replay close event — should be deduped.
+	event := marshalSSEBeadPayload(BeadEvent{
+		ID: "bd-task-closed2", Type: "task", Title: "[PE-960] Old task",
+		Status: "closed",
+		Labels: []string{"source:jira"},
+		Fields: map[string]string{"jira_key": "PE-960"},
+	})
+	s.handleClosed(context.Background(), event)
+
+	mu.Lock()
+	defer mu.Unlock()
+	if commentCount != 0 {
+		t.Errorf("expected 0 comments for replayed close event (deduped), got %d", commentCount)
+	}
+}

--- a/gasboat/helm/gasboat/templates/gitlab-bridge/deployment.yaml
+++ b/gasboat/helm/gasboat/templates/gitlab-bridge/deployment.yaml
@@ -100,7 +100,12 @@ spec:
             {{- toYaml .Values.gitlabBridge.resources | nindent 12 }}
       volumes:
         - name: state
+          {{- if .Values.gitlabBridge.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "gasboat.fullname" . }}-gitlab-bridge-state
+          {{- else }}
           emptyDir: {}
+          {{- end }}
       {{- include "gasboat.nodeSelector" (dict "local" .Values.gitlabBridge.nodeSelector "global" .Values.global.nodeSelector) | nindent 6 }}
       {{- with .Values.gitlabBridge.tolerations }}
       tolerations:

--- a/gasboat/helm/gasboat/templates/gitlab-bridge/pvc.yaml
+++ b/gasboat/helm/gasboat/templates/gitlab-bridge/pvc.yaml
@@ -1,0 +1,20 @@
+{{- if and .Values.gitlabBridge.enabled .Values.gitlabBridge.persistence.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "gasboat.fullname" . }}-gitlab-bridge-state
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ include "gasboat.fullname" . }}-gitlab-bridge
+    app.kubernetes.io/component: gitlab-bridge
+    {{- include "gasboat.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  {{- if .Values.gitlabBridge.persistence.storageClass }}
+  storageClassName: {{ .Values.gitlabBridge.persistence.storageClass }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.gitlabBridge.persistence.size | default "100Mi" }}
+{{- end }}

--- a/gasboat/helm/gasboat/templates/jira-bridge/deployment.yaml
+++ b/gasboat/helm/gasboat/templates/jira-bridge/deployment.yaml
@@ -121,7 +121,12 @@ spec:
             {{- toYaml .Values.jiraBridge.resources | nindent 12 }}
       volumes:
         - name: state
+          {{- if .Values.jiraBridge.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "gasboat.fullname" . }}-jira-bridge-state
+          {{- else }}
           emptyDir: {}
+          {{- end }}
       {{- include "gasboat.nodeSelector" (dict "local" .Values.jiraBridge.nodeSelector "global" .Values.global.nodeSelector) | nindent 6 }}
       {{- with .Values.jiraBridge.tolerations }}
       tolerations:

--- a/gasboat/helm/gasboat/templates/jira-bridge/pvc.yaml
+++ b/gasboat/helm/gasboat/templates/jira-bridge/pvc.yaml
@@ -1,0 +1,20 @@
+{{- if and .Values.jiraBridge.enabled .Values.jiraBridge.persistence.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "gasboat.fullname" . }}-jira-bridge-state
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ include "gasboat.fullname" . }}-jira-bridge
+    app.kubernetes.io/component: jira-bridge
+    {{- include "gasboat.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  {{- if .Values.jiraBridge.persistence.storageClass }}
+  storageClassName: {{ .Values.jiraBridge.persistence.storageClass }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.jiraBridge.persistence.size | default "100Mi" }}
+{{- end }}

--- a/gasboat/helm/gasboat/values.yaml
+++ b/gasboat/helm/gasboat/values.yaml
@@ -944,6 +944,13 @@ jiraBridge:
       cpu: 200m
       memory: 128Mi
 
+  # State persistence — survives pod restarts, preserves SSE last-event-ID and dedup state.
+  # When disabled (default), an emptyDir is used (state lost on restart, CatchUp covers dedup).
+  persistence:
+    enabled: false
+    size: 100Mi
+    storageClass: ""
+
   # Pod scheduling
   nodeSelector: {}
   tolerations: []
@@ -1063,6 +1070,13 @@ gitlabBridge:
     limits:
       cpu: 200m
       memory: 128Mi
+
+  # State persistence — survives pod restarts, preserves SSE last-event-ID and dedup state.
+  # When disabled (default), an emptyDir is used (state lost on restart, CatchUp covers dedup).
+  persistence:
+    enabled: false
+    size: 100Mi
+    storageClass: ""
 
   # Pod scheduling
   nodeSelector: {}


### PR DESCRIPTION
## Summary

- **Root cause**: Jira/GitLab bridges re-posted "working on this issue" comments and duplicate notes after pod restarts because (1) `CatchUp()` did not query closed beads, so replayed SSE events for previously-claimed-then-closed beads triggered fresh Jira comments, and (2) `emptyDir` volumes lost the SSE `last-event-ID` on restart, causing full event replay.
- **CatchUp fix**: Expanded `CatchUp()` to include `closed` beads in its query and pre-mark them in the dedup map. Also marks claims for any bead with an assignee (not just `in_progress` ones), catching beads that were claimed and then closed between restarts.
- **Helm persistence**: Added optional PVC persistence for jira-bridge and gitlab-bridge (matching the existing slack-bridge pattern), so the SSE cursor and dedup state file survive pod restarts.
- **Tests**: Added `TestJiraSync_CatchUp_ClosedBeadPreventsReplay` and `TestJiraSync_CatchUp_ClosedBeadPreventsCloseReplay` to verify the dedup behavior.

## Test plan

- [x] `go test ./internal/bridge/ -run TestJiraSync_CatchUp` — all 4 CatchUp tests pass
- [x] `go test ./...` — full test suite passes
- [x] `helm lint helm/gasboat/` — chart lints clean
- [x] `make build && make build-bridge` — both binaries compile
- [ ] Deploy with `jiraBridge.persistence.enabled=true` and verify no duplicate comments after bridge restart

Closes kd-bYqomtlZmn

🤖 Generated with [Claude Code](https://claude.com/claude-code)