### PR TITLE
feat(kbeads): add scheduler fields to task and agent builtins

### DIFF
--- a/kbeads/internal/server/beads_test.go
+++ b/kbeads/internal/server/beads_test.go
@@ -406,3 +406,47 @@ func TestGRPCListBeads_BundleFilterResolvesToMolecule(t *testing.T) {
 		t.Fatalf("expected type=molecule, got %q", resp.Beads[0].Type)
 	}
 }
+
+// --- Scheduler field tests ---
+
+func TestGRPCCreateBead_TaskType_WithScheduleID(t *testing.T) {
+	srv, _, ctx := testCtx(t)
+
+	resp, err := srv.CreateBead(ctx, &beadsv1.CreateBeadRequest{
+		Title:  "Scheduled: connectivity test",
+		Type:   "task",
+		Fields: []byte(`{"schedule_id":"kd-sched-1"}`),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error creating task with schedule_id: %v", err)
+	}
+	if resp.Bead.Kind != "issue" {
+		t.Fatalf("expected kind=issue, got %q", resp.Bead.Kind)
+	}
+}
+
+func TestGRPCCreateBead_AgentType_WithSchedulerFields(t *testing.T) {
+	srv, _, ctx := testCtx(t)
+
+	resp, err := srv.CreateBead(ctx, &beadsv1.CreateBeadRequest{
+		Title: "sched-agent",
+		Type:  "agent",
+		Fields: []byte(`{
+			"agent":"sched-agent",
+			"role":"crew",
+			"project":"gasboat",
+			"prompt":"Run health check",
+			"task_id":"kd-task-1",
+			"schedule_id":"kd-sched-1",
+			"schedule_title":"Daily Health Check",
+			"schedule_cron":"0 9 * * *",
+			"schedule_slack_channel":"C_ALERTS"
+		}`),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error creating agent with scheduler fields: %v", err)
+	}
+	if resp.Bead.Kind != "config" {
+		t.Fatalf("expected kind=config, got %q", resp.Bead.Kind)
+	}
+}

--- a/kbeads/internal/server/config.go
+++ b/kbeads/internal/server/config.go
@@ -22,7 +22,12 @@ var builtinConfigs = map[string]*model.Config{
 		Value: json.RawMessage(`{"filter":{"status":["open","in_progress"],"kind":["issue"]},"sort":"priority","limit":5}`),
 	},
 	"type:epic":    {Key: "type:epic", Value: json.RawMessage(`{"kind":"issue","fields":[]}`)},
-	"type:task":    {Key: "type:task", Value: json.RawMessage(`{"kind":"issue","fields":[]}`)},
+	"type:task": {Key: "type:task", Value: json.RawMessage(`{
+		"kind": "issue",
+		"fields": [
+			{"name": "schedule_id", "type": "string"}
+		]
+	}`)},
 	"type:feature": {Key: "type:feature", Value: json.RawMessage(`{"kind":"issue","fields":[]}`)},
 	"type:chore":   {Key: "type:chore", Value: json.RawMessage(`{"kind":"issue","fields":[]}`)},
 	"type:bug":     {Key: "type:bug", Value: json.RawMessage(`{"kind":"issue","fields":[]}`)},
@@ -66,9 +71,15 @@ var builtinConfigs = map[string]*model.Config{
 			{"name": "project",       "type": "string", "required": true},
 			{"name": "mode",          "type": "string"},
 			{"name": "agent_state",   "type": "string"},
+			{"name": "prompt",        "type": "string"},
+			{"name": "task_id",       "type": "string"},
 			{"name": "mock_scenario", "type": "string"},
 			{"name": "stop_requested",    "type": "string"},
 			{"name": "gate_satisfied_by", "type": "string"},
+			{"name": "schedule_id",            "type": "string"},
+			{"name": "schedule_title",         "type": "string"},
+			{"name": "schedule_cron",          "type": "string"},
+			{"name": "schedule_slack_channel", "type": "string"},
 			{"name": "advice_subscriptions",         "type": "string[]"},
 			{"name": "advice_subscriptions_exclude",  "type": "string[]"}
 		]


### PR DESCRIPTION
## Summary
- Add `schedule_id` to `type:task` builtin so the scheduler can create task beads on fresh installs without needing runtime config beads
- Add `prompt`, `task_id`, `schedule_id`, `schedule_title`, `schedule_cron`, `schedule_slack_channel` to `type:agent` builtin so `SpawnAgent` and the scheduler work out-of-the-box
- Companion to PR #101 which added `type:schedule` but left the task/agent builtins unchanged

## Context
When PR #101's scheduler was first deployed, it failed for 5 minutes with `"unknown field: schedule_id"` until runtime config beads were applied. This fix makes the scheduler work immediately on a fresh kbeads install.

## Test plan
- [x] `go test ./kbeads/...` — all tests pass
- [x] New `TestGRPCCreateBead_TaskType_WithScheduleID` verifies task beads accept `schedule_id`
- [x] New `TestGRPCCreateBead_AgentType_WithSchedulerFields` verifies agent beads accept all scheduler fields

Closes kd-I6eLMhcaZQ

🤖 Generated with [Claude Code](https://claude.com/claude-code)